### PR TITLE
DCMAW-8264: Add validation for token claims

### DIFF
--- a/.github/workflows/async-credential-pull-req.yml
+++ b/.github/workflows/async-credential-pull-req.yml
@@ -15,9 +15,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  SIGNING_KEY_ID: "test"
-
 jobs:
   ci-checks:
     name: Run CI checks

--- a/.github/workflows/async-credential-pull-req.yml
+++ b/.github/workflows/async-credential-pull-req.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  SIGNING_KEY_IDS: "test"
+  SIGNING_KEY_ID: "test"
 
 jobs:
   ci-checks:

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -8,17 +8,33 @@ const mockJwt =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 
 describe("Token Service", () => {
-  describe("Given the token signature is not valid", () => {
-    it("Returns a log", async () => {
-      const kmsMock = mockClient(KMSClient);
-      kmsMock.on(VerifyCommand).resolves({ SignatureValid: false });
-      const tokenService = new TokenService();
-      const result = await tokenService.verifyTokenSignature(
-        "mockKeyId",
-        mockJwt,
-      );
-      expect(result.isLog).toBe(true);
-      expect(result.value).toEqual("TOKEN_SIGNATURE_INVALID");
+  describe("JWT signature verification", () => {
+    describe("Given the token signature is not valid", () => {
+      it("Returns a log", async () => {
+        const kmsMock = mockClient(KMSClient);
+        kmsMock.on(VerifyCommand).resolves({ SignatureValid: false });
+        const tokenService = new TokenService();
+        const result = await tokenService.verifyTokenSignature(
+          "mockKeyId",
+          mockJwt,
+        );
+        expect(result.isLog).toBe(true);
+        expect(result.value).toEqual("TOKEN_SIGNATURE_INVALID");
+      });
+    });
+
+    describe("Given the token signature is valid", () => {
+      it("Returns a value of null", async () => {
+        const kmsMock = mockClient(KMSClient);
+        kmsMock.on(VerifyCommand).resolves({ SignatureValid: true });
+        const tokenService = new TokenService();
+        const result = await tokenService.verifyTokenSignature(
+          "mockKeyId",
+          mockJwt,
+        );
+        expect(result.isLog).toBe(false);
+        expect(result.value).toEqual(null);
+      });
     });
   });
 });
@@ -48,6 +64,7 @@ export class TokenService implements IVerifyTokenSignature {
     if (result.SignatureValid === false) {
       return log("TOKEN_SIGNATURE_INVALID");
     }
+
     return value(null);
   }
 }

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -10,28 +10,6 @@ const mockJwt =
 const mockJwtExpInThePast = "";
 
 describe("Token Service", () => {
-  describe("JWT payload validation", () => {
-    describe("Given expiry date is not present", () => {
-      it("Returns a log", () => {
-        const tokenService = new TokenService();
-        const result = tokenService.validateTokenPayload(mockJwt);
-
-        expect(result.isLog).toBe(true);
-        expect(result.value).toEqual("EXPIRY_DATE_MISSING");
-      });
-    });
-
-    describe("Given expiry date is in the past", () => {
-      it("Returns a log", () => {
-        const tokenService = new TokenService();
-        const result = tokenService.validateTokenPayload(mockJwt);
-
-        expect(result.isLog).toBe(true);
-        expect(result.value).toEqual("EXPIRY_DATE_IN_THE_PAST");
-      });
-    });
-  });
-
   describe("JWT signature verification", () => {
     describe("Given the token signature is not valid", () => {
       it("Returns a log", async () => {
@@ -74,19 +52,17 @@ export interface IVerifyTokenSignature {
   ) => Promise<LogOrValue<null>>;
 }
 
-export class TokenService
-  implements IValidateTokenPayload, IVerifyTokenSignature
-{
-  validateTokenPayload(jwt: string): LogOrValue<null> {
-    const [header, payload, signature] = jwt.split(".");
-    const decodedPayload = JSON.parse(base64Decode(payload));
+export class TokenService implements IVerifyTokenSignature {
+  // validateTokenPayload(jwt: string): LogOrValue<null> {
+  //   const [header, payload, signature] = jwt.split(".");
+  //   const decodedPayload = JSON.parse(base64Decode(payload));
 
-    if (!decodedPayload.exp) {
-      return log("EXPIRY_DATE_MISSING");
-    }
+  //   if (!decodedPayload.exp) {
+  //     return log("EXPIRY_DATE_MISSING");
+  //   }
 
-    return value(null);
-  }
+  //   return value(null);
+  // }
 
   async verifyTokenSignature(
     keyId: string,

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -3,7 +3,7 @@ import { mockClient } from "aws-sdk-client-mock";
 import format from "ecdsa-sig-formatter";
 import { LogOrValue, log, value } from "../../types/logOrValue";
 
-// Generated using jwt.io with thier public and private keys
+// Generated using jwt.io with their public and private keys
 const mockJwt =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -7,6 +7,8 @@ import { LogOrValue, log, value } from "../../types/logOrValue";
 const mockJwt =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 
+const mockJwtExpInThePast = "";
+
 describe("Token Service", () => {
   describe("JWT payload validation", () => {
     describe("Given expiry date is not present", () => {
@@ -16,6 +18,16 @@ describe("Token Service", () => {
 
         expect(result.isLog).toBe(true);
         expect(result.value).toEqual("EXPIRY_DATE_MISSING");
+      });
+    });
+
+    describe("Given expiry date is in the past", () => {
+      it("Returns a log", () => {
+        const tokenService = new TokenService();
+        const result = tokenService.validateTokenPayload(mockJwt);
+
+        expect(result.isLog).toBe(true);
+        expect(result.value).toEqual("EXPIRY_DATE_IN_THE_PAST");
       });
     });
   });

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -1,13 +1,25 @@
 import { KMSClient, VerifyCommand } from "@aws-sdk/client-kms";
-import { LogOrValue, log, value } from "../../types/logOrValue";
 import { mockClient } from "aws-sdk-client-mock";
 import format from "ecdsa-sig-formatter";
+import { LogOrValue, log, value } from "../../types/logOrValue";
 
 // Generated using jwt.io with thier public and private keys
 const mockJwt =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 
 describe("Token Service", () => {
+  describe("JWT payload validation", () => {
+    describe("Given expiry date is not present", () => {
+      it("Returns a log", () => {
+        const tokenService = new TokenService();
+        const result = tokenService.validateTokenPayload(mockJwt);
+
+        expect(result.isLog).toBe(true);
+        expect(result.value).toEqual("EXPIRY_DATE_MISSING");
+      });
+    });
+  });
+
   describe("JWT signature verification", () => {
     describe("Given the token signature is not valid", () => {
       it("Returns a log", async () => {
@@ -39,6 +51,10 @@ describe("Token Service", () => {
   });
 });
 
+export interface IValidateTokenPayload {
+  validateTokenPayload: (keyId: string, jwt: string) => LogOrValue<null>;
+}
+
 export interface IVerifyTokenSignature {
   verifyTokenSignature: (
     keyId: string,
@@ -46,7 +62,20 @@ export interface IVerifyTokenSignature {
   ) => Promise<LogOrValue<null>>;
 }
 
-export class TokenService implements IVerifyTokenSignature {
+export class TokenService
+  implements IValidateTokenPayload, IVerifyTokenSignature
+{
+  validateTokenPayload(jwt: string): LogOrValue<null> {
+    const [header, payload, signature] = jwt.split(".");
+    const decodedPayload = JSON.parse(base64Decode(payload));
+
+    if (!decodedPayload.exp) {
+      return log("EXPIRY_DATE_MISSING");
+    }
+
+    return value(null);
+  }
+
   async verifyTokenSignature(
     keyId: string,
     jwt: string,
@@ -67,4 +96,8 @@ export class TokenService implements IVerifyTokenSignature {
 
     return value(null);
   }
+}
+
+function base64Decode(value: string): string {
+  return Buffer.from(value, "base64").toString("utf-8");
 }

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -4,7 +4,8 @@ import { mockClient } from "aws-sdk-client-mock";
 import format from "ecdsa-sig-formatter";
 
 // Generated using jwt.io with thier public and private keys
-const mockJwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA"
+const mockJwt =
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 
 describe("Token Service", () => {
   describe("Given the token signature is not valid", () => {

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -3,6 +3,9 @@ import { LogOrValue, log, value } from "../../types/logOrValue";
 import { mockClient } from "aws-sdk-client-mock";
 import format from "ecdsa-sig-formatter";
 
+// Generated using jwt.io with thier public and private keys
+const mockJwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA"
+
 describe("Token Service", () => {
   describe("Given the token signature is not valid", () => {
     it("Returns a log", async () => {
@@ -11,7 +14,7 @@ describe("Token Service", () => {
       const tokenService = new TokenService();
       const result = await tokenService.verifyTokenSignature(
         "mockKeyId",
-        "TO-DO - INSERT MOCK JWT HERE",
+        mockJwt,
       );
       expect(result.isLog).toBe(true);
       expect(result.value).toEqual("TOKEN_SIGNATURE_INVALID");

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -7,8 +7,6 @@ import { LogOrValue, log, value } from "../../types/logOrValue";
 const mockJwt =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
 
-const mockJwtExpInThePast = "";
-
 describe("Token Service", () => {
   describe("JWT signature verification", () => {
     describe("Given the token signature is not valid", () => {
@@ -53,17 +51,6 @@ export interface IVerifyTokenSignature {
 }
 
 export class TokenService implements IVerifyTokenSignature {
-  // validateTokenPayload(jwt: string): LogOrValue<null> {
-  //   const [header, payload, signature] = jwt.split(".");
-  //   const decodedPayload = JSON.parse(base64Decode(payload));
-
-  //   if (!decodedPayload.exp) {
-  //     return log("EXPIRY_DATE_MISSING");
-  //   }
-
-  //   return value(null);
-  // }
-
   async verifyTokenSignature(
     keyId: string,
     jwt: string,
@@ -84,8 +71,4 @@ export class TokenService implements IVerifyTokenSignature {
 
     return value(null);
   }
-}
-
-function base64Decode(value: string): string {
-  return Buffer.from(value, "base64").toString("utf-8");
 }

--- a/src/functions/asyncCredential/TokenService/tokenService.test.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.test.ts
@@ -9,6 +9,20 @@ const mockJwt =
 
 describe("Token Service", () => {
   describe("JWT signature verification", () => {
+    describe("Given the token signature is not present", () => {
+      it("Returns a log", async () => {
+        const kmsMock = mockClient(KMSClient);
+        kmsMock.on(VerifyCommand).resolves({});
+        const tokenService = new TokenService();
+        const result = await tokenService.verifyTokenSignature(
+          "mockKeyId",
+          mockJwt,
+        );
+        expect(result.isLog).toBe(true);
+        expect(result.value).toEqual("TOKEN_SIGNATURE_INVALID");
+      });
+    });
+
     describe("Given the token signature is not valid", () => {
       it("Returns a log", async () => {
         const kmsMock = mockClient(KMSClient);
@@ -65,7 +79,7 @@ export class TokenService implements IVerifyTokenSignature {
     });
 
     const result = await kmsClient.send(verifyCommand);
-    if (result.SignatureValid === false) {
+    if (result.SignatureValid !== true) {
       return log("TOKEN_SIGNATURE_INVALID");
     }
 

--- a/src/functions/asyncCredential/TokenService/tokenService.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.ts
@@ -2,10 +2,6 @@ import format from "ecdsa-sig-formatter";
 import { LogOrValue, log, value } from "../../types/logOrValue";
 import { KMSClient, VerifyCommand } from "@aws-sdk/client-kms";
 
-export interface IValidateTokenPayload {
-  validateTokenPayload: (keyId: string, jwt: string) => LogOrValue<null>;
-}
-
 export interface IVerifyTokenSignature {
   verifyTokenSignature: (
     keyId: string,

--- a/src/functions/asyncCredential/TokenService/tokenService.ts
+++ b/src/functions/asyncCredential/TokenService/tokenService.ts
@@ -1,0 +1,37 @@
+import format from "ecdsa-sig-formatter";
+import { LogOrValue, log, value } from "../../types/logOrValue";
+import { KMSClient, VerifyCommand } from "@aws-sdk/client-kms";
+
+export interface IValidateTokenPayload {
+  validateTokenPayload: (keyId: string, jwt: string) => LogOrValue<null>;
+}
+
+export interface IVerifyTokenSignature {
+  verifyTokenSignature: (
+    keyId: string,
+    jwt: string,
+  ) => Promise<LogOrValue<null>>;
+}
+
+export class TokenService implements IVerifyTokenSignature {
+  async verifyTokenSignature(
+    keyId: string,
+    jwt: string,
+  ): Promise<LogOrValue<null>> {
+    const [header, payload, signature] = jwt.split(".");
+    const kmsClient = new KMSClient();
+    const verifyCommand = new VerifyCommand({
+      KeyId: keyId,
+      SigningAlgorithm: "ECDSA_SHA_256",
+      Signature: format.joseToDer(signature, "ES256"),
+      Message: Buffer.from(`${header}.${payload}`),
+    });
+
+    const result = await kmsClient.send(verifyCommand);
+    if (result.SignatureValid !== true) {
+      return log("TOKEN_SIGNATURE_INVALID");
+    }
+
+    return value(null);
+  }
+}

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1,9 +1,12 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 import { buildRequest } from "../testUtils/mockRequest";
-import { IVerifyTokenSignature } from "./TokenService/tokenService.test";
-import { TokenService } from "./TokenService/tokenService.test";
-import { LogOrValue, log } from "../types/logOrValue";
+import { LogOrValue, log, value } from "../types/logOrValue";
+import {
+  IValidateTokenPayload,
+  IVerifyTokenSignature,
+  TokenService,
+} from "./TokenService/tokenService.test";
+import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 
 describe("Async Credential", () => {
   let dependencies: Dependencies;
@@ -109,7 +112,13 @@ describe("Async Credential", () => {
   });
 });
 
-class MockTokenSeviceInvalidSignature implements IVerifyTokenSignature {
+class MockTokenSeviceInvalidSignature
+  implements IValidateTokenPayload, IVerifyTokenSignature
+{
+  validateTokenPayload(): LogOrValue<null> {
+    return value(null);
+  }
+
   verifyTokenSignature(): Promise<LogOrValue<null>> {
     return Promise.resolve(log(""));
   }

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -290,8 +290,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing iss claim",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -10,15 +10,10 @@ import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 
 const mockJwtNoExp =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.0C_S0NEicI6k1yaTAV0l85Z0SlW3HI2YIqJb_unXZ1MttAvjR9wAOhsl_0X20i1NYN0ZhnaoHnGLpApUSz2kwQ";
-const mockJwtNoIat =
-  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjoiMjE0NTk2NDY5NSJ9.HoDHE7kqaw89XmM2p0kfiT4gg-rn1kf5LkFxZgHO51ZJcO_kQpQn79SH8KgYBPqp81p8AnZSv3QRZPeLgbJgdw";
 const mockJwtIatInTheFuture =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjoiMjE0NTk2NDY5NSIsImlhdCI6IjIxNDU5NjQ2OTUifQ.VnfFwIElQqPwbayMqLz-YaUK-BOx9tEKJE4_N49xh65TQvtP-9EWaPgD0D0C_3hULWjtvt2gh46nTPi-m7-y4A";
 const mockJwtExpInThePast =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
-
-const mockJwtNoNbf =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjIxNDU5NjQ2OTV9.DKhK1oE5CZPkQ3Va9wCJjohm7ft9QgXH0ZYTICfa3Z4";
 
 const mockJwtNbfInFuture =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIyMTQ1OTY0Njk1In0.7-OeXAHrUdvRirCd_7H_yxFf8aGzkGIk944gqAbCBVM";
@@ -148,10 +143,11 @@ describe("Async Credential", () => {
     });
 
     describe("iat claim validation", () => {
-      describe("Given issued at (iat) is not present", () => {
+      // iat does not need to be present
+      describe("Given issued at (iat) is in the future", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
-            headers: { Authorization: `Bearer ${mockJwtNoIat}` },
+            headers: { Authorization: `Bearer ${mockJwtIatInTheFuture}` },
           });
 
           dependencies.tokenService = () => new MockTokenSeviceValidSignature();
@@ -169,30 +165,10 @@ describe("Async Credential", () => {
         });
       });
     });
+  });
 
-    describe("nbf claim validation", () => {
-      describe("Given not before (nbf) is not present", () => {
-        it("Returns a log", async () => {
-          const event = buildRequest({
-            headers: { Authorization: `Bearer ${mockJwtNoNbf}` },
-          });
-
-          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
-
-          const result: APIGatewayProxyResult = await lambdaHandler(
-            event,
-            dependencies,
-          );
-
-          expect(result).toStrictEqual({
-            headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
-          });
-        });
-      });
-    });
-
+  describe("nbf claim validation", () => {
+    // nbf does not need to be present
     describe("Given not before (nbf) is in the future", () => {
       it("Returns a log", async () => {
         const event = buildRequest({

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -17,6 +17,11 @@ const mockJwtIatInTheFuture =
 const mockJwtExpInThePast =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
 
+const mockJwtNoNbf =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjIxNDU5NjQ2OTV9.DKhK1oE5CZPkQ3Va9wCJjohm7ft9QgXH0ZYTICfa3Z4";
+
+const mockJwtNbfInFuture =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIyMTQ1OTY0Njk1In0.7-OeXAHrUdvRirCd_7H_yxFf8aGzkGIk944gqAbCBVM";
 describe("Async Credential", () => {
   let dependencies: Dependencies;
 
@@ -165,10 +170,33 @@ describe("Async Credential", () => {
       });
     });
 
-    describe("Given issued at (iat) is in the future", () => {
+    describe("nbf claim validation", () => {
+      describe("Given not before (nbf) is not present", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtNoNbf}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
+    });
+
+    describe("Given not before (nbf) is in the future", () => {
       it("Returns a log", async () => {
         const event = buildRequest({
-          headers: { Authorization: `Bearer ${mockJwtIatInTheFuture}` },
+          headers: { Authorization: `Bearer ${mockJwtNbfInFuture}` },
         });
 
         dependencies.tokenService = () => new MockTokenSeviceValidSignature();

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -7,7 +7,6 @@ import {
   IClientCredentials,
   IClientCredentialsService,
 } from "../services/clientCredentialsService/clientCredentialsService";
-import { IDecodedClientCredentials } from "../types/clientCredentials";
 import { IGetClientCredentials } from "../asyncToken/ssmService/ssmService";
 
 const mockJwtNoExp =
@@ -558,53 +557,19 @@ class MockTokenSeviceValidSignature implements IVerifyTokenSignature {
 class MockFailingClientCredentialsServiceGetClientCredentialsById
   implements IClientCredentialsService
 {
-  getClientCredentialsById(
-    storedCredentialsArray: IClientCredentials[],
-    suppliedClientId: string,
-  ) {
+  getClientCredentialsById() {
     return null;
   }
-  validate(
-    storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedClientCredentials,
-  ) {
-    return false;
-  }
-}
-
-class MockFailingClientCredentialsServiceValidation
-  implements IClientCredentialsService
-{
-  getClientCredentialsById(
-    storedCredentialsArray: IClientCredentials[],
-    suppliedClientId: string,
-  ) {
-    return {
-      client_id: "mockClientId",
-      issuer: "mockIssuer",
-      salt: "mockSalt",
-      hashed_client_secret: "mockHashedClientSecret",
-    };
-  }
-  validate(
-    storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedClientCredentials,
-  ) {
+  validate() {
     return false;
   }
 }
 
 class MockPassingClientCredentialsService implements IClientCredentialsService {
-  validate(
-    _storedCredentials: IClientCredentials,
-    _suppliedCredentials: IDecodedClientCredentials,
-  ) {
+  validate() {
     return true;
   }
-  getClientCredentialsById(
-    _storedCredentialsArray: IClientCredentials[],
-    _suppliedClientId: string,
-  ) {
+  getClientCredentialsById() {
     return {
       client_id: "mockClientId",
       issuer: "mockIssuer",

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -2,7 +2,6 @@ import { APIGatewayProxyResult } from "aws-lambda";
 import { buildRequest } from "../testUtils/mockRequest";
 import { LogOrValue, log, value } from "../types/logOrValue";
 import {
-  IValidateTokenPayload,
   IVerifyTokenSignature,
   TokenService,
 } from "./TokenService/tokenService.test";

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -35,6 +35,9 @@ const mockJwtNoScope =
 const mockJwtScopeNotValid =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoibW9ja0ludmFsaWRTY29wZSJ9.kO0R0-bN6uYkknOD9E0oqtpRlp0rHB-6njrHN3mKkX4";
 
+const mockJwtNoClientId =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUifQ.xN-h1mVndN7kNRSrVM0WLcdKblniD3q70xnY-RYBIlc";
+
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -319,6 +322,29 @@ describe("Async Credential", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtScopeNotValid}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
+    });
+
+    describe("client_id claim validation", () => {
+      describe("Given client_id is not present", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtNoClientId}` },
           });
 
           dependencies.tokenService = () => new MockTokenSeviceValidSignature();

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -10,7 +10,7 @@ import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 
 const mockJwtNoExp =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.0C_S0NEicI6k1yaTAV0l85Z0SlW3HI2YIqJb_unXZ1MttAvjR9wAOhsl_0X20i1NYN0ZhnaoHnGLpApUSz2kwQ";
-const mockJwtExpInThePast = "";
+const mockJwtExpInThePast = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
 
 describe("Async Credential", () => {
   let dependencies: Dependencies;
@@ -114,15 +114,26 @@ describe("Async Credential", () => {
       });
     });
 
-    // describe("Given expiry date is in the past", () => {
-    //   it("Returns a log", () => {
-    //     const tokenService = new TokenService();
-    //     const result = tokenService.validateTokenPayload(mockJwtExpInThePast);
+    describe("Given expiry date is in the past", () => {
+      it("Returns a log", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockJwtExpInThePast}` },
+        });
 
-    //     expect(result.isLog).toBe(true);
-    //     expect(result.value).toEqual("EXPIRY_DATE_IN_THE_PAST");
-    //   });
-    // });
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: "Unauthorized",
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -44,10 +44,14 @@ const mockJwtNoAud =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.FzBrIcM0DDp1ecivQpCNF216l2ZFzU3fPAOgAegKylY";
 
 const mockJwtInvalidAud =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJpbnZhbGlkSXNzdWVyIn0.eaBbLzwDd69MaqozqXJnWqQI8JQK8rcughYlbS29qD0";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJpbnZhbGlkSXNzdWVyIiwic3RhdGUiOiJtb2NrU3RhdGUifQ.bMxAW6t5TzESfGqTAzIJwRn38-mLwYg_pVJbupscrU8";
+
+const mockJwtMissingState =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIn0.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8";
 
 const mockValidJwt =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIn0.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIiwic3RhdGUiOiJtb2NrU3RhdGUifQ.GTL43WFrvk2bGiw7Sf8kDTkT_L37JDzUQG84t7uP6wo";
+
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -425,6 +429,32 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("state claim validation", () => {
+      describe("Given state is missing", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtMissingState}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing state claim",
+            }),
+          });
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {
@@ -503,7 +533,7 @@ describe("Async Credential", () => {
         const result = await lambdaHandler(event, dependencies);
 
         expect(result.statusCode).toBe(400);
-        expect(JSON.parse(result.body).error).toEqual("invalid_client");
+        // expect(JSON.parse(result.body).error).toEqual("invalid_client");
         expect(JSON.parse(result.body).error_description).toEqual(
           "Invalid aud claim",
         );

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -19,6 +19,7 @@ const mockJwtNbfInFuture =
 
 const env = {
   SIGNING_KEY_ID: "mockKid",
+  ISSUER: "mockIssuer",
 };
 
 describe("Async Credential", () => {
@@ -36,6 +37,21 @@ describe("Async Credential", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
         delete dependencies.env["SIGNING_KEY_ID"];
+        const event = buildRequest();
+        const result = await lambdaHandler(event, dependencies);
+
+        expect(result.statusCode).toBe(500);
+        expect(JSON.parse(result.body).error).toEqual("server_error");
+        expect(JSON.parse(result.body).error_description).toEqual(
+          "Server Error",
+        );
+      });
+    });
+
+    describe("Given ISSUER is missing", () => {
+      it("Returns a 500 Server Error response", async () => {
+        dependencies.env = JSON.parse(JSON.stringify(env));
+        delete dependencies.env["ISSUER"];
         const event = buildRequest();
         const result = await lambdaHandler(event, dependencies);
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -189,7 +189,7 @@ describe("Async Credential", () => {
             statusCode: 400,
             body: JSON.stringify({
               error: "bad_request",
-              error_description: "Missing exp claim in jwt",
+              error_description: "Missing exp claim",
             }),
           });
         });
@@ -213,7 +213,7 @@ describe("Async Credential", () => {
             statusCode: 400,
             body: JSON.stringify({
               error: "bad_request",
-              error_description: "Invalid exp claim in jwt",
+              error_description: "exp claim is in the past",
             }),
           });
         });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -340,8 +340,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing scope claim",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1,10 +1,7 @@
 import { APIGatewayProxyResult } from "aws-lambda";
 import { buildRequest } from "../testUtils/mockRequest";
 import { LogOrValue, log, value } from "../types/logOrValue";
-import {
-  IVerifyTokenSignature,
-  TokenService,
-} from "./TokenService/tokenService.test";
+import { IVerifyTokenSignature } from "./TokenService/tokenService";
 import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 import {
   IClientCredentials,

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -350,7 +350,7 @@ describe("Async Credential", () => {
         });
       });
 
-      describe("Given scope is invalid", () => {
+      describe("Given scope is not dcmaw.session.async_create", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtScopeNotValid}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -71,11 +71,14 @@ describe("Async Credential", () => {
         const event = buildRequest();
         const result = await lambdaHandler(event, dependencies);
 
-        expect(result.statusCode).toBe(500);
-        expect(JSON.parse(result.body).error).toEqual("server_error");
-        expect(JSON.parse(result.body).error_description).toEqual(
-          "Server Error",
-        );
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 500,
+          body: JSON.stringify({
+            error: "server_error",
+            error_description: "Server Error",
+          }),
+        });
       });
     });
 
@@ -86,17 +89,20 @@ describe("Async Credential", () => {
         const event = buildRequest();
         const result = await lambdaHandler(event, dependencies);
 
-        expect(result.statusCode).toBe(500);
-        expect(JSON.parse(result.body).error).toEqual("server_error");
-        expect(JSON.parse(result.body).error_description).toEqual(
-          "Server Error",
-        );
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 500,
+          body: JSON.stringify({
+            error: "server_error",
+            error_description: "Server Error",
+          }),
+        });
       });
     });
   });
 
   describe("Access token validation", () => {
-    describe("Given access token payload is missing", () => {
+    describe("Given Authentication header is missing", () => {
       it("Returns 401 Unauthorized", async () => {
         const event = buildRequest();
 
@@ -104,10 +110,14 @@ describe("Async Credential", () => {
           event,
           dependencies,
         );
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 401,
-          body: "Unauthorized",
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
         });
       });
     });
@@ -122,10 +132,14 @@ describe("Async Credential", () => {
           event,
           dependencies,
         );
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 401,
-          body: "Unauthorized",
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
         });
       });
     });
@@ -140,10 +154,14 @@ describe("Async Credential", () => {
           event,
           dependencies,
         );
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 401,
-          body: "Unauthorized",
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
         });
       });
     });
@@ -158,10 +176,14 @@ describe("Async Credential", () => {
           event,
           dependencies,
         );
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 401,
-          body: "Unauthorized",
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
         });
       });
     });
@@ -442,7 +464,10 @@ describe("Async Credential", () => {
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 401,
-          body: "Unauthorized",
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid signature",
+          }),
         });
       });
     });
@@ -459,10 +484,14 @@ describe("Async Credential", () => {
 
         const result = await lambdaHandler(event, dependencies);
 
-        expect(JSON.parse(result.body).error).toEqual("server_error");
-        expect(JSON.parse(result.body).error_description).toEqual(
-          "Server Error",
-        );
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 500,
+          body: JSON.stringify({
+            error: "server_error",
+            error_description: "Server Error",
+          }),
+        });
       });
     });
   });
@@ -479,11 +508,14 @@ describe("Async Credential", () => {
 
           const result = await lambdaHandler(event, dependencies);
 
-          expect(result.statusCode).toBe(400);
-          expect(JSON.parse(result.body).error).toEqual("invalid_client");
-          expect(JSON.parse(result.body).error_description).toEqual(
-            "Supplied client not recognised",
-          );
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "invalid_client",
+              error_description: "Supplied client not recognised",
+            }),
+          });
         });
       });
     });
@@ -500,11 +532,14 @@ describe("Async Credential", () => {
 
         const result = await lambdaHandler(event, dependencies);
 
-        expect(result.statusCode).toBe(400);
-        // expect(JSON.parse(result.body).error).toEqual("invalid_client");
-        expect(JSON.parse(result.body).error_description).toEqual(
-          "Invalid aud claim",
-        );
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_client",
+            error_description: "Invalid aud claim",
+          }),
+        });
       });
     });
   });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -98,7 +98,7 @@ describe("Async Credential", () => {
   });
 
   describe("Access token validation", () => {
-    describe("Given access token payload is not present", () => {
+    describe("Given access token payload is missing", () => {
       it("Returns 401 Unauthorized", async () => {
         const event = buildRequest();
 
@@ -171,7 +171,7 @@ describe("Async Credential", () => {
 
   describe("JWT payload validation", () => {
     describe("exp claim validation", () => {
-      describe("Given expiry date is not present", () => {
+      describe("Given expiry date is missing", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoExp}` },
@@ -325,7 +325,7 @@ describe("Async Credential", () => {
     });
 
     describe("scope claim validation", () => {
-      describe("Given scope is not present", () => {
+      describe("Given scope is missing", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoScope}` },
@@ -369,7 +369,7 @@ describe("Async Credential", () => {
     });
 
     describe("client_id claim validation", () => {
-      describe("Given client_id is not present", () => {
+      describe("Given client_id is missing", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoClientId}` },
@@ -392,7 +392,7 @@ describe("Async Credential", () => {
     });
 
     describe("aud claim validation", () => {
-      describe("Given aud (audience) is not present", () => {
+      describe("Given aud (audience) is missing", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoAud}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -275,7 +275,7 @@ describe("Async Credential", () => {
     });
 
     describe("iss claim validation", () => {
-      describe("Given issuer (iss) is not present", () => {
+      describe("Given issuer (iss) is missing", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoIss}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -40,6 +40,8 @@ const mockJwtScopeNotValid =
 const mockJwtNoClientId =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUifQ.xN-h1mVndN7kNRSrVM0WLcdKblniD3q70xnY-RYBIlc";
 
+const mockJwtNoAud =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.FzBrIcM0DDp1ecivQpCNF216l2ZFzU3fPAOgAegKylY";
 const mockValidJwt =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.FzBrIcM0DDp1ecivQpCNF216l2ZFzU3fPAOgAegKylY";
 
@@ -367,6 +369,29 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("aud claim validation", () => {
+      describe("Given aud (audience) is not present", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtNoAud}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {
@@ -431,6 +456,10 @@ describe("Async Credential", () => {
         });
       });
     });
+  });
+
+  describe("JWT Payload validatiobn - using Client Credentials", () => {
+    describe("aud claim validation", () => {});
   });
 });
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -390,8 +390,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing client_id claim",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -364,8 +364,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Invalid scope claim",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -210,8 +210,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Invalid exp claim in jwt",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -264,8 +264,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "nbf claim is in the future",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -299,7 +299,7 @@ describe("Async Credential", () => {
         });
       });
 
-      describe("Given issuer (iss) is not valid", () => {
+      describe("Given issuer (iss) is invalid", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtIssNotValid}` },
@@ -314,8 +314,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "iss claim does not match registered issuer",
+            }),
           });
         });
       });
@@ -476,7 +479,7 @@ describe("Async Credential", () => {
     });
   });
 
-  describe("JWT Payload validatiobn - using Client Credentials", () => {
+  describe("JWT Payload validation - using Client Credentials", () => {
     describe("aud claim does not match registered issue for given client", () => {
       it("Returns a 400 Bad request response", async () => {
         const event = buildRequest({

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -10,7 +10,7 @@ describe("Async Credential", () => {
 
   beforeEach(() => {
     dependencies = {
-      tokenService: (keyId: string) => new TokenService(),
+      tokenService: () => new TokenService(),
     };
   });
   describe("Access token validation", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -300,7 +300,7 @@ describe("Async Credential", () => {
         });
       });
 
-      describe("Given issuer (iss) is invalid", () => {
+      describe("Given issuer (iss) is does not match environment variable", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtIssNotValid}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -496,26 +496,24 @@ describe("Async Credential", () => {
     });
   });
 
-  describe("Client Credentials Service", () => {
-    describe("Get client credentials by ID", () => {
-      describe("Given credentials are not found", () => {
-        it("Returns 400 Bad Request response", async () => {
-          const event = buildRequest({
-            headers: { Authorization: `Bearer ${mockValidJwt}` },
-          });
-          dependencies.clientCredentialsService = () =>
-            new MockFailingClientCredentialsServiceGetClientCredentialsById();
+  describe("Client Credentials Service - get client credentials by ID", () => {
+    describe("Given credentials are not found", () => {
+      it("Returns 400 Bad Request response", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+        });
+        dependencies.clientCredentialsService = () =>
+          new MockFailingClientCredentialsServiceGetClientCredentialsById();
 
-          const result = await lambdaHandler(event, dependencies);
+        const result = await lambdaHandler(event, dependencies);
 
-          expect(result).toStrictEqual({
-            headers: { "Content-Type": "application/json" },
-            statusCode: 400,
-            body: JSON.stringify({
-              error: "invalid_client",
-              error_description: "Supplied client not recognised",
-            }),
-          });
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_client",
+            error_description: "Supplied client not recognised",
+          }),
         });
       });
     });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -23,6 +23,9 @@ const mockJwtNoIss =
 const mockJwtIssNotValid =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0ludmFsaWRJc3N1ZXIifQ.K9lS44Bm3iHfXxAL2q-SBK2q-HB2NQ-UQSlmoqaaBVw";
 
+const mockJwtNoScope =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciJ9._-4Sn9N5grVDSxI2vvoUH90-6bAh6nH53ELZ38b3Gwk";
+
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -277,6 +280,50 @@ describe("Async Credential", () => {
           });
         });
       });
+    });
+
+    describe("scope claim validation", () => {
+      describe("Given scope is not present", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtNoScope}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
+
+      // describe("Given scope is not valid", () => {
+      //   it("Returns a log", async () => {
+      //     const event = buildRequest({
+      //       headers: { Authorization: `Bearer ${mockJwtIssNotValid}` },
+      //     });
+
+      //     dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+      //     const result: APIGatewayProxyResult = await lambdaHandler(
+      //       event,
+      //       dependencies,
+      //     );
+
+      //     expect(result).toStrictEqual({
+      //       headers: { "Content-Type": "application/json" },
+      //       statusCode: 401,
+      //       body: "Unauthorized",
+      //     });
+      //   });
+      // });
     });
   });
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -416,8 +416,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing aud claim",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -16,14 +16,38 @@ const mockJwtExpInThePast =
 
 const mockJwtNbfInFuture =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIyMTQ1OTY0Njk1In0.7-OeXAHrUdvRirCd_7H_yxFf8aGzkGIk944gqAbCBVM";
+
+const env = {
+  SIGNING_KEY_ID: "mockKid",
+};
+
 describe("Async Credential", () => {
   let dependencies: Dependencies;
 
   beforeEach(() => {
     dependencies = {
       tokenService: () => new TokenService(),
+      env,
     };
   });
+
+  describe("Environment variable validation", () => {
+    describe("Given SIGNING_KEY_ID is missing", () => {
+      it("Returns a 500 Server Error response", async () => {
+        dependencies.env = JSON.parse(JSON.stringify(env));
+        delete dependencies.env["SIGNING_KEY_ID"];
+        const event = buildRequest();
+        const result = await lambdaHandler(event, dependencies);
+
+        expect(result.statusCode).toBe(500);
+        expect(JSON.parse(result.body).error).toEqual("server_error");
+        expect(JSON.parse(result.body).error_description).toEqual(
+          "Server Error",
+        );
+      });
+    });
+  });
+
   describe("Access token validation", () => {
     describe("Given access token payload is not present", () => {
       it("Returns 401 Unauthorized", async () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -189,7 +189,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing exp claim",
             }),
           });
@@ -213,7 +213,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "exp claim is in the past",
             }),
           });
@@ -240,7 +240,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "iat claim is in the future",
             }),
           });
@@ -267,7 +267,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "nbf claim is in the future",
             }),
           });
@@ -293,7 +293,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing iss claim",
             }),
           });
@@ -317,7 +317,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "iss claim does not match registered issuer",
             }),
           });
@@ -343,7 +343,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing scope claim",
             }),
           });
@@ -367,7 +367,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Invalid scope claim",
             }),
           });
@@ -393,7 +393,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing client_id claim",
             }),
           });
@@ -419,7 +419,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing aud claim",
             }),
           });
@@ -445,7 +445,7 @@ describe("Async Credential", () => {
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
-              error: "bad_request",
+              error: "invalid_token",
               error_description: "Missing state claim",
             }),
           });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -520,7 +520,7 @@ describe("Async Credential", () => {
   });
 
   describe("JWT Payload validation - using Client Credentials", () => {
-    describe("aud claim does not match registered issue for given client", () => {
+    describe("aud claim does not match registered issuer for given client", () => {
       it("Returns a 400 Bad request response", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockJwtInvalidAud}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -186,8 +186,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "Missing exp claim in jwt",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -237,8 +237,11 @@ describe("Async Credential", () => {
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
-            statusCode: 401,
-            body: "Unauthorized",
+            statusCode: 400,
+            body: JSON.stringify({
+              error: "bad_request",
+              error_description: "iat claim is in the future",
+            }),
           });
         });
       });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -43,11 +43,8 @@ const mockJwtNoAud =
 const mockJwtInvalidAud =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJpbnZhbGlkSXNzdWVyIiwic3RhdGUiOiJtb2NrU3RhdGUifQ.bMxAW6t5TzESfGqTAzIJwRn38-mLwYg_pVJbupscrU8";
 
-const mockJwtMissingState =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIn0.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8";
-
 const mockValidJwt =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIiwic3RhdGUiOiJtb2NrU3RhdGUifQ.GTL43WFrvk2bGiw7Sf8kDTkT_L37JDzUQG84t7uP6wo";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIn0.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8";
 
 const env = {
   SIGNING_KEY_ID: "mockKid",
@@ -421,32 +418,6 @@ describe("Async Credential", () => {
             body: JSON.stringify({
               error: "invalid_token",
               error_description: "Missing aud claim",
-            }),
-          });
-        });
-      });
-    });
-
-    describe("state claim validation", () => {
-      describe("Given state is missing", () => {
-        it("Returns a log", async () => {
-          const event = buildRequest({
-            headers: { Authorization: `Bearer ${mockJwtMissingState}` },
-          });
-
-          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
-
-          const result: APIGatewayProxyResult = await lambdaHandler(
-            event,
-            dependencies,
-          );
-
-          expect(result).toStrictEqual({
-            headers: { "Content-Type": "application/json" },
-            statusCode: 400,
-            body: JSON.stringify({
-              error: "invalid_token",
-              error_description: "Missing state claim",
             }),
           });
         });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -12,6 +12,8 @@ const mockJwtNoExp =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.0C_S0NEicI6k1yaTAV0l85Z0SlW3HI2YIqJb_unXZ1MttAvjR9wAOhsl_0X20i1NYN0ZhnaoHnGLpApUSz2kwQ";
 const mockJwtNoIat =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjoiMjE0NTk2NDY5NSJ9.HoDHE7kqaw89XmM2p0kfiT4gg-rn1kf5LkFxZgHO51ZJcO_kQpQn79SH8KgYBPqp81p8AnZSv3QRZPeLgbJgdw";
+const mockJwtIatInTheFuture =
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjoiMjE0NTk2NDY5NSIsImlhdCI6IjIxNDU5NjQ2OTUifQ.VnfFwIElQqPwbayMqLz-YaUK-BOx9tEKJE4_N49xh65TQvtP-9EWaPgD0D0C_3hULWjtvt2gh46nTPi-m7-y4A";
 const mockJwtExpInThePast =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
 
@@ -159,6 +161,27 @@ describe("Async Credential", () => {
             statusCode: 401,
             body: "Unauthorized",
           });
+        });
+      });
+    });
+
+    describe("Given issued at (iat) is in the future", () => {
+      it("Returns a log", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockJwtIatInTheFuture}` },
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: "Unauthorized",
         });
       });
     });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -20,6 +20,9 @@ const mockJwtNbfInFuture =
 const mockJwtNoIss =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIn0.PO0IKWByJKerqZonGpagwKEaX-psQQPYZPPnXwI3JC4";
 
+const mockJwtIssNotValid =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0ludmFsaWRJc3N1ZXIifQ.K9lS44Bm3iHfXxAL2q-SBK2q-HB2NQ-UQSlmoqaaBVw";
+
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -233,11 +236,31 @@ describe("Async Credential", () => {
     });
 
     describe("iss claim validation", () => {
-      // nbf does not need to be present
       describe("Given issuer (iss) is not present", () => {
         it("Returns a log", async () => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockJwtNoIss}` },
+          });
+
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
+
+      describe("Given issuer (iss) is not valid", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtIssNotValid}` },
           });
 
           dependencies.tokenService = () => new MockTokenSeviceValidSignature();

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -10,7 +10,8 @@ import { Dependencies, lambdaHandler } from "./asyncCredentialHandler";
 
 const mockJwtNoExp =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.0C_S0NEicI6k1yaTAV0l85Z0SlW3HI2YIqJb_unXZ1MttAvjR9wAOhsl_0X20i1NYN0ZhnaoHnGLpApUSz2kwQ";
-const mockJwtExpInThePast = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
+const mockJwtExpInThePast =
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.LMHQh9wrANRpJYdQsP1oOVsrDEFTTJTYgpUVBy_w1Jd8GFRLwbenFEjFyXr2PZF-COP9xI87vpEOtrAri3ge8A";
 
 describe("Async Credential", () => {
   let dependencies: Dependencies;

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -42,9 +42,12 @@ const mockJwtNoClientId =
 
 const mockJwtNoAud =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.FzBrIcM0DDp1ecivQpCNF216l2ZFzU3fPAOgAegKylY";
-const mockValidJwt =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.FzBrIcM0DDp1ecivQpCNF216l2ZFzU3fPAOgAegKylY";
 
+const mockJwtInvalidAud =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJpbnZhbGlkSXNzdWVyIn0.eaBbLzwDd69MaqozqXJnWqQI8JQK8rcughYlbS29qD0";
+
+const mockValidJwt =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiLCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQiLCJhdWQiOiJtb2NrSXNzdWVyIn0.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8";
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -459,7 +462,23 @@ describe("Async Credential", () => {
   });
 
   describe("JWT Payload validatiobn - using Client Credentials", () => {
-    describe("aud claim validation", () => {});
+    describe("aud claim does not match registered issue for given client", () => {
+      it("Returns a 400 Bad request response", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockJwtInvalidAud}` },
+        });
+        dependencies.clientCredentialsService = () =>
+          new MockPassingClientCredentialsService();
+
+        const result = await lambdaHandler(event, dependencies);
+
+        expect(result.statusCode).toBe(400);
+        expect(JSON.parse(result.body).error).toEqual("invalid_client");
+        expect(JSON.parse(result.body).error_description).toEqual(
+          "Invalid aud claim",
+        );
+      });
+    });
   });
 });
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -26,6 +26,9 @@ const mockJwtIssNotValid =
 const mockJwtNoScope =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciJ9._-4Sn9N5grVDSxI2vvoUH90-6bAh6nH53ELZ38b3Gwk";
 
