### PR TITLE
DCMAW-9561: Update NPM version bump scan to run Tuesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     directory: "src"
     schedule:
       interval: "weekly"
-      day: "thursday"
+      day: "tuesday"
       time: "03:00"
     open-pull-requests-limit: 5
     groups:


### PR DESCRIPTION
### What changed
Dependabot scans the npm packages once a week on Thursday morning at 03:00. This has now been updated to run on Tuesday at 03:00

### Why did it change
Running Tuesday morning allows us to see a free set of version bump PRs at the start of each sprint, rather than a random day in the middle of it.

### Ticket
DCMAW-9561. This change is just a part of the continious maintainence of this version-bump process, do not believe it requires a standalone ticket

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
