### PR TITLE
DCMAW-8264: WIP - Add validation to check request redirect_uri and registered redirect_uri

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -812,16 +812,22 @@ class MockTokenSeviceValidSignature implements IVerifyTokenSignature {
 class MockFailingClientCredentialsServiceGetClientCredentialsById
   implements IClientCredentialsService
 {
+  validateTokenRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
+  validateCredentialRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
     return errorResponse("No credentials found");
-  }
-  validate(): ErrorOrSuccess<null> {
-    return errorResponse("invalid credentials");
   }
 }
 
 class MockPassingClientCredentialsService implements IClientCredentialsService {
-  validate() {
+  validateTokenRequest() {
+    return successResponse(null);
+  }
+  validateCredentialRequest() {
     return successResponse(null);
   }
   getClientCredentialsById() {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -647,35 +647,35 @@ describe("Async Credential", () => {
     });
   });
 
-  // describe("Request body validation - using Client Credentials", () => {
-  //   describe("Given redirect_uri is present and does not match the registered redirect_uri value", () => {
-  //     it("Returns a 400 Bad Request response", async () => {
-  //       const event = buildRequest({
-  //         headers: { Authorization: `Bearer ${mockValidJwt}` },
-  //         body: JSON.stringify({
-  //           state: "mockState",
-  //           sub: "mockSub",
-  //           client_id: "mockClientId",
-  //           govuk_signin_journey_id: "mockGovukSigninJourneyId",
-  //           redirect_uri: "mockInvalidRedirectUri",
-  //         }),
-  //       });
-  //       dependencies.clientCredentialsService = () =>
-  //         new MockPassingClientCredentialsService();
+  describe("Request body validation - using Client Credentials", () => {
+    describe("Given redirect_uri is present and does not match the registered redirect_uri value", () => {
+      it("Returns a 400 Bad Request response", async () => {
+        const event = buildRequest({
+          headers: { Authorization: `Bearer ${mockValidJwt}` },
+          body: JSON.stringify({
+            state: "mockState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockGovukSigninJourneyId",
+            redirect_uri: "https://mockUnregisteredRedirectUri.com",
+          }),
+        });
+        dependencies.clientCredentialsService = () =>
+          new MockPassingClientCredentialsService();
 
-  //       const result = await lambdaHandler(event, dependencies);
+        const result = await lambdaHandler(event, dependencies);
 
-  //       expect(result).toStrictEqual({
-  //         headers: { "Content-Type": "application/json" },
-  //         statusCode: 400,
-  //         body: JSON.stringify({
-  //           error: "invalid_request",
-  //           error_description: "Unregistered redirect_uri",
-  //         }),
-  //       });
-  //     });
-  //   });
-  // });
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 400,
+          body: JSON.stringify({
+            error: "invalid_request",
+            error_description: "Unregistered redirect_uri",
+          }),
+        });
+      });
+    });
+  });
 
   describe("JWT signature verification", () => {
     describe("Given that the JWT signature verification fails", () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -647,6 +647,36 @@ describe("Async Credential", () => {
     });
   });
 
+  // describe("Request body validation - using Client Credentials", () => {
+  //   describe("Given redirect_uri is present and does not match the registered redirect_uri value", () => {
+  //     it("Returns a 400 Bad Request response", async () => {
+  //       const event = buildRequest({
+  //         headers: { Authorization: `Bearer ${mockValidJwt}` },
+  //         body: JSON.stringify({
+  //           state: "mockState",
+  //           sub: "mockSub",
+  //           client_id: "mockClientId",
+  //           govuk_signin_journey_id: "mockGovukSigninJourneyId",
+  //           redirect_uri: "mockInvalidRedirectUri",
+  //         }),
+  //       });
+  //       dependencies.clientCredentialsService = () =>
+  //         new MockPassingClientCredentialsService();
+
+  //       const result = await lambdaHandler(event, dependencies);
+
+  //       expect(result).toStrictEqual({
+  //         headers: { "Content-Type": "application/json" },
+  //         statusCode: 400,
+  //         body: JSON.stringify({
+  //           error: "invalid_request",
+  //           error_description: "Unregistered redirect_uri",
+  //         }),
+  //       });
+  //     });
+  //   });
+  // });
+
   describe("JWT signature verification", () => {
     describe("Given that the JWT signature verification fails", () => {
       it("Returns 401 Unauthorized", async () => {

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -648,7 +648,7 @@ describe("Async Credential", () => {
   });
 
   describe("Request body validation - using Client Credentials", () => {
-    describe("Given request body validation fails", () => {
+    describe("Given redirect_uri is present and the request body validation fails", () => {
       it("Returns a 400 Bad Request response", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -129,10 +129,10 @@ export async function lambdaHandler(
       clientCredentials,
       JSON.parse(requestBody),
     );
-  if (validateClientCredentialsResponse.value != null) {
+  if (validateClientCredentialsResponse.isError) {
     return badRequestResponse({
       error: "invalid_request",
-      errorDescription: validateClientCredentialsResponse.value,
+      errorDescription: validateClientCredentialsResponse.value as string,
     });
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -124,15 +124,15 @@ export async function lambdaHandler(
     clientCredentialResponse.value as IClientCredentials;
 
   // TODO - create separate method to validate async credential request
-  const validateClientCredentialsResponse =
+  const validateClientCredentialsResult =
     clientCredentialsService.validateCredentialRequest(
       clientCredentials,
       JSON.parse(requestBody),
     );
-  if (validateClientCredentialsResponse.isError) {
+  if (validateClientCredentialsResult.isError) {
     return badRequestResponse({
       error: "invalid_request",
-      errorDescription: validateClientCredentialsResponse.value as string,
+      errorDescription: validateClientCredentialsResult.value as string,
     });
   }
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -67,8 +67,18 @@ export async function lambdaHandler(
     });
   }
 
+  let parsedRequestBody: IRequestBody;
+  try {
+    parsedRequestBody = JSON.parse(requestBody);
+  } catch (error) {
+    return badRequestResponse({
+      error: "invalid_request",
+      errorDescription: "Invalid JSON in request body",
+    });
+  }
+
   const requestBodyValidationResponse = requestBodyValidator(
-    requestBody,
+    parsedRequestBody,
     jwtPayload.client_id,
   );
 
@@ -113,6 +123,7 @@ export async function lambdaHandler(
   const clientCredentials =
     clientCredentialResponse.value as IClientCredentials;
 
+  // TODO - create separate method to validate async credential request
   const validateClientCredentialsResponse = clientCredentialsService.validate(
     clientCredentials,
     JSON.parse(requestBody),
@@ -121,16 +132,6 @@ export async function lambdaHandler(
     return badRequestResponse({
       error: "invalid_request",
       errorDescription: validateClientCredentialsResponse.value,
-    });
-  }
-
-  let parsedRequestBody: IClientCredentials;
-  try {
-    parsedRequestBody = JSON.parse(requestBody);
-  } catch (error) {
-    return badRequestResponse({
-      error: "invalid_request",
-      errorDescription: "Invalid JSON in request body",
     });
   }
 
@@ -229,35 +230,34 @@ const jwtClaimValidator = (
 };
 
 const requestBodyValidator = (
-  body: string,
+  requestBody: IRequestBody,
   jwtClientId: string,
 ): ErrorOrSuccess<null> => {
-  const parsedBody = JSON.parse(body);
-  if (!parsedBody.state) {
+  if (!requestBody.state) {
     return errorResponse("Missing state in request body");
   }
 
-  if (!parsedBody.sub) {
+  if (!requestBody.sub) {
     return errorResponse("Missing sub in request body");
   }
 
-  if (!parsedBody.client_id) {
+  if (!requestBody.client_id) {
     return errorResponse("Missing client_id in request body");
   }
 
-  if (parsedBody.client_id !== jwtClientId) {
+  if (requestBody.client_id !== jwtClientId) {
     return errorResponse(
       "client_id in request body does not match client_id in access token",
     );
   }
 
-  if (!parsedBody["govuk_signin_journey_id"]) {
+  if (!requestBody["govuk_signin_journey_id"]) {
     return errorResponse("Missing govuk_signin_journey_id in request body");
   }
 
-  if (parsedBody.redirect_uri) {
+  if (requestBody.redirect_uri) {
     try {
-      new URL(parsedBody.redirect_uri);
+      new URL(requestBody.redirect_uri);
     } catch (error) {
       return errorResponse("Invalid redirect_uri");
     }
@@ -306,6 +306,14 @@ const serverError500Responses: APIGatewayProxyResult = {
     error_description: "Server Error",
   }),
 };
+
+interface IRequestBody {
+  sub: string;
+  govuk_signin_journey_id: string;
+  client_id: string;
+  state: string;
+  redirect_uri?: string;
+}
 
 export interface Dependencies {
   tokenService: () => TokenService;

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -123,7 +123,6 @@ export async function lambdaHandler(
   const clientCredentials =
     clientCredentialResponse.value as IClientCredentials;
 
-  // TODO - create separate method to validate async credential request
   const validateClientCredentialsResult =
     clientCredentialsService.validateCredentialRequest(
       clientCredentials,

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -135,15 +135,6 @@ export async function lambdaHandler(
     });
   }
 
-  if (parsedRequestBody.redirect_uri) {
-    if (parsedRequestBody.redirect_uri !== clientCredentials.redirect_uri) {
-      return badRequestResponse({
-        error: "invalid_request",
-        errorDescription: "Unregistered redirect_uri",
-      });
-    }
-  }
-
   // Validate aud claim matches the ISSUER in client credential array
   if (jwtPayload.aud !== clientCredentials.issuer) {
     return badRequestResponse({

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -124,10 +124,11 @@ export async function lambdaHandler(
     clientCredentialResponse.value as IClientCredentials;
 
   // TODO - create separate method to validate async credential request
-  const validateClientCredentialsResponse = clientCredentialsService.validate(
-    clientCredentials,
-    JSON.parse(requestBody),
-  );
+  const validateClientCredentialsResponse =
+    clientCredentialsService.validateCredentialRequest(
+      clientCredentials,
+      JSON.parse(requestBody),
+    );
   if (validateClientCredentialsResponse.value != null) {
     return badRequestResponse({
       error: "invalid_request",

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -123,16 +123,18 @@ export async function lambdaHandler(
   const clientCredentials =
     clientCredentialResponse.value as IClientCredentials;
 
-  const validateClientCredentialsResult =
-    clientCredentialsService.validateCredentialRequest(
-      clientCredentials,
-      parsedRequestBody,
-    );
-  if (validateClientCredentialsResult.isError) {
-    return badRequestResponse({
-      error: "invalid_request",
-      errorDescription: validateClientCredentialsResult.value as string,
-    });
+  if (parsedRequestBody.redirect_uri) {
+    const validateClientCredentialsResult =
+      clientCredentialsService.validateCredentialRequest(
+        clientCredentials,
+        parsedRequestBody,
+      );
+    if (validateClientCredentialsResult.isError) {
+      return badRequestResponse({
+        error: "invalid_request",
+        errorDescription: validateClientCredentialsResult.value as string,
+      });
+    }
   }
 
   // Validate aud claim matches the ISSUER in client credential array

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -3,7 +3,6 @@ import { validOrThrow } from "../config";
 import {
   ClientCredentialsService,
   IClientCredentials,
-  IRegisteredClientCredentials,
 } from "../services/clientCredentialsService/clientCredentialsService";
 import { IGetClientCredentials } from "../asyncToken/ssmService/ssmService";
 import { TokenService } from "./TokenService/tokenService";
@@ -112,7 +111,7 @@ export async function lambdaHandler(
   }
 
   const clientCredentials =
-    clientCredentialResponse.value as IRegisteredClientCredentials;
+    clientCredentialResponse.value as IClientCredentials;
 
   const validateClientCredentialsResponse = clientCredentialsService.validate(
     clientCredentials,

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -67,7 +67,7 @@ export async function lambdaHandler(
     });
   }
 
-  let parsedRequestBody: IRequestBody;
+  let parsedRequestBody: ICredentialRequestBody;
   try {
     parsedRequestBody = JSON.parse(requestBody);
   } catch (error) {
@@ -126,7 +126,7 @@ export async function lambdaHandler(
   const validateClientCredentialsResult =
     clientCredentialsService.validateCredentialRequest(
       clientCredentials,
-      JSON.parse(requestBody),
+      parsedRequestBody,
     );
   if (validateClientCredentialsResult.isError) {
     return badRequestResponse({
@@ -230,7 +230,7 @@ const jwtClaimValidator = (
 };
 
 const requestBodyValidator = (
-  requestBody: IRequestBody,
+  requestBody: ICredentialRequestBody,
   jwtClientId: string,
 ): ErrorOrSuccess<null> => {
   if (!requestBody.state) {
@@ -307,7 +307,7 @@ const serverError500Responses: APIGatewayProxyResult = {
   }),
 };
 
-interface IRequestBody {
+export interface ICredentialRequestBody {
   sub: string;
   govuk_signin_journey_id: string;
   client_id: string;

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -323,6 +323,12 @@ class MockFailingSsmService implements IGetClientCredentials {
 }
 
 class MockPassingClientCredentialsService implements IClientCredentialsService {
+  validateTokenRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
+  validateCredentialRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
     return successResponse({
       client_id: "mockClientId",
@@ -331,25 +337,31 @@ class MockPassingClientCredentialsService implements IClientCredentialsService {
       hashed_client_secret: "mockHashedClientSecret",
     });
   }
-  validate(): ErrorOrSuccess<null> {
-    return successResponse(null);
-  }
 }
 
 class MockFailingClientCredentialsServiceGetClientCredentialsById
   implements IClientCredentialsService
 {
+  validateTokenRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
+  validateCredentialRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
     return errorResponse("Client credentials not recognised");
-  }
-  validate(): ErrorOrSuccess<null> {
-    throw Error("This should not be used");
   }
 }
 
 class MockFailingClientCredentialsServiceValidation
   implements IClientCredentialsService
 {
+  validateTokenRequest(): ErrorOrSuccess<null> {
+    return errorResponse("Client secrets not valid");
+  }
+  validateCredentialRequest(): ErrorOrSuccess<null> {
+    return successResponse(null);
+  }
   getClientCredentialsById() {
     return successResponse({
       client_id: "mockClientId",
@@ -357,9 +369,6 @@ class MockFailingClientCredentialsServiceValidation
       salt: "mockSalt",
       hashed_client_secret: "mockHashedClientSecret",
     });
-  }
-  validate(): ErrorOrSuccess<null> {
-    return errorResponse("Client secrets not valid");
   }
 }
 

--- a/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.ts
@@ -89,10 +89,11 @@ export async function lambdaHandlerConstructor(
   const storedCredentials =
     clientCredentialsByIdResponse.value as IClientCredentials;
 
-  const isValidClientCredentialsResponse = clientCredentialsService.validate(
-    storedCredentials,
-    suppliedCredentials,
-  );
+  const isValidClientCredentialsResponse =
+    clientCredentialsService.validateTokenRequest(
+      storedCredentials,
+      suppliedCredentials,
+    );
   if (isValidClientCredentialsResponse.isError) {
     logger.log("INVALID_REQUEST", {
       errorMessage: isValidClientCredentialsResponse.value,

--- a/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.ts
@@ -9,6 +9,7 @@ import {
   ClientCredentialsService,
   IClientCredentials,
   IClientCredentialsService,
+  IRegisteredClientCredentials,
 } from "../services/clientCredentialsService/clientCredentialsService";
 import {
   IProcessRequest,
@@ -87,7 +88,7 @@ export async function lambdaHandlerConstructor(
   }
 
   const storedCredentials =
-    clientCredentialsByIdResponse.value as IClientCredentials;
+    clientCredentialsByIdResponse.value as IRegisteredClientCredentials;
 
   const isValidClientCredentialsResponse = clientCredentialsService.validate(
     storedCredentials,

--- a/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.ts
@@ -9,7 +9,6 @@ import {
   ClientCredentialsService,
   IClientCredentials,
   IClientCredentialsService,
-  IRegisteredClientCredentials,
 } from "../services/clientCredentialsService/clientCredentialsService";
 import {
   IProcessRequest,
@@ -88,7 +87,7 @@ export async function lambdaHandlerConstructor(
   }
 
   const storedCredentials =
-    clientCredentialsByIdResponse.value as IRegisteredClientCredentials;
+    clientCredentialsByIdResponse.value as IClientCredentials;
 
   const isValidClientCredentialsResponse = clientCredentialsService.validate(
     storedCredentials,

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -1,3 +1,4 @@
+import { ICredentialRequestBody } from "../../asyncCredential/asyncCredentialHandler";
 import { IDecodedClientCredentials } from "../../types/clientCredentials";
 import {
   ClientCredentialsService,
@@ -6,15 +7,22 @@ import {
 
 describe("Client Credentials Service", () => {
   let clientCredentialsService: ClientCredentialsService;
-  let mockSuppliedClientCredentials: IDecodedClientCredentials;
+  let mockTokenSuppliedClientCredentials: IDecodedClientCredentials;
+  let mockCredentialSuppliedClientCredentials: ICredentialRequestBody;
   let mockStoredClientCredentialsArray: IClientCredentials[];
   let mockStoredClientCredentials: IClientCredentials;
 
   beforeEach(() => {
     clientCredentialsService = new ClientCredentialsService();
-    mockSuppliedClientCredentials = {
+    mockTokenSuppliedClientCredentials = {
       clientId: "mockClientId",
       clientSecret: "mockClientSecret",
+    };
+    mockCredentialSuppliedClientCredentials = {
+      sub: "mockSub",
+      govuk_signin_journey_id: "mockGovukSigninJourneyId",
+      client_id: "mockClientId",
+      state: "mockState",
     };
     mockStoredClientCredentialsArray = [
       {
@@ -47,14 +55,14 @@ describe("Client Credentials Service", () => {
   describe("Validate token request credentials", () => {
     describe("Given the supplied hashed client secret does not match the stored hashed client secret", () => {
       it("Returns false", async () => {
-        mockSuppliedClientCredentials = {
+        mockTokenSuppliedClientCredentials = {
           clientId: "mockClientId",
           clientSecret: "mockInvalidClientSecret",
         };
 
         const result = clientCredentialsService.validateTokenRequest(
           mockStoredClientCredentials,
-          mockSuppliedClientCredentials,
+          mockTokenSuppliedClientCredentials,
         );
 
         expect(result.isError).toBe(true);
@@ -71,7 +79,7 @@ describe("Client Credentials Service", () => {
 
           const result = clientCredentialsService.validateTokenRequest(
             mockStoredClientCredentials,
-            mockSuppliedClientCredentials,
+            mockTokenSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
@@ -85,7 +93,7 @@ describe("Client Credentials Service", () => {
 
           const result = clientCredentialsService.validateTokenRequest(
             mockStoredClientCredentials,
-            mockSuppliedClientCredentials,
+            mockTokenSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
@@ -96,14 +104,14 @@ describe("Client Credentials Service", () => {
 
     describe("Given the supplied credentials match the stored credentials", () => {
       it("Returns true", async () => {
-        mockSuppliedClientCredentials = {
+        mockTokenSuppliedClientCredentials = {
           clientId: "mockAnotherClientId",
           clientSecret: "mockClientSecret",
         };
 
         const result = clientCredentialsService.validateTokenRequest(
           mockStoredClientCredentials,
-          mockSuppliedClientCredentials,
+          mockTokenSuppliedClientCredentials,
         );
 
         expect(result.isError).toBe(false);
@@ -115,14 +123,14 @@ describe("Client Credentials Service", () => {
   describe("Get client credentials by ID", () => {
     describe("Given the supplied credential clientId is not present in the stored credentials array", () => {
       it("Returns an error response", async () => {
-        mockSuppliedClientCredentials = {
+        mockTokenSuppliedClientCredentials = {
           clientId: "mockInvalidClientId",
           clientSecret: "mockClientSecret",
         };
 
         const result = clientCredentialsService.getClientCredentialsById(
           mockStoredClientCredentialsArray,
-          mockSuppliedClientCredentials.clientId,
+          mockTokenSuppliedClientCredentials.clientId,
         );
 
         expect(result.isError).toBe(true);
@@ -132,7 +140,7 @@ describe("Client Credentials Service", () => {
 
     describe("Given the supplied credential clientId is present in the stored credentials array", () => {
       it("Returns client credentials", async () => {
-        mockSuppliedClientCredentials = {
+        mockTokenSuppliedClientCredentials = {
           clientId: "mockClientId",
           clientSecret: "mockClientSecret",
         };
@@ -147,7 +155,7 @@ describe("Client Credentials Service", () => {
 
         const result = clientCredentialsService.getClientCredentialsById(
           mockStoredClientCredentialsArray,
-          mockSuppliedClientCredentials.clientId,
+          mockTokenSuppliedClientCredentials.clientId,
         );
         expect(result.isError).toBe(false);
         expect(result.value).toEqual(expectedClientCredentials);
@@ -163,7 +171,7 @@ describe("Client Credentials Service", () => {
 
           const result = clientCredentialsService.validateCredentialRequest(
             mockStoredClientCredentials,
-            mockSuppliedClientCredentials,
+            mockCredentialSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
@@ -177,7 +185,7 @@ describe("Client Credentials Service", () => {
 
           const result = clientCredentialsService.validateCredentialRequest(
             mockStoredClientCredentials,
-            mockSuppliedClientCredentials,
+            mockCredentialSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -61,6 +61,20 @@ describe("Client Credentials Service", () => {
       });
     });
 
+    // describe("redirect_uri validation", () => {
+    //   describe("Given redirect_uri is not present", () => {
+    //     it("Returns a log", () => {
+    //       const result = clientCredentialsService.validate(
+    //         mockStoredClientCredentials,
+    //         mockSuppliedClientCredentials,
+    //       );
+
+    //       expect(result.isError).toBe(true);
+    //       expect(result.value).toBe("Missing redirect_uri");
+    //     });
+    //   });
+    // });
+
     describe("Given the supplied credentials match the stored credentials", () => {
       it("Returns true", async () => {
         mockSuppliedClientCredentials = {

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -44,7 +44,7 @@ describe("Client Credentials Service", () => {
     };
   });
 
-  describe("Validate", () => {
+  describe("Validate token request credentials", () => {
     describe("Given the supplied hashed client secret does not match the stored hashed client secret", () => {
       it("Returns false", async () => {
         mockSuppliedClientCredentials = {
@@ -52,7 +52,7 @@ describe("Client Credentials Service", () => {
           clientSecret: "mockInvalidClientSecret",
         };
 
-        const result = clientCredentialsService.validate(
+        const result = clientCredentialsService.validateTokenRequest(
           mockStoredClientCredentials,
           mockSuppliedClientCredentials,
         );
@@ -69,7 +69,7 @@ describe("Client Credentials Service", () => {
         it("Returns a log", () => {
           mockStoredClientCredentials.redirect_uri = "";
 
-          const result = clientCredentialsService.validate(
+          const result = clientCredentialsService.validateTokenRequest(
             mockStoredClientCredentials,
             mockSuppliedClientCredentials,
           );
@@ -83,7 +83,7 @@ describe("Client Credentials Service", () => {
         it("Returns a log", () => {
           mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
 
-          const result = clientCredentialsService.validate(
+          const result = clientCredentialsService.validateTokenRequest(
             mockStoredClientCredentials,
             mockSuppliedClientCredentials,
           );
@@ -101,7 +101,7 @@ describe("Client Credentials Service", () => {
           clientSecret: "mockClientSecret",
         };
 
-        const result = clientCredentialsService.validate(
+        const result = clientCredentialsService.validateTokenRequest(
           mockStoredClientCredentials,
           mockSuppliedClientCredentials,
         );
@@ -151,6 +151,38 @@ describe("Client Credentials Service", () => {
         );
         expect(result.isError).toBe(false);
         expect(result.value).toEqual(expectedClientCredentials);
+      });
+    });
+  });
+
+  describe("Validate credential request credentials", () => {
+    describe("redirect_uri validation", () => {
+      describe("Given redirect_uri is not present", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "";
+
+          const result = clientCredentialsService.validateCredentialRequest(
+            mockStoredClientCredentials,
+            mockSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Missing redirect_uri");
+        });
+      });
+
+      describe("Given redirect_uri is not a valid URL", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
+
+          const result = clientCredentialsService.validateCredentialRequest(
+            mockStoredClientCredentials,
+            mockSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Invalid redirect_uri");
+        });
       });
     });
   });

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -120,6 +120,53 @@ describe("Client Credentials Service", () => {
     });
   });
 
+  describe("Validate credential request credentials", () => {
+    describe("redirect_uri validation", () => {
+      describe("Given stored redirect_uri is not present", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "";
+
+          const result = clientCredentialsService.validateCredentialRequest(
+            mockStoredClientCredentials,
+            mockCredentialSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Missing redirect_uri");
+        });
+      });
+
+      describe("Given stored redirect_uri is not a valid URL", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
+
+          const result = clientCredentialsService.validateCredentialRequest(
+            mockStoredClientCredentials,
+            mockCredentialSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Invalid redirect_uri");
+        });
+      });
+
+      describe("Given supplied redirect_uri does not match stored redirect_uri", () => {
+        it("Returns a log", () => {
+          mockCredentialSuppliedClientCredentials.redirect_uri =
+            "https://mockInvalidRedirectUri.com";
+
+          const result = clientCredentialsService.validateCredentialRequest(
+            mockStoredClientCredentials,
+            mockCredentialSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Unregistered redirect_uri");
+        });
+      });
+    });
+  });
+
   describe("Get client credentials by ID", () => {
     describe("Given the supplied credential clientId is not present in the stored credentials array", () => {
       it("Returns an error response", async () => {
@@ -159,38 +206,6 @@ describe("Client Credentials Service", () => {
         );
         expect(result.isError).toBe(false);
         expect(result.value).toEqual(expectedClientCredentials);
-      });
-    });
-  });
-
-  describe("Validate credential request credentials", () => {
-    describe("redirect_uri validation", () => {
-      describe("Given redirect_uri is not present", () => {
-        it("Returns a log", () => {
-          mockStoredClientCredentials.redirect_uri = "";
-
-          const result = clientCredentialsService.validateCredentialRequest(
-            mockStoredClientCredentials,
-            mockCredentialSuppliedClientCredentials,
-          );
-
-          expect(result.isError).toBe(true);
-          expect(result.value).toBe("Missing redirect_uri");
-        });
-      });
-
-      describe("Given redirect_uri is not a valid URL", () => {
-        it("Returns a log", () => {
-          mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
-
-          const result = clientCredentialsService.validateCredentialRequest(
-            mockStoredClientCredentials,
-            mockCredentialSuppliedClientCredentials,
-          );
-
-          expect(result.isError).toBe(true);
-          expect(result.value).toBe("Invalid redirect_uri");
-        });
       });
     });
   });

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -78,6 +78,20 @@ describe("Client Credentials Service", () => {
           expect(result.value).toBe("Missing redirect_uri");
         });
       });
+
+      describe("Given redirect_uri is not a valid URL", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
+
+          const result = clientCredentialsService.validate(
+            mockStoredClientCredentials,
+            mockSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Invalid redirect_uri");
+        });
+      });
     });
 
     describe("Given the supplied credentials match the stored credentials", () => {

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -1,14 +1,14 @@
 import { IDecodedClientCredentials } from "../../types/clientCredentials";
 import {
   ClientCredentialsService,
-  IClientCredentials,
+  IRegisteredClientCredentials,
 } from "./clientCredentialsService";
 
 describe("Client Credentials Service", () => {
   let clientCredentialsService: ClientCredentialsService;
   let mockSuppliedClientCredentials: IDecodedClientCredentials;
-  let mockStoredClientCredentialsArray: IClientCredentials[];
-  let mockStoredClientCredentials: IClientCredentials;
+  let mockStoredClientCredentialsArray: IRegisteredClientCredentials[];
+  let mockStoredClientCredentials: IRegisteredClientCredentials;
 
   beforeEach(() => {
     clientCredentialsService = new ClientCredentialsService();
@@ -23,6 +23,7 @@ describe("Client Credentials Service", () => {
         salt: "0vjPs=djeEHP",
         hashed_client_secret:
           "964adf477e02f0fd3fac7fdd08655d1e70ba142f02c946e21e1e194f49a05379", // mockClientSecret hashing with above salt
+        redirect_uri: "https://mockRedirectUri.com",
       },
       {
         client_id: "mockAnotherClientId",
@@ -30,6 +31,7 @@ describe("Client Credentials Service", () => {
         salt: "0vjPs=djeEHP",
         hashed_client_secret:
           "964adf477e02f0fd3fac7fdd08655d1e70ba142f02c946e21e1e194f49a05379", // mockClientSecret hashing with above salt
+        redirect_uri: "https://mockRedirectUri.com",
       },
     ];
     mockStoredClientCredentials = {
@@ -38,6 +40,7 @@ describe("Client Credentials Service", () => {
       salt: "0vjPs=djeEHP",
       hashed_client_secret:
         "964adf477e02f0fd3fac7fdd08655d1e70ba142f02c946e21e1e194f49a05379", // mockClientSecret hashing with above salt
+      redirect_uri: "https://mockRedirectUri.com",
     };
   });
 
@@ -61,19 +64,21 @@ describe("Client Credentials Service", () => {
       });
     });
 
-    // describe("redirect_uri validation", () => {
-    //   describe("Given redirect_uri is not present", () => {
-    //     it("Returns a log", () => {
-    //       const result = clientCredentialsService.validate(
-    //         mockStoredClientCredentials,
-    //         mockSuppliedClientCredentials,
-    //       );
+    describe("redirect_uri validation", () => {
+      describe("Given redirect_uri is not present", () => {
+        it("Returns a log", () => {
+          mockStoredClientCredentials.redirect_uri = "";
 
-    //       expect(result.isError).toBe(true);
-    //       expect(result.value).toBe("Missing redirect_uri");
-    //     });
-    //   });
-    // });
+          const result = clientCredentialsService.validate(
+            mockStoredClientCredentials,
+            mockSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(true);
+          expect(result.value).toBe("Missing redirect_uri");
+        });
+      });
+    });
 
     describe("Given the supplied credentials match the stored credentials", () => {
       it("Returns true", async () => {
@@ -123,6 +128,7 @@ describe("Client Credentials Service", () => {
           salt: "0vjPs=djeEHP",
           hashed_client_secret:
             "964adf477e02f0fd3fac7fdd08655d1e70ba142f02c946e21e1e194f49a05379", // mockClientSecret hashing with above salt
+          redirect_uri: "https://mockRedirectUri.com",
         };
 
         const result = clientCredentialsService.getClientCredentialsById(

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -1,14 +1,14 @@
 import { IDecodedClientCredentials } from "../../types/clientCredentials";
 import {
   ClientCredentialsService,
-  IRegisteredClientCredentials,
+  IClientCredentials,
 } from "./clientCredentialsService";
 
 describe("Client Credentials Service", () => {
   let clientCredentialsService: ClientCredentialsService;
   let mockSuppliedClientCredentials: IDecodedClientCredentials;
-  let mockStoredClientCredentialsArray: IRegisteredClientCredentials[];
-  let mockStoredClientCredentials: IRegisteredClientCredentials;
+  let mockStoredClientCredentialsArray: IClientCredentials[];
+  let mockStoredClientCredentials: IClientCredentials;
 
   beforeEach(() => {
     clientCredentialsService = new ClientCredentialsService();

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -7,7 +7,7 @@ import {
 
 export class ClientCredentialsService implements IClientCredentialsService {
   validate = (
-    storedCredentials: IRegisteredClientCredentials,
+    storedCredentials: IClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ): ErrorOrSuccess<null> => {
     const { clientSecret: suppliedClientSecret } = suppliedCredentials;
@@ -58,7 +58,7 @@ const hashSecret = (secret: string, salt: string): string => {
 
 export interface IClientCredentialsService {
   validate: (
-    storedCredentials: IRegisteredClientCredentials,
+    storedCredentials: IClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ) => ErrorOrSuccess<null>;
 
@@ -74,14 +74,6 @@ export type IClientCredentials = {
   salt: string;
   hashed_client_secret: string;
   redirect_uri?: string;
-};
-
-export type IRegisteredClientCredentials = {
-  client_id: string;
-  issuer: string;
-  salt: string;
-  hashed_client_secret: string;
-  redirect_uri: string;
 };
 
 export interface IDecodedClientCredentials {

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -4,6 +4,7 @@ import {
   errorResponse,
   successResponse,
 } from "../../types/errorOrValue";
+import { ICredentialRequestBody } from "../../asyncCredential/asyncCredentialHandler";
 
 export class ClientCredentialsService implements IClientCredentialsService {
   validateTokenRequest = (
@@ -40,7 +41,7 @@ export class ClientCredentialsService implements IClientCredentialsService {
 
   validateCredentialRequest = (
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedClientCredentials,
+    suppliedCredentials: ICredentialRequestBody,
   ): ErrorOrSuccess<null> => {
     // eslint-disable-next-line
     const credentials = suppliedCredentials; // To be removed
@@ -85,7 +86,7 @@ export interface IClientCredentialsService {
 
   validateCredentialRequest: (
     storedCredentials: IClientCredentials,
-    suppliedCredentials: IDecodedClientCredentials,
+    suppliedCredentials: ICredentialRequestBody,
   ) => ErrorOrSuccess<null>;
 
   getClientCredentialsById: (

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -20,9 +20,11 @@ export class ClientCredentialsService implements IClientCredentialsService {
     const isValidClientSecret =
       hashedStoredClientSecret === hashedSuppliedClientSecret;
 
-    if (isValidClientSecret) return successResponse(null);
+    if (!isValidClientSecret) {
+      return errorResponse("Client secret not valid for the supplied clientId");
+    }
 
-    return errorResponse("Client secret not valid for the supplied clientId");
+    return successResponse(null);
   };
 
   getClientCredentialsById = (

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -7,7 +7,7 @@ import {
 
 export class ClientCredentialsService implements IClientCredentialsService {
   validate = (
-    storedCredentials: IClientCredentials,
+    storedCredentials: IRegisteredClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ): ErrorOrSuccess<null> => {
     const { clientSecret: suppliedClientSecret } = suppliedCredentials;
@@ -22,6 +22,10 @@ export class ClientCredentialsService implements IClientCredentialsService {
 
     if (!isValidClientSecret) {
       return errorResponse("Client secret not valid for the supplied clientId");
+    }
+
+    if (!storedCredentials.redirect_uri) {
+      return errorResponse("Missing redirect_uri");
     }
 
     return successResponse(null);
@@ -47,7 +51,7 @@ const hashSecret = (secret: string, salt: string): string => {
 
 export interface IClientCredentialsService {
   validate: (
-    storedCredentials: IClientCredentials,
+    storedCredentials: IRegisteredClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ) => ErrorOrSuccess<null>;
 
@@ -62,6 +66,14 @@ export type IClientCredentials = {
   issuer: string;
   salt: string;
   hashed_client_secret: string;
+};
+
+export type IRegisteredClientCredentials = {
+  client_id: string;
+  issuer: string;
+  salt: string;
+  hashed_client_secret: string;
+  redirect_uri: string;
 };
 
 export interface IDecodedClientCredentials {

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -6,7 +6,7 @@ import {
 } from "../../types/errorOrValue";
 
 export class ClientCredentialsService implements IClientCredentialsService {
-  validate = (
+  validateTokenRequest = (
     storedCredentials: IClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ): ErrorOrSuccess<null> => {
@@ -23,6 +23,27 @@ export class ClientCredentialsService implements IClientCredentialsService {
     if (!isValidClientSecret) {
       return errorResponse("Client secret not valid for the supplied clientId");
     }
+
+    const registeredRedirectUri = storedCredentials.redirect_uri;
+    if (!registeredRedirectUri) {
+      return errorResponse("Missing redirect_uri");
+    }
+
+    try {
+      new URL(registeredRedirectUri);
+    } catch (error) {
+      return errorResponse("Invalid redirect_uri");
+    }
+
+    return successResponse(null);
+  };
+
+  validateCredentialRequest = (
+    storedCredentials: IClientCredentials,
+    suppliedCredentials: IDecodedClientCredentials,
+  ): ErrorOrSuccess<null> => {
+    // eslint-disable-next-line
+    const credentials = suppliedCredentials; // To be removed
 
     const registeredRedirectUri = storedCredentials.redirect_uri;
     if (!registeredRedirectUri) {
@@ -57,7 +78,12 @@ const hashSecret = (secret: string, salt: string): string => {
 };
 
 export interface IClientCredentialsService {
-  validate: (
+  validateTokenRequest: (
+    storedCredentials: IClientCredentials,
+    suppliedCredentials: IDecodedClientCredentials,
+  ) => ErrorOrSuccess<null>;
+
+  validateCredentialRequest: (
     storedCredentials: IClientCredentials,
     suppliedCredentials: IDecodedClientCredentials,
   ) => ErrorOrSuccess<null>;

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -44,8 +44,6 @@ export class ClientCredentialsService implements IClientCredentialsService {
     suppliedCredentials: ICredentialRequestBody,
   ): ErrorOrSuccess<null> => {
     // eslint-disable-next-line
-    const credentials = suppliedCredentials; // To be removed
-
     const registeredRedirectUri = storedCredentials.redirect_uri;
     if (!registeredRedirectUri) {
       return errorResponse("Missing redirect_uri");
@@ -55,6 +53,10 @@ export class ClientCredentialsService implements IClientCredentialsService {
       new URL(registeredRedirectUri);
     } catch (error) {
       return errorResponse("Invalid redirect_uri");
+    }
+
+    if (suppliedCredentials.redirect_uri !== storedCredentials.redirect_uri) {
+      return errorResponse("Unregistered redirect_uri");
     }
 
     return successResponse(null);

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -24,8 +24,15 @@ export class ClientCredentialsService implements IClientCredentialsService {
       return errorResponse("Client secret not valid for the supplied clientId");
     }
 
-    if (!storedCredentials.redirect_uri) {
+    const registeredRedirectUri = storedCredentials.redirect_uri;
+    if (!registeredRedirectUri) {
       return errorResponse("Missing redirect_uri");
+    }
+
+    try {
+      new URL(registeredRedirectUri);
+    } catch (error) {
+      return errorResponse("Invalid redirect_uri");
     }
 
     return successResponse(null);

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -43,7 +43,6 @@ export class ClientCredentialsService implements IClientCredentialsService {
     storedCredentials: IClientCredentials,
     suppliedCredentials: ICredentialRequestBody,
   ): ErrorOrSuccess<null> => {
-    // eslint-disable-next-line
     const registeredRedirectUri = storedCredentials.redirect_uri;
     if (!registeredRedirectUri) {
       return errorResponse("Missing redirect_uri");

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -73,6 +73,7 @@ export type IClientCredentials = {
   issuer: string;
   salt: string;
   hashed_client_secret: string;
+  redirect_uri?: string;
 };
 
 export type IRegisteredClientCredentials = {


### PR DESCRIPTION
### What changed
- Add validation to check the stored/registered `redirect_uri` is valid when a request is made to the `/async/token` endpoint and the `/async/credential` endpoint.
- Update `validate()` method on `ClientCredentialsService` to validate the registered `redirect_uri` and update method name to reflect that the validation is being done on the `/async/token` endpoint request data
- Add method to the `ClientCredentialsService` to validate the supplied `redirect_uri` from the `/async/credential` request data


## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