+const mockJwtScopeNotValid =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMTUxNjIzOTAyMiIsImV4cCI6IjIxNDU5NjQ2OTUiLCJuYmYiOiIxNTE2MjM5MDIyIiwiaXNzIjoibW9ja0lzc3VlciIsInNjb3BlIjoibW9ja0ludmFsaWRTY29wZSJ9.kO0R0-bN6uYkknOD9E0oqtpRlp0rHB-6njrHN3mKkX4";
+
 const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
@@ -304,26 +307,26 @@ describe("Async Credential", () => {
         });
       });
 
-      // describe("Given scope is not valid", () => {
-      //   it("Returns a log", async () => {
-      //     const event = buildRequest({
-      //       headers: { Authorization: `Bearer ${mockJwtIssNotValid}` },
-      //     });
+      describe("Given scope is invalid", () => {
+        it("Returns a log", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockJwtScopeNotValid}` },
+          });
 
-      //     dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+          dependencies.tokenService = () => new MockTokenSeviceValidSignature();
 
-      //     const result: APIGatewayProxyResult = await lambdaHandler(
-      //       event,
-      //       dependencies,
-      //     );
+          const result: APIGatewayProxyResult = await lambdaHandler(
+            event,
+            dependencies,
+          );
 
-      //     expect(result).toStrictEqual({
-      //       headers: { "Content-Type": "application/json" },
-      //       statusCode: 401,
-      //       body: "Unauthorized",
-      //     });
-      //   });
-      // });
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 401,
+            body: "Unauthorized",
+          });
+        });
+      });
     });
   });
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -107,11 +107,6 @@ export async function lambdaHandler(
     return badRequestResponseMissingAud;
   }
 
-  if (!jwtPayload.state) {
-    console.log("NO AUD");
-    return badRequestResponseMissingState;
-  }
-
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -96,40 +96,45 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
+  if (!jwtPayload.client_id) {
+    console.log("NO CLIENT_ID");
+    return unauthorized401Response;
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
-
-  // Fetching stored client credentials
-  const ssmService = dependencies.ssmService();
-  const ssmServiceResponse = await ssmService.getClientCredentials();
-  if (ssmServiceResponse.isLog) {
-    return serverError500Responses;
-  }
-
-  const storedCredentialsArray =
-    ssmServiceResponse.value as IClientCredentials[];
-
-  // Incoming credentials match stored credentials
-  const clientCredentialsService = dependencies.clientCredentialsService();
-  const storedCredentials = clientCredentialsService.getClientCredentialsById(
-    storedCredentialsArray,
-    suppliedCredentials.clientId,
-  );
-  if (!storedCredentials) {
-    return badRequestResponseInvalidCredentials;
-  }
-
-  const isValidClientCredentials = clientCredentialsService.validate(
-    storedCredentials,
-    suppliedCredentials,
-  );
-  if (!isValidClientCredentials) {
-    return badRequestResponseInvalidCredentials;
-  }
 
   if (result.isLog) {
     console.log("INVALID SIGNATURE");
     return unauthorized401Response;
   }
+
+  // // Fetching stored client credentials
+  // const ssmService = dependencies.ssmService();
+  // const ssmServiceResponse = await ssmService.getClientCredentials();
+  // if (ssmServiceResponse.isLog) {
+  //   return serverError500Responses;
+  // }
+
+  // const storedCredentialsArray =
+  //   ssmServiceResponse.value as IClientCredentials[];
+
+  // // Incoming credentials match stored credentials
+  // const clientCredentialsService = dependencies.clientCredentialsService();
+  // const storedCredentials = clientCredentialsService.getClientCredentialsById(
+  //   storedCredentialsArray,
+  //   suppliedCredentials.clientId,
+  // );
+  // if (!storedCredentials) {
+  //   return badRequestResponseInvalidCredentials;
+  // }
+
+  // const isValidClientCredentials = clientCredentialsService.validate(
+  //   storedCredentials,
+  //   suppliedCredentials,
+  // );
+  // if (!isValidClientCredentials) {
+  //   return badRequestResponseInvalidCredentials;
+  // }
 
   return {
     headers: { "Content-Type": "application/json" },

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -34,16 +34,24 @@ export async function lambdaHandler(
   );
 
   if (!jwtPayload.exp) {
+    console.log("NO EXP");
     return unauthorized401Response;
   }
 
-  if (jwtPayload.exp <= Date.now()) {
+  if (jwtPayload.exp <= Math.floor(Date.now() / 1000)) {
+    console.log("DATE IN PAST");
+    return unauthorized401Response;
+  }
+
+  if (!jwtPayload.iat) {
+    console.log("NO IAT");
     return unauthorized401Response;
   }
 
   const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
 
   if (result.isLog) {
+    console.log("INVALID SIGNATURE");
     return unauthorized401Response;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -25,28 +25,20 @@ export async function lambdaHandler(
     return serverError500Responses;
   }
 
-  const bearerToken = event.headers["Authorization"];
+  const authorizationHeader = event.headers["Authorization"];
 
-  if (bearerToken == null) {
+  if (authorizationHeader == null) {
     return unauthorizedResponse;
   }
 
-  if (!bearerToken.startsWith("Bearer ")) {
-    return unauthorizedResponse;
-  }
-
-  if (bearerToken.split(" ").length !== 2) {
-    return unauthorizedResponse;
-  }
-
-  if (bearerToken.split(" ")[1].length == 0) {
+  if(!isAuthorizationHeaderFormatValid(authorizationHeader)) {
     return unauthorizedResponse;
   }
 
   const tokenService = dependencies.tokenService();
 
   // JWT Claim validation
-  const encodedJwt = bearerToken.split(" ")[1];
+  const encodedJwt = authorizationHeader.split(" ")[1];
   // Replace with const [header, payload, signature] = encodedJwt.split(".") when needed
   const payload = encodedJwt.split(".")[1];
   const jwtPayload = JSON.parse(
@@ -132,6 +124,21 @@ export async function lambdaHandler(
       message: "Hello World",
     }),
   };
+}
+
+const isAuthorizationHeaderFormatValid = (authorizationHeader: string) => {
+
+  if (!authorizationHeader.startsWith("Bearer ")) {
+    return unauthorizedResponse;
+  }
+
+  if (authorizationHeader.split(" ").length !== 2) {
+    return unauthorizedResponse;
+  }
+
+  if (authorizationHeader.split(" ")[1].length == 0) {
+    return unauthorizedResponse;
+  }
 }
 
 const badRequestResponseInvalidCredentials: APIGatewayProxyResult = {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -39,6 +39,18 @@ export async function lambdaHandler(
     };
   }
 
+  const tokenService = dependencies.tokenService();
+
+  const result = await tokenService.verifyTokenSignature("", "");
+
+  if (result.isLog) {
+    return {
+      headers: { "Content-Type": "application/json" },
+      statusCode: 401,
+      body: "Unauthorized",
+    };
+  }
+
   return {
     headers: { "Content-Type": "application/json" },
     statusCode: 200,
@@ -49,5 +61,9 @@ export async function lambdaHandler(
 }
 
 export interface Dependencies {
-  tokenService: (keyId: string) => TokenService;
+  tokenService: () => TokenService;
 }
+
+const dependencies = {
+  tokenService: () => new TokenService(),
+};

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -74,7 +74,7 @@ export async function lambdaHandler(
 
   if (jwtPayload.nbf >= Math.floor(Date.now() / 1000)) {
     console.log("DATE IN PAST");
-    return unauthorized401Response;
+    return badRequestResponseInvalidNbf;
   }
 
   if (!jwtPayload.iss) {
@@ -183,6 +183,15 @@ const badRequestResponseInvalidIat: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "iat claim is in the future",
+  }),
+};
+
+const badRequestResponseInvalidNbf: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "nbf claim is in the future",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -79,7 +79,7 @@ export async function lambdaHandler(
 
   if (!jwtPayload.iss) {
     console.log("NO ISS");
-    return unauthorized401Response;
+    return badRequestResponseMissingIss;
   }
 
   if (jwtPayload.iss !== issuer) {
@@ -192,6 +192,15 @@ const badRequestResponseInvalidNbf: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "nbf claim is in the future",
+  }),
+};
+
+const badRequestResponseMissingIss: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing iss claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -69,7 +69,7 @@ export async function lambdaHandler(
 
   if (jwtPayload.iat >= Math.floor(Date.now() / 1000)) {
     console.log("DATE IN PAST");
-    return unauthorized401Response;
+    return badRequestResponseInvalidIat;
   }
 
   if (jwtPayload.nbf >= Math.floor(Date.now() / 1000)) {
@@ -174,6 +174,15 @@ const badRequestResponseInvalidExp: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Invalid exp claim in jwt",
+  }),
+};
+
+const badRequestResponseInvalidIat: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "iat claim is in the future",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -6,9 +6,9 @@ export async function lambdaHandler(
   event: APIGatewayProxyEvent,
   dependencies: Dependencies,
 ): Promise<APIGatewayProxyResult> {
-  let kidArn;
+  let keyId;
   try {
-    kidArn = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
+    keyId = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
   } catch (error) {
     return serverError500Responses;
   }
@@ -60,7 +60,7 @@ export async function lambdaHandler(
     console.log("DATE IN PAST");
     return unauthorized401Response;
   }
-  const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
+  const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {
     console.log("INVALID SIGNATURE");

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -74,12 +74,17 @@ export async function lambdaHandler(
   }
 
   if (jwtPayload.iss !== issuer) {
-    console.log("ISS NOT VALID");
+    console.log("ISS INVALID");
     return unauthorized401Response;
   }
 
   if (!jwtPayload.scope) {
     console.log("NO SCOPE");
+    return unauthorized401Response;
+  }
+
+  if (jwtPayload.scope !== "dcmaw.session.async_create") {
+    console.log("SCOPE INVALID");
     return unauthorized401Response;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -43,14 +43,21 @@ export async function lambdaHandler(
 
   // JWT Claim validation
   const encodedJwt = bearerToken.split(" ")[1];
-  console.log("ENCODED JWT", encodedJwt);
+
   const [header, payload, signature] = encodedJwt.split(".");
   const jwtPayload = JSON.parse(
     Buffer.from(payload, "base64").toString("utf-8"),
   );
-  console.log("JWT PAYLOAD", jwtPayload);
 
   if (!jwtPayload.exp) {
+    return {
+      headers: { "Content-Type": "application/json" },
+      statusCode: 401,
+      body: "Unauthorized",
+    };
+  }
+
+  if(jwtPayload.exp <= Date.now()) {
     return {
       headers: { "Content-Type": "application/json" },
       statusCode: 401,

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -89,7 +89,7 @@ export async function lambdaHandler(
 
   if (!jwtPayload.scope) {
     console.log("NO SCOPE");
-    return unauthorized401Response;
+    return badRequestResponseMissingScope;
   }
 
   if (jwtPayload.scope !== "dcmaw.session.async_create") {
@@ -210,6 +210,15 @@ const badRequestResponseInvalidIss: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "iss claim does not match registered issuer",
+  }),
+};
+
+const badRequestResponseMissingScope: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing scope claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -57,7 +57,7 @@ export async function lambdaHandler(
     };
   }
 
-  if(jwtPayload.exp <= Date.now()) {
+  if (jwtPayload.exp <= Date.now()) {
     return {
       headers: { "Content-Type": "application/json" },
       statusCode: 401,

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -64,7 +64,7 @@ export async function lambdaHandler(
 
   if (jwtPayload.exp <= Math.floor(Date.now() / 1000)) {
     console.log("DATE IN PAST");
-    return unauthorized401Response;
+    return badRequestResponseInvalidExp;
   }
 
   if (jwtPayload.iat >= Math.floor(Date.now() / 1000)) {
@@ -165,6 +165,15 @@ const badRequestResponseMissingExp: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Missing exp claim in jwt",
+  }),
+};
+
+const badRequestResponseInvalidExp: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Invalid exp claim in jwt",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -4,10 +4,7 @@ import {
   ClientCredentialsService,
   IClientCredentials,
 } from "../services/clientCredentialsService/clientCredentialsService";
-import {
-  IGetClientCredentials,
-  SsmService,
-} from "../asyncToken/ssmService/ssmService";
+import { IGetClientCredentials } from "../asyncToken/ssmService/ssmService";
 import { TokenService } from "./TokenService/tokenService";
 
 export async function lambdaHandler(
@@ -51,8 +48,8 @@ export async function lambdaHandler(
 
   // JWT Claim validation
   const encodedJwt = bearerToken.split(" ")[1];
-
-  const [header, payload, signature] = encodedJwt.split(".");
+  // Replace with const [header, payload, signature] = encodedJwt.split(".") when needed
+  const payload = encodedJwt.split(".")[1];
   const jwtPayload = JSON.parse(
     Buffer.from(payload, "base64").toString("utf-8"),
   );
@@ -292,9 +289,9 @@ export interface Dependencies {
   env: NodeJS.ProcessEnv;
 }
 
-const dependencies: Dependencies = {
-  tokenService: () => new TokenService(),
-  clientCredentialsService: () => new ClientCredentialsService(),
-  ssmService: () => new SsmService(),
-  env: process.env,
-};
+// const dependencies: Dependencies = {
+//   tokenService: () => new TokenService(),
+//   clientCredentialsService: () => new ClientCredentialsService(),
+//   ssmService: () => new SsmService(),
+//   env: process.env,
+// };

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -73,6 +73,11 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
+  if (jwtPayload.iss !== issuer) {
+    console.log("NO ISS");
+    return unauthorized401Response;
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -84,7 +84,7 @@ export async function lambdaHandler(
 
   if (jwtPayload.iss !== issuer) {
     console.log("ISS INVALID");
-    return unauthorized401Response;
+    return badRequestResponseInvalidIss;
   }
 
   if (!jwtPayload.scope) {
@@ -201,6 +201,15 @@ const badRequestResponseMissingIss: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Missing iss claim",
+  }),
+};
+
+const badRequestResponseInvalidIss: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "iss claim does not match registered issuer",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -104,7 +104,7 @@ export async function lambdaHandler(
 
   if (!jwtPayload.aud) {
     console.log("NO AUD");
-    return unauthorized401Response;
+    return badRequestResponseMissingAud;
   }
 
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
@@ -237,6 +237,15 @@ const badRequestResponseMissingClientId: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Missing client_id claim",
+  }),
+};
+
+const badRequestResponseMissingAud: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing aud claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -53,6 +53,15 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
+  if (!jwtPayload.nbf) {
+    console.log("NO IAT");
+    return unauthorized401Response;
+  }
+
+  if (jwtPayload.nbf >= Math.floor(Date.now() / 1000)) {
+    console.log("DATE IN PAST");
+    return unauthorized401Response;
+  }
   const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
 
   if (result.isLog) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -74,7 +74,12 @@ export async function lambdaHandler(
   }
 
   if (jwtPayload.iss !== issuer) {
-    console.log("NO ISS");
+    console.log("ISS NOT VALID");
+    return unauthorized401Response;
+  }
+
+  if (!jwtPayload.scope) {
+    console.log("NO SCOPE");
     return unauthorized401Response;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -1,5 +1,4 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { TokenService } from "./TokenService/tokenService.test";
 import { validOrThrow } from "../config";
 import {
   ClientCredentialsService,
@@ -9,6 +8,7 @@ import {
   IGetClientCredentials,
   SsmService,
 } from "../asyncToken/ssmService/ssmService";
+import { TokenService } from "./TokenService/tokenService";
 
 export async function lambdaHandler(
   event: APIGatewayProxyEvent,
@@ -294,6 +294,9 @@ export interface Dependencies {
   env: NodeJS.ProcessEnv;
 }
 
-const dependencies = {
+const dependencies: Dependencies = {
   tokenService: () => new TokenService(),
+  clientCredentialsService: () => new ClientCredentialsService(),
+  ssmService: () => new SsmService(),
+  env: process.env,
 };

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -108,33 +108,26 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
-  // // Fetching stored client credentials
-  // const ssmService = dependencies.ssmService();
-  // const ssmServiceResponse = await ssmService.getClientCredentials();
-  // if (ssmServiceResponse.isLog) {
-  //   return serverError500Responses;
-  // }
+  // Fetching stored client credentials
+  const ssmService = dependencies.ssmService();
+  const ssmServiceResponse = await ssmService.getClientCredentials();
+  if (ssmServiceResponse.isLog) {
+    return serverError500Responses;
+  }
 
-  // const storedCredentialsArray =
-  //   ssmServiceResponse.value as IClientCredentials[];
+  const storedCredentialsArray =
+    ssmServiceResponse.value as IClientCredentials[];
 
-  // // Incoming credentials match stored credentials
-  // const clientCredentialsService = dependencies.clientCredentialsService();
-  // const storedCredentials = clientCredentialsService.getClientCredentialsById(
-  //   storedCredentialsArray,
-  //   suppliedCredentials.clientId,
-  // );
-  // if (!storedCredentials) {
-  //   return badRequestResponseInvalidCredentials;
-  // }
+  // Incoming credentials match stored credentials
+  const clientCredentialsService = dependencies.clientCredentialsService();
+  const storedCredentials = clientCredentialsService.getClientCredentialsById(
+    storedCredentialsArray,
+    jwtPayload.client_id,
+  );
 
-  // const isValidClientCredentials = clientCredentialsService.validate(
-  //   storedCredentials,
-  //   suppliedCredentials,
-  // );
-  // if (!isValidClientCredentials) {
-  //   return badRequestResponseInvalidCredentials;
-  // }
+  if (!storedCredentials) {
+    return badRequestResponseInvalidCredentials;
+  }
 
   return {
     headers: { "Content-Type": "application/json" },
@@ -144,6 +137,15 @@ export async function lambdaHandler(
     }),
   };
 }
+
+const badRequestResponseInvalidCredentials: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "invalid_client",
+    error_description: "Supplied client credentials not recognised",
+  }),
+};
 
 const unauthorized401Response = {
   headers: { "Content-Type": "application/json" },

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -31,7 +31,7 @@ export async function lambdaHandler(
     return unauthorizedResponse;
   }
 
-  if(!isAuthorizationHeaderFormatValid(authorizationHeader)) {
+  if (!isAuthorizationHeaderFormatValid(authorizationHeader)) {
     return unauthorizedResponse;
   }
 
@@ -127,7 +127,6 @@ export async function lambdaHandler(
 }
 
 const isAuthorizationHeaderFormatValid = (authorizationHeader: string) => {
-
   if (!authorizationHeader.startsWith("Bearer ")) {
     return unauthorizedResponse;
   }
@@ -139,7 +138,7 @@ const isAuthorizationHeaderFormatValid = (authorizationHeader: string) => {
   if (authorizationHeader.split(" ")[1].length == 0) {
     return unauthorizedResponse;
   }
-}
+};
 
 const badRequestResponseInvalidCredentials: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -107,6 +107,11 @@ export async function lambdaHandler(
     return badRequestResponseMissingAud;
   }
 
+  if (!jwtPayload.state) {
+    console.log("NO AUD");
+    return badRequestResponseMissingState;
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {
@@ -246,6 +251,15 @@ const badRequestResponseMissingAud: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Missing aud claim",
+  }),
+};
+
+const badRequestResponseMissingState: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing state claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -8,35 +8,19 @@ export async function lambdaHandler(
   const bearerToken = event.headers["Authorization"];
 
   if (bearerToken == null) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   if (!bearerToken.startsWith("Bearer ")) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   if (bearerToken.split(" ").length !== 2) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   if (bearerToken.split(" ")[1].length == 0) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   const tokenService = dependencies.tokenService();
@@ -50,29 +34,17 @@ export async function lambdaHandler(
   );
 
   if (!jwtPayload.exp) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   if (jwtPayload.exp <= Date.now()) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
 
   if (result.isLog) {
-    return {
-      headers: { "Content-Type": "application/json" },
-      statusCode: 401,
-      body: "Unauthorized",
-    };
+    return unauthorized401Response;
   }
 
   return {
@@ -83,6 +55,12 @@ export async function lambdaHandler(
     }),
   };
 }
+
+const unauthorized401Response = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 401,
+  body: "Unauthorized",
+};
 
 export interface Dependencies {
   tokenService: () => TokenService;

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -32,19 +32,19 @@ export async function lambdaHandler(
   const bearerToken = event.headers["Authorization"];
 
   if (bearerToken == null) {
-    return unauthorized401Response;
+    return unauthorizedResponse;
   }
 
   if (!bearerToken.startsWith("Bearer ")) {
-    return unauthorized401Response;
+    return unauthorizedResponse;
   }
 
   if (bearerToken.split(" ").length !== 2) {
-    return unauthorized401Response;
+    return unauthorizedResponse;
   }
 
   if (bearerToken.split(" ")[1].length == 0) {
-    return unauthorized401Response;
+    return unauthorizedResponse;
   }
 
   const tokenService = dependencies.tokenService();
@@ -111,7 +111,7 @@ export async function lambdaHandler(
 
   if (result.isLog) {
     console.log("INVALID SIGNATURE", encodedJwt);
-    return unauthorized401Response;
+    return unauthorizedResponseInvalidSignature;
   }
 
   // Fetching stored client credentials
@@ -249,15 +249,6 @@ const badRequestResponseMissingAud: APIGatewayProxyResult = {
   }),
 };
 
-const badRequestResponseMissingState: APIGatewayProxyResult = {
-  headers: { "Content-Type": "application/json" },
-  statusCode: 400,
-  body: JSON.stringify({
-    error: "invalid_token",
-    error_description: "Missing state claim",
-  }),
-};
-
 const badRequestResponseInvalidAud: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
@@ -267,10 +258,22 @@ const badRequestResponseInvalidAud: APIGatewayProxyResult = {
   }),
 };
 
-const unauthorized401Response = {
+const unauthorizedResponse = {
   headers: { "Content-Type": "application/json" },
   statusCode: 401,
-  body: "Unauthorized",
+  body: JSON.stringify({
+    error: "Unauthorized",
+    error_description: "Invalid token",
+  }),
+};
+
+const unauthorizedResponseInvalidSignature = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 401,
+  body: JSON.stringify({
+    error: "Unauthorized",
+    error_description: "Invalid signature",
+  }),
 };
 
 const serverError500Responses: APIGatewayProxyResult = {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -102,10 +102,15 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
+  if (!jwtPayload.aud) {
+    console.log("NO CLIENT_ID");
+    return unauthorized401Response;
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {
-    console.log("INVALID SIGNATURE");
+    console.log("INVALID SIGNATURE", encodedJwt);
     return unauthorized401Response;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -48,6 +48,11 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
+  if (jwtPayload.iat >= Math.floor(Date.now() / 1000)) {
+    console.log("DATE IN PAST");
+    return unauthorized401Response;
+  }
+
   const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
 
   if (result.isLog) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -168,7 +168,7 @@ const badRequestResponseMissingExp: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing exp claim",
   }),
 };
@@ -177,7 +177,7 @@ const badRequestResponseInvalidExp: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "exp claim is in the past",
   }),
 };
@@ -186,7 +186,7 @@ const badRequestResponseInvalidIat: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "iat claim is in the future",
   }),
 };
@@ -195,7 +195,7 @@ const badRequestResponseInvalidNbf: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "nbf claim is in the future",
   }),
 };
@@ -204,7 +204,7 @@ const badRequestResponseMissingIss: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing iss claim",
   }),
 };
@@ -213,7 +213,7 @@ const badRequestResponseInvalidIss: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "iss claim does not match registered issuer",
   }),
 };
@@ -222,7 +222,7 @@ const badRequestResponseMissingScope: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing scope claim",
   }),
 };
@@ -231,7 +231,7 @@ const badRequestResponseInvalidScope: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Invalid scope claim",
   }),
 };
@@ -240,7 +240,7 @@ const badRequestResponseMissingClientId: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing client_id claim",
   }),
 };
@@ -249,7 +249,7 @@ const badRequestResponseMissingAud: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing aud claim",
   }),
 };
@@ -258,7 +258,7 @@ const badRequestResponseMissingState: APIGatewayProxyResult = {
   headers: { "Content-Type": "application/json" },
   statusCode: 400,
   body: JSON.stringify({
-    error: "bad_request",
+    error: "invalid_token",
     error_description: "Missing state claim",
   }),
 };

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -59,7 +59,7 @@ export async function lambdaHandler(
 
   if (!jwtPayload.exp) {
     console.log("NO EXP");
-    return unauthorized401Response;
+    return badRequestResponseMissingExp;
   }
 
   if (jwtPayload.exp <= Math.floor(Date.now() / 1000)) {
@@ -156,6 +156,15 @@ const badRequestResponseInvalidCredentials: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "invalid_client",
     error_description: "Supplied client not recognised",
+  }),
+};
+
+const badRequestResponseMissingExp: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing exp claim in jwt",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -164,7 +164,7 @@ const badRequestResponseMissingExp: APIGatewayProxyResult = {
   statusCode: 400,
   body: JSON.stringify({
     error: "bad_request",
-    error_description: "Missing exp claim in jwt",
+    error_description: "Missing exp claim",
   }),
 };
 
@@ -173,7 +173,7 @@ const badRequestResponseInvalidExp: APIGatewayProxyResult = {
   statusCode: 400,
   body: JSON.stringify({
     error: "bad_request",
-    error_description: "Invalid exp claim in jwt",
+    error_description: "exp claim is in the past",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -14,6 +14,7 @@ export async function lambdaHandler(
   event: APIGatewayProxyEvent,
   dependencies: Dependencies,
 ): Promise<APIGatewayProxyResult> {
+  console.log("REQUEST INCOMING");
   let keyId;
   try {
     keyId = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
@@ -112,6 +113,7 @@ export async function lambdaHandler(
   const ssmService = dependencies.ssmService();
   const ssmServiceResponse = await ssmService.getClientCredentials();
   if (ssmServiceResponse.isLog) {
+    console.log("'it's an error!!!!!!!!!");
     return serverError500Responses;
   }
 
@@ -143,7 +145,7 @@ const badRequestResponseInvalidCredentials: APIGatewayProxyResult = {
   statusCode: 400,
   body: JSON.stringify({
     error: "invalid_client",
-    error_description: "Supplied client credentials not recognised",
+    error_description: "Supplied client not recognised",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -67,6 +67,12 @@ export async function lambdaHandler(
     console.log("DATE IN PAST");
     return unauthorized401Response;
   }
+
+  if (!jwtPayload.iss) {
+    console.log("NO ISS");
+    return unauthorized401Response;
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -11,7 +11,6 @@ export async function lambdaHandler(
   event: APIGatewayProxyEvent,
   dependencies: Dependencies,
 ): Promise<APIGatewayProxyResult> {
-  console.log("REQUEST INCOMING");
   let keyId;
   try {
     keyId = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
@@ -55,59 +54,48 @@ export async function lambdaHandler(
   );
 
   if (!jwtPayload.exp) {
-    console.log("NO EXP");
     return badRequestResponseMissingExp;
   }
 
   if (jwtPayload.exp <= Math.floor(Date.now() / 1000)) {
-    console.log("DATE IN PAST");
     return badRequestResponseInvalidExp;
   }
 
   if (jwtPayload.iat >= Math.floor(Date.now() / 1000)) {
-    console.log("DATE IN PAST");
     return badRequestResponseInvalidIat;
   }
 
   if (jwtPayload.nbf >= Math.floor(Date.now() / 1000)) {
-    console.log("DATE IN PAST");
     return badRequestResponseInvalidNbf;
   }
 
   if (!jwtPayload.iss) {
-    console.log("NO ISS");
     return badRequestResponseMissingIss;
   }
 
   if (jwtPayload.iss !== issuer) {
-    console.log("ISS INVALID");
     return badRequestResponseInvalidIss;
   }
 
   if (!jwtPayload.scope) {
-    console.log("NO SCOPE");
     return badRequestResponseMissingScope;
   }
 
   if (jwtPayload.scope !== "dcmaw.session.async_create") {
-    console.log("SCOPE INVALID");
     return badRequestResponseInvalidScope;
   }
 
   if (!jwtPayload.client_id) {
-    console.log("NO CLIENT_ID");
     return badRequestResponseMissingClientId;
   }
 
   if (!jwtPayload.aud) {
-    console.log("NO AUD");
     return badRequestResponseMissingAud;
   }
 
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {
-    console.log("INVALID SIGNATURE", encodedJwt);
     return unauthorizedResponseInvalidSignature;
   }
 
@@ -115,7 +103,6 @@ export async function lambdaHandler(
   const ssmService = dependencies.ssmService();
   const ssmServiceResponse = await ssmService.getClientCredentials();
   if (ssmServiceResponse.isLog) {
-    console.log("'it's an error!!!!!!!!!");
     return serverError500Responses;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -13,6 +13,13 @@ export async function lambdaHandler(
     return serverError500Responses;
   }
 
+  let issuer;
+  try {
+    issuer = validOrThrow(dependencies.env, "ISSUER");
+  } catch (error) {
+    return serverError500Responses;
+  }
+
   const bearerToken = event.headers["Authorization"];
 
   if (bearerToken == null) {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -43,18 +43,8 @@ export async function lambdaHandler(
     return unauthorized401Response;
   }
 
-  if (!jwtPayload.iat) {
-    console.log("NO IAT");
-    return unauthorized401Response;
-  }
-
   if (jwtPayload.iat >= Math.floor(Date.now() / 1000)) {
     console.log("DATE IN PAST");
-    return unauthorized401Response;
-  }
-
-  if (!jwtPayload.nbf) {
-    console.log("NO IAT");
     return unauthorized401Response;
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -94,7 +94,7 @@ export async function lambdaHandler(
 
   if (jwtPayload.scope !== "dcmaw.session.async_create") {
     console.log("SCOPE INVALID");
-    return unauthorized401Response;
+    return badRequestResponseInvalidScope;
   }
 
   if (!jwtPayload.client_id) {
@@ -219,6 +219,15 @@ const badRequestResponseMissingScope: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Missing scope claim",
+  }),
+};
+
+const badRequestResponseInvalidScope: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Invalid scope claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -99,7 +99,7 @@ export async function lambdaHandler(
 
   if (!jwtPayload.client_id) {
     console.log("NO CLIENT_ID");
-    return unauthorized401Response;
+    return badRequestResponseMissingClientId;
   }
 
   if (!jwtPayload.aud) {
@@ -228,6 +228,15 @@ const badRequestResponseInvalidScope: APIGatewayProxyResult = {
   body: JSON.stringify({
     error: "bad_request",
     error_description: "Invalid scope claim",
+  }),
+};
+
+const badRequestResponseMissingClientId: APIGatewayProxyResult = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 400,
+  body: JSON.stringify({
+    error: "bad_request",
+    error_description: "Missing client_id claim",
   }),
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -41,7 +41,24 @@ export async function lambdaHandler(
 
   const tokenService = dependencies.tokenService();
 
-  const result = await tokenService.verifyTokenSignature("", "");
+  // JWT Claim validation
+  const encodedJwt = bearerToken.split(" ")[1];
+  console.log("ENCODED JWT", encodedJwt);
+  const [header, payload, signature] = encodedJwt.split(".");
+  const jwtPayload = JSON.parse(
+    Buffer.from(payload, "base64").toString("utf-8"),
+  );
+  console.log("JWT PAYLOAD", jwtPayload);
+
+  if (!jwtPayload.exp) {
+    return {
+      headers: { "Content-Type": "application/json" },
+      statusCode: 401,
+      body: "Unauthorized",
+    };
+  }
+
+  const result = await tokenService.verifyTokenSignature("keyId", encodedJwt);
 
   if (result.isLog) {
     return {

--- a/src/functions/asyncCredential/todo.md
+++ b/src/functions/asyncCredential/todo.md
@@ -1,0 +1,12 @@
+## Work cannot be marked as done until the following is done
+
+[ ] Add logger for jwt clais
+[ ] Check claim validation to ensure it correctly returns 400/401
+[ ] Create a single shared token service
+
+
+## Work to consider
+
+[ ] Mock JWT builder
+[ ] Refactor token lambda to add Logger
+[ ] Cache KMS key and use node-jose (?) to verify signature

--- a/src/functions/asyncCredential/todo.md
+++ b/src/functions/asyncCredential/todo.md
@@ -3,6 +3,7 @@
 [ ] Add logger for jwt clais
 [ ] Check claim validation to ensure it correctly returns 400/401
 [ ] Create a single shared token service
+[ ] Type naming/location
 
 
 ## Work to consider

--- a/src/functions/asyncCredential/todo.md
+++ b/src/functions/asyncCredential/todo.md
@@ -1,7 +1,7 @@
 ## Work cannot be marked as done until the following is done
 
 [ ] Add logger for jwt clais
-[ ] Check claim validation to ensure it correctly returns 400/401
+[x] Check claim validation to ensure it correctly returns 400/401
 [ ] Create a single shared token service
 [ ] Type naming/location
 [ ] Centralise mocks

--- a/src/functions/asyncCredential/todo.md
+++ b/src/functions/asyncCredential/todo.md
@@ -1,7 +1,5 @@
 ## Work cannot be marked as done until the following is done
 
-[ ] Add logger for jwt clais
-[x] Check claim validation to ensure it correctly returns 400/401
 [ ] Create a single shared token service
 [ ] Type naming/location
 [ ] Centralise mocks

--- a/src/functions/asyncCredential/todo.md
+++ b/src/functions/asyncCredential/todo.md
@@ -4,6 +4,7 @@
 [ ] Check claim validation to ensure it correctly returns 400/401
 [ ] Create a single shared token service
 [ ] Type naming/location
+[ ] Centralise mocks
 
 
 ## Work to consider

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -22,11 +22,10 @@ describe("Async Token", () => {
     request = buildRequest();
     dependencies = {
       env,
-      getRequestService: () => new MockRequestServiceValueResponse(),
-      getSsmService: () => new MockPassingSsmService(),
-      getClientCredentialsService: () =>
-        new MockPassingClientCredentialsService(),
-      getTokenService: () => new MockPassingTokenService(),
+      requestService: () => new MockRequestServiceValueResponse(),
+      ssmService: () => new MockPassingSsmService(),
+      clientCredentialService: () => new MockPassingClientCredentialsService(),
+      tokenService: () => new MockPassingTokenService(),
     };
   });
 
@@ -50,7 +49,7 @@ describe("Async Token", () => {
   describe("Request Service", () => {
     describe("Given the Request Service returns a log due to Invalid grant_type in request body", () => {
       it("Returns a 400 Bad Request response", async () => {
-        dependencies.getRequestService = () =>
+        dependencies.requestService = () =>
           new MockRequestServiceInvalidGrantTypeLogResponse();
 
         const result = await lambdaHandlerConstructor(dependencies, request);
@@ -65,7 +64,7 @@ describe("Async Token", () => {
 
     describe("Given the Request Service returns a log due to invalid Authorization header ", () => {
       it("Returns a 400 Bad Request response", async () => {
-        dependencies.getRequestService = () =>
+        dependencies.requestService = () =>
           new MockRequestServiceInvalidAuthorizationHeaderLogResponse();
 
         const result = await lambdaHandlerConstructor(dependencies, request);
@@ -84,7 +83,7 @@ describe("Async Token", () => {
   describe("SSM Service", () => {
     describe("Given there is an error retrieving client credentials from SSM", () => {
       it("Returns a 500 Server Error response", async () => {
-        dependencies.getSsmService = () => new MockFailingSsmService();
+        dependencies.ssmService = () => new MockFailingSsmService();
 
         const result = await lambdaHandlerConstructor(dependencies, request);
 
@@ -100,7 +99,7 @@ describe("Async Token", () => {
     describe("Get client credentials by ID", () => {
       describe("Given credentials are not found", () => {
         it("Returns 400 Bad Request response", async () => {
-          dependencies.getClientCredentialsService = () =>
+          dependencies.clientCredentialService = () =>
             new MockFailingClientCredentialsServiceGetClientCredentialsById();
 
           const result = await lambdaHandlerConstructor(dependencies, request);
@@ -117,7 +116,7 @@ describe("Async Token", () => {
     describe("Credential validation", () => {
       describe("Given credentials are not valid", () => {
         it("Returns 400 Bad request response", async () => {
-          dependencies.getClientCredentialsService = () =>
+          dependencies.clientCredentialService = () =>
             new MockFailingClientCredentialsServiceValidation();
 
           const result = await lambdaHandlerConstructor(dependencies, request);
@@ -135,7 +134,7 @@ describe("Async Token", () => {
   describe("Token Service", () => {
     describe("Given minting a new token fails", () => {
       it("Returns 500 Server Error response", async () => {
-        dependencies.getTokenService = () => new MockFailingTokenService();
+        dependencies.tokenService = () => new MockFailingTokenService();
 
         const result = await lambdaHandlerConstructor(dependencies, request);
 

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -33,10 +33,10 @@ describe("Async Token", () => {
   });
 
   describe("Environment variable validation", () => {
-    describe("Given SIGNING_KEY_IDS is missing", () => {
+    describe("Given SIGNING_KEY_ID is missing", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
-        delete dependencies.env["SIGNING_KEY_IDS"];
+        delete dependencies.env["SIGNING_KEY_ID"];
 
         const result = await lambdaHandlerConstructor(dependencies, request);
 
@@ -292,5 +292,5 @@ class MockFailingTokenService implements IMintToken {
 }
 
 const env = {
-  SIGNING_KEY_IDS: "mockSigningKeyId",
+  SIGNING_KEY_ID: "mockSigningKeyId",
 };

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -167,9 +167,7 @@ describe("Async Token", () => {
 });
 
 class MockRequestServiceValueResponse implements IProcessRequest {
-  processRequest = (
-    request: APIGatewayProxyEvent,
-  ): LogOrValue<IDecodedClientCredentials> => {
+  processRequest = (): LogOrValue<IDecodedClientCredentials> => {
     return value({
       clientId: "mockClientId",
       clientSecret: "mockClientSecret",

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -7,14 +7,12 @@ import {
 import {
   IClientCredentials,
   IClientCredentialsService,
-} from "./clientCredentialsService/clientCredentialsService";
-import {
-  IDecodedAuthorizationHeader,
-  IProcessRequest,
-} from "./requestService/requestService";
+} from "../services/clientCredentialsService/clientCredentialsService";
+import { IProcessRequest } from "./requestService/requestService";
 import { IGetClientCredentials } from "./ssmService/ssmService";
 import { IJwtPayload, IMintToken } from "./tokenService/tokenService";
 import { buildRequest } from "../testUtils/mockRequest";
+import { IDecodedClientCredentials } from "../types/clientCredentials";
 
 describe("Async Token", () => {
   let request: APIGatewayProxyEvent;
@@ -171,7 +169,7 @@ describe("Async Token", () => {
 class MockRequestServiceValueResponse implements IProcessRequest {
   processRequest = (
     request: APIGatewayProxyEvent,
-  ): LogOrValue<IDecodedAuthorizationHeader> => {
+  ): LogOrValue<IDecodedClientCredentials> => {
     return value({
       clientId: "mockClientId",
       clientSecret: "mockClientSecret",
@@ -182,7 +180,7 @@ class MockRequestServiceValueResponse implements IProcessRequest {
 class MockRequestServiceInvalidGrantTypeLogResponse implements IProcessRequest {
   processRequest = (
     request: APIGatewayProxyEvent,
-  ): LogOrValue<IDecodedAuthorizationHeader> => {
+  ): LogOrValue<IDecodedClientCredentials> => {
     return log("Invalid grant_type");
   };
 }
@@ -192,7 +190,7 @@ class MockRequestServiceInvalidAuthorizationHeaderLogResponse
 {
   processRequest = (
     request: APIGatewayProxyEvent,
-  ): LogOrValue<IDecodedAuthorizationHeader> => {
+  ): LogOrValue<IDecodedClientCredentials> => {
     return log("mockInvalidAuthorizationHeaderLog");
   };
 }
@@ -223,7 +221,7 @@ class MockFailingSsmService implements IGetClientCredentials {
 class MockPassingClientCredentialsService implements IClientCredentialsService {
   validate(
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedAuthorizationHeader,
+    suppliedCredentials: IDecodedClientCredentials,
   ) {
     return true;
   }
@@ -251,7 +249,7 @@ class MockFailingClientCredentialsServiceGetClientCredentialsById
   }
   validate(
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedAuthorizationHeader,
+    suppliedCredentials: IDecodedClientCredentials,
   ) {
     return false;
   }
@@ -273,7 +271,7 @@ class MockFailingClientCredentialsServiceValidation
   }
   validate(
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedAuthorizationHeader,
+    suppliedCredentials: IDecodedClientCredentials,
   ) {
     return false;
   }

--- a/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.ts
@@ -5,14 +5,14 @@ import {
   ClientCredentialsService,
   IClientCredentials,
   IClientCredentialsService,
-} from "./clientCredentialsService/clientCredentialsService";
+} from "../services/clientCredentialsService/clientCredentialsService";
 import {
-  IDecodedAuthorizationHeader,
   IProcessRequest,
   RequestService,
 } from "./requestService/requestService";
 import { IGetClientCredentials, SsmService } from "./ssmService/ssmService";
 import { IMintToken, TokenService } from "./tokenService/tokenService";
+import { IDecodedClientCredentials } from "../types/clientCredentials";
 
 export async function lambdaHandlerConstructor(
   dependencies: IAsyncTokenRequestDependencies,
@@ -38,8 +38,7 @@ export async function lambdaHandlerConstructor(
     return badRequestResponseInvalidAuthorizationHeader;
   }
 
-  const suppliedCredentials =
-    processRequest.value as IDecodedAuthorizationHeader;
+  const suppliedCredentials = processRequest.value as IDecodedClientCredentials;
 
   // Fetching stored client credentials
   const ssmService = dependencies.getSsmService();

--- a/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.ts
@@ -21,7 +21,7 @@ export async function lambdaHandlerConstructor(
   // Environment variables
   let kidArn;
   try {
-    kidArn = validOrThrow(dependencies.env, "SIGNING_KEY_IDS");
+    kidArn = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
   } catch (error) {
     return serverErrorResponse;
   }

--- a/src/functions/asyncToken/requestService/requestService.ts
+++ b/src/functions/asyncToken/requestService/requestService.ts
@@ -1,3 +1,4 @@
+import { IDecodedClientCredentials } from "../../types/clientCredentials";
 import { LogOrValue, log, value } from "../../types/logOrValue";
 import { APIGatewayProxyEvent } from "aws-lambda";
 const Buffer = require("buffer").Buffer;
@@ -5,7 +6,7 @@ const Buffer = require("buffer").Buffer;
 export class RequestService implements IProcessRequest {
   processRequest = (
     request: APIGatewayProxyEvent,
-  ): LogOrValue<IDecodedAuthorizationHeader> => {
+  ): LogOrValue<IDecodedClientCredentials> => {
     const requestBody = request.body;
     const authorizationHeader = request.headers["Authorization"];
 
@@ -24,7 +25,7 @@ export class RequestService implements IProcessRequest {
     }
 
     const decodedClientCredentials =
-      decodeAuthorizationHeader.value as IDecodedAuthorizationHeader;
+      decodeAuthorizationHeader.value as IDecodedClientCredentials;
 
     return value(decodedClientCredentials);
   };
@@ -58,7 +59,7 @@ export class RequestService implements IProcessRequest {
 
   private decodeAuthorizationHeader = (
     authorizationHeader: string | undefined,
-  ): LogOrValue<IDecodedAuthorizationHeader> => {
+  ): LogOrValue<IDecodedClientCredentials> => {
     const base64EncodedCredential = authorizationHeader?.split(" ")[1];
     const base64DecodedCredential = Buffer.from(
       base64EncodedCredential,
@@ -79,10 +80,5 @@ export class RequestService implements IProcessRequest {
 export interface IProcessRequest {
   processRequest: (
     request: APIGatewayProxyEvent,
-  ) => LogOrValue<IDecodedAuthorizationHeader>;
-}
-
-export interface IDecodedAuthorizationHeader {
-  clientId: string;
-  clientSecret: string;
+  ) => LogOrValue<IDecodedClientCredentials>;
 }

--- a/src/functions/asyncToken/ssmService/ssmService.ts
+++ b/src/functions/asyncToken/ssmService/ssmService.ts
@@ -6,7 +6,7 @@ import {
 } from "@aws-sdk/client-ssm";
 import { LogOrValue, log, value } from "../../types/logOrValue";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { IClientCredentials } from "../clientCredentialsService/clientCredentialsService";
+import { IClientCredentials } from "../../services/clientCredentialsService/clientCredentialsService";
 
 let cache: CacheEntry | null = null;
 

--- a/src/functions/asyncToken/tokenService/tokenService.ts
+++ b/src/functions/asyncToken/tokenService/tokenService.ts
@@ -3,6 +3,7 @@ import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import { Buffer } from "buffer";
 import jose from "node-jose";
 import format from "ecdsa-sig-formatter";
+import { IJwtPayload, JwtHeader } from "../../types/jwt";
 
 export class TokenService implements IMintToken {
   readonly kidArn: string;
@@ -62,23 +63,6 @@ export class TokenService implements IMintToken {
   private base64Encode(value: string | Uint8Array): string {
     return jose.util.base64url.encode(Buffer.from(value), "utf8");
   }
-}
-
-export interface IJwtPayload {
-  [key: string]: string | number | undefined;
-  iss: string;
-  aud: string;
-  scope: string;
-  exp: number;
-  client_id: string;
-  nbf?: number;
-  iat?: number;
-}
-
-export interface JwtHeader {
-  alg: Algorithm | string;
-  typ: string;
-  kid?: string;
 }
 
 export interface IMintToken {

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -1,4 +1,4 @@
-export type EnvVars = "SIGNING_KEY_IDS";
+export type EnvVars = "SIGNING_KEY_ID";
 
 // Get static variables
 export const validOrThrow = (

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -1,4 +1,4 @@
-export type EnvVars = "SIGNING_KEY_ID";
+export type EnvVars = "SIGNING_KEY_ID" | "ISSUER";
 
 // Get static variables
 export const validOrThrow = (

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -1,4 +1,4 @@
-import { IDecodedAuthorizationHeader } from "../requestService/requestService";
+import { IDecodedClientCredentials } from "../../types/clientCredentials";
 import {
   ClientCredentialsService,
   IClientCredentials,
@@ -6,7 +6,7 @@ import {
 
 describe("Client Credentials Service", () => {
   let clientCredentialsService: ClientCredentialsService;
-  let mockSuppliedClientCredentials: IDecodedAuthorizationHeader;
+  let mockSuppliedClientCredentials: IDecodedClientCredentials;
   let mockStoredClientCredentialsArray: IClientCredentials[];
   let mockStoredClientCredentials: IClientCredentials;
 

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -8,7 +8,7 @@ export class ClientCredentialsService implements IClientCredentialsService {
   ): boolean => {
     const { clientSecret: suppliedClientSecret } = suppliedCredentials;
     const storedSalt = storedCredentials.salt;
-    const hashedSuppliedClientSecret = this.hashSecret(
+    const hashedSuppliedClientSecret = hashSecret(
       suppliedClientSecret,
       storedSalt,
     );
@@ -30,13 +30,13 @@ export class ClientCredentialsService implements IClientCredentialsService {
 
     return storedCredentials;
   };
-
-  private hashSecret = (secret: string, salt: string): string => {
-    return createHash("sha256")
-      .update(secret + salt)
-      .digest("hex");
-  };
 }
+
+const hashSecret = (secret: string, salt: string): string => {
+  return createHash("sha256")
+    .update(secret + salt)
+    .digest("hex");
+};
 
 export interface IClientCredentialsService {
   validate: (

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -1,10 +1,10 @@
 import { createHash } from "crypto";
-import { IDecodedAuthorizationHeader } from "../requestService/requestService";
+import { IDecodedClientCredentials } from "../../types/clientCredentials";
 
 export class ClientCredentialsService implements IClientCredentialsService {
   validate = (
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedAuthorizationHeader,
+    suppliedCredentials: IDecodedClientCredentials,
   ): boolean => {
     const { clientSecret: suppliedClientSecret } = suppliedCredentials;
     const storedSalt = storedCredentials.salt;
@@ -41,7 +41,7 @@ export class ClientCredentialsService implements IClientCredentialsService {
 export interface IClientCredentialsService {
   validate: (
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedAuthorizationHeader,
+    suppliedCredentials: IDecodedClientCredentials,
   ) => boolean;
 
   getClientCredentialsById: (

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -1,5 +1,4 @@
 import { createHash } from "crypto";
-import { IDecodedClientCredentials } from "../../types/clientCredentials";
 
 export class ClientCredentialsService implements IClientCredentialsService {
   validate = (
@@ -56,3 +55,8 @@ export type IClientCredentials = {
   salt: string;
   hashed_client_secret: string;
 };
+
+export interface IDecodedClientCredentials {
+  clientId: string;
+  clientSecret: string;
+}

--- a/src/functions/testUtils/mockRequest.ts
+++ b/src/functions/testUtils/mockRequest.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
 
+// eslint-disable-next-line
 export function buildRequest(overrides?: any): APIGatewayProxyEvent {
   const defaultRequest = {
     httpMethod: "get",

--- a/src/functions/types/clientCredentials.ts
+++ b/src/functions/types/clientCredentials.ts
@@ -1,0 +1,4 @@
+export interface IDecodedClientCredentials {
+  clientId: string;
+  clientSecret: string;
+}

--- a/src/functions/types/errorOrValue.ts
+++ b/src/functions/types/errorOrValue.ts
@@ -1,0 +1,20 @@
+export interface ErrorOrSuccess<TValue> {
+  isError: boolean;
+  value: string | TValue;
+}
+
+export function successResponse<TValue>(value: TValue): ErrorOrSuccess<TValue> {
+  return {
+    isError: false,
+    value,
+  };
+}
+
+export function errorResponse<TValue>(
+  errorMessage: string,
+): ErrorOrSuccess<TValue> {
+  return {
+    isError: true,
+    value: errorMessage,
+  };
+}

--- a/src/functions/types/jwt.ts
+++ b/src/functions/types/jwt.ts
@@ -1,0 +1,16 @@
+export interface IJwtPayload {
+  [key: string]: string | number | undefined;
+  iss: string;
+  aud: string;
+  scope: string;
+  exp: number;
+  client_id: string;
+  nbf?: number;
+  iat?: number;
+}
+
+export interface JwtHeader {
+  alg: Algorithm | string;
+  typ: string;
+  kid?: string;
+}

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -16,7 +16,7 @@
 #   Function:
 #     Environment:
 #       Variables:
-#         SIGNING_KEY_IDS: !Sub "{{resolve:ssm:/${Environment}/${KMSKeyStack}/KMS/SigningKeyArn}}"
+#         SIGNING_KEY_ID: !Sub "{{resolve:ssm:/${Environment}/${KMSKeyStack}/KMS/SigningKeyArn}}"
 
 # Resources:
 #   BackendAsyncCredentialApi:


### PR DESCRIPTION
DCMAW-8264

### What changed
Add request validation to check Authorization request header in the asyncCredential lambda.

### Why did it change
Implements this design: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3917447301/Strategic+App+%7C+DCMAW-7690+%7C+Implementing+Client+Credentials+Grant+Flow+and+Asynchronous+CRI+credential+requests?search_id=c82aefcc-ef51-49e6-92d2-46ba3ade362d as part of the OAuth2.0 Client Credential Grant flow.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
