### PR TITLE
DCMAW-8264: Remove pull request ci badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ It follows the Client credentials grant flow from the OAuth2.0 Framework [see he
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mobile-id-check-async&metric=alert_status&token=2b3ffa4269d7a6f80ff97e936fea21a45f10dd33)](https://sonarcloud.io/summary/new_code?id=mobile-id-check-async)
 
-[![Async-credential Pull Request CI](https://github.com/govuk-one-login/mobile-id-check-async/actions/workflows/async-credential-pull-req.yml/badge.svg)](https://github.com/govuk-one-login/mobile-id-check-async/actions/workflows/async-credential-pull-req.yml)
-
 [![Async-credential Push to Main](https://github.com/govuk-one-login/mobile-id-check-async/actions/workflows/async-credential-push-to-main.yml/badge.svg?branch=main)](https://github.com/govuk-one-login/mobile-id-check-async/actions/workflows/async-credential-push-to-main.yml)
 
 


### PR DESCRIPTION
### What changed

Removed Async-credential Pull Request CI badge from the README.

### Evidence

![Screenshot 2024-07-11 at 09 19 41](https://github.com/govuk-one-login/mobile-id-check-async/assets/76539706/50c4e4e2-0cca-4a28-acbc-59e7cde6db5e)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
