### PR TITLE
DCMAW-8264: Create push to main GHA

### DIFF
--- a/.github/workflows/async-credential-push-to-main.yml
+++ b/.github/workflows/async-credential-push-to-main.yml
@@ -1,0 +1,48 @@
+name: Async-credential Push to Main
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "./src/**"
+      - ".github/workflows/async-credential-push-to-main.yml"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sonar-scan:
+    name: Sonar main branch scan
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: src
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      # Generate test coverage report for Sonar main branch analysis
+      - name: Run Tests
+        run: npm run test
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
DCMAW-8264
​
### What changed
Adds a GHA workflow when there is a push to the main branch. There is branch protection enabled ensuring that only Pull Requests can update the main branch - i.e. this workflow will only run on result of merging a Pull Request.

### Why did it change
To run a main branch Sonar scan.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here]