### PR TITLE
DCMAW-8264: Implement request body validation in credential lambda

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -580,6 +580,36 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("Given govuk_signin_journey_id is missing", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+          }),
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description:
+              "Missing govuk_signin_journey_id in request body",
+          }),
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -522,6 +522,34 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("Given client_id is missing", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+          }),
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description: "Missing client_id in request body",
+          }),
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -619,6 +619,12 @@ describe("Async Credential", () => {
 
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockGovukSigninJourneyId",
+          }),
         });
 
         const result: APIGatewayProxyResult = await lambdaHandler(
@@ -645,6 +651,12 @@ describe("Async Credential", () => {
 
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockGovukSigninJourneyId",
+          }),
         });
 
         const result = await lambdaHandler(event, dependencies);
@@ -666,6 +678,12 @@ describe("Async Credential", () => {
       it("Returns 400 Bad Request response", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockGovukSigninJourneyId",
+          }),
         });
         dependencies.clientCredentialsService = () =>
           new MockFailingClientCredentialsServiceGetClientCredentialsById();
@@ -689,6 +707,12 @@ describe("Async Credential", () => {
       it("Returns a 400 Bad request response", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockJwtInvalidAud}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockGovukSigninJourneyId",
+          }),
         });
         dependencies.clientCredentialsService = () =>
           new MockPassingClientCredentialsService();

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -448,7 +448,7 @@ describe("Async Credential", () => {
 
   describe("Request body validation", () => {
     describe("Given body is missing", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
         });
@@ -464,7 +464,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description: "Missing request body",
           }),
         });
@@ -472,7 +472,7 @@ describe("Async Credential", () => {
     });
 
     describe("Given state is missing", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
           body: JSON.stringify({}),
@@ -489,7 +489,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description: "Missing state in request body",
           }),
         });
@@ -497,7 +497,7 @@ describe("Async Credential", () => {
     });
 
     describe("Given sub is missing", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
           body: JSON.stringify({
@@ -516,7 +516,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description: "Missing sub in request body",
           }),
         });
@@ -524,7 +524,7 @@ describe("Async Credential", () => {
     });
 
     describe("Given client_id is missing", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
           body: JSON.stringify({
@@ -544,7 +544,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description: "Missing client_id in request body",
           }),
         });
@@ -552,7 +552,7 @@ describe("Async Credential", () => {
     });
 
     describe("Given client_id is invalid", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
           body: JSON.stringify({
@@ -573,7 +573,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description:
               "client_id in request body does not match client_id in access token",
           }),
@@ -582,7 +582,7 @@ describe("Async Credential", () => {
     });
 
     describe("Given govuk_signin_journey_id is missing", () => {
-      it("Returns 400 status code with invalid_request_body error", async () => {
+      it("Returns 400 status code with invalid_request error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
           body: JSON.stringify({
@@ -603,7 +603,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "invalid_request_body",
+            error: "invalid_request",
             error_description:
               "Missing govuk_signin_journey_id in request body",
           }),

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -446,6 +446,57 @@ describe("Async Credential", () => {
     });
   });
 
+  describe("Request body validation", () => {
+    describe("Given body is missing", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description: "Missing request body",
+          }),
+        });
+      });
+    });
+
+    describe("Given state is missing", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({}),
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description: "Missing state in request body",
+          }),
+        });
+      });
+    });
+  });
+
   describe("JWT signature verification", () => {
     describe("Given that the JWT signature verification fails", () => {
       it("Returns 401 Unauthorized", async () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -495,6 +495,33 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("Given sub is missing", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+          }),
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description: "Missing sub in request body",
+          }),
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -550,6 +550,36 @@ describe("Async Credential", () => {
         });
       });
     });
+
+    describe("Given client_id is invalid", () => {
+      it("Returns 400 status code with invalid_request_body error", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockInvalidClientId",
+          }),
+        });
+
+        dependencies.tokenService = () => new MockTokenSeviceValidSignature();
+
+        const result: APIGatewayProxyResult = await lambdaHandler(
+          event,
+          dependencies,
+        );
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request_body",
+            error_description:
+              "client_id in request body does not match client_id in access token",
+          }),
+        });
+      });
+    });
   });
 
   describe("JWT signature verification", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -58,6 +58,23 @@ export async function lambdaHandler(
     });
   }
 
+  const requestBody = event.body;
+
+  if (!requestBody) {
+    return badRequestResponse({
+      error: "invalid_request_body",
+      errorDescription: "Missing request body",
+    });
+  }
+  const requestBodyValidationResponse = requestBodyValidator(requestBody);
+
+  if (requestBodyValidationResponse.isError) {
+    return badRequestResponse({
+      error: "invalid_request_body",
+      errorDescription: jwtClaimValidationResponse.value as string,
+    });
+  }
+
   const result = await tokenService.verifyTokenSignature(keyId, encodedJwt);
 
   if (result.isLog) {
@@ -168,6 +185,15 @@ const jwtClaimValidator = (
 
   if (!jwtPayload.aud) {
     return errorResponse("Missing aud claim");
+  }
+
+  return successResponse(null);
+};
+
+const requestBodyValidator = (body: string): ErrorOrSuccess<null> => {
+  const parsedBody = JSON.parse(body);
+  if (!parsedBody.state) {
+    return errorResponse("Missing state in request body");
   }
 
   return successResponse(null);

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -200,6 +200,10 @@ const requestBodyValidator = (body: string): ErrorOrSuccess<null> => {
     return errorResponse("Missing sub in request body");
   }
 
+  if (!parsedBody.client_id) {
+    return errorResponse("Missing client_id in request body");
+  }
+
   return successResponse(null);
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -66,7 +66,11 @@ export async function lambdaHandler(
       errorDescription: "Missing request body",
     });
   }
-  const requestBodyValidationResponse = requestBodyValidator(requestBody);
+
+  const requestBodyValidationResponse = requestBodyValidator(
+    requestBody,
+    jwtPayload.client_id,
+  );
 
   if (requestBodyValidationResponse.isError) {
     return badRequestResponse({
@@ -190,7 +194,10 @@ const jwtClaimValidator = (
   return successResponse(null);
 };
 
-const requestBodyValidator = (body: string): ErrorOrSuccess<null> => {
+const requestBodyValidator = (
+  body: string,
+  jwtClientId: string,
+): ErrorOrSuccess<null> => {
   const parsedBody = JSON.parse(body);
   if (!parsedBody.state) {
     return errorResponse("Missing state in request body");
@@ -202,6 +209,12 @@ const requestBodyValidator = (body: string): ErrorOrSuccess<null> => {
 
   if (!parsedBody.client_id) {
     return errorResponse("Missing client_id in request body");
+  }
+
+  if (parsedBody.client_id !== jwtClientId) {
+    return errorResponse(
+      "client_id in request body does not match client_id in access token",
+    );
   }
 
   return successResponse(null);

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -62,7 +62,7 @@ export async function lambdaHandler(
 
   if (!requestBody) {
     return badRequestResponse({
-      error: "invalid_request_body",
+      error: "invalid_request",
       errorDescription: "Missing request body",
     });
   }
@@ -74,7 +74,7 @@ export async function lambdaHandler(
 
   if (requestBodyValidationResponse.isError) {
     return badRequestResponse({
-      error: "invalid_request_body",
+      error: "invalid_request",
       errorDescription: requestBodyValidationResponse.value as string,
     });
   }

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -217,6 +217,10 @@ const requestBodyValidator = (
     );
   }
 
+  if (!parsedBody["govuk_signin_journey_id"]) {
+    return errorResponse("Missing govuk_signin_journey_id in request body");
+  }
+
   return successResponse(null);
 };
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -71,7 +71,7 @@ export async function lambdaHandler(
   if (requestBodyValidationResponse.isError) {
     return badRequestResponse({
       error: "invalid_request_body",
-      errorDescription: jwtClaimValidationResponse.value as string,
+      errorDescription: requestBodyValidationResponse.value as string,
     });
   }
 
@@ -194,6 +194,10 @@ const requestBodyValidator = (body: string): ErrorOrSuccess<null> => {
   const parsedBody = JSON.parse(body);
   if (!parsedBody.state) {
     return errorResponse("Missing state in request body");
+  }
+
+  if (!parsedBody.sub) {
+    return errorResponse("Missing sub in request body");
   }
 
   return successResponse(null);


### PR DESCRIPTION
### What changed
Add request body validation in Async Credential lambda

### Why did it change
Implements [this design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3917447301/Strategic+App+%7C+DCMAW-7690+%7C+Implementing+Client+Credentials+Grant+Flow+and+Asynchronous+CRI+credential+requests?search_id=c82aefcc-ef51-49e6-92d2-46ba3ade362d) as part of the OAuth2.0 Client Credential Grant flow.

### Body validation progress

We have validated the following in this PR:
- `state`
- `sub`
- `client_id`
- `govuk_signin_journey_id`

The following have not yet been validated and will be in the next PR:
- `redirect_uri`


### Ticket
DCMAW-8264

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
