### PR TITLE
DCMAW-8264: Add missing JSON.parse test

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -477,15 +477,15 @@ describe("Async Credential", () => {
     });
 
     describe("Given body contains invalid JSON", () => {
-      const invalidJson = [
+      const invalidJsonCases = [
         ["an empty string", ""],
         ["a plain string", "This shall not parse!"],
         ["an object with an unquoted key", "{key: 'value'}"],
         ["malformed JSON", '{"key": value}'],
       ];
-      test.each(invalidJson)(
+      test.each(invalidJsonCases)(
         "Returns 400 status code with invalid_request error when body is %s",
-        async (_, invalidJson) => {
+        async (_description, invalidJson) => {
           const event = buildRequest({
             headers: { Authorization: `Bearer ${mockValidJwt}` },
             body: invalidJson,

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -491,8 +491,6 @@ describe("Async Credential", () => {
             body: invalidJson,
           });
 
-          console.log("what is this?", invalidJson);
-
           dependencies.tokenService = () => new MockTokenSeviceValidSignature();
 
           const result: APIGatewayProxyResult = await lambdaHandler(

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -479,7 +479,7 @@ describe("Async Credential", () => {
     describe("Given body contains invalid JSON", () => {
       const invalidJsonCases = [
         ["an empty string", ""],
-        ["a plain string", "This shall not parse!"],
+        ["a plain string", "This is not JSON!"],
         ["an object with an unquoted key", "{key: 'value'}"],
         ["malformed JSON", '{"key": value}'],
       ];

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -58,9 +58,7 @@ export async function lambdaHandler(
     });
   }
 
-  const requestBody = event.body;
-
-  if (requestBody == null) {
+  if (event.body == null) {
     return badRequestResponse({
       error: "invalid_request",
       errorDescription: "Missing request body",
@@ -69,7 +67,7 @@ export async function lambdaHandler(
 
   let parsedRequestBody: ICredentialRequestBody;
   try {
-    parsedRequestBody = JSON.parse(requestBody);
+    parsedRequestBody = JSON.parse(event.body);
   } catch (error) {
     return badRequestResponse({
       error: "invalid_request",

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -60,7 +60,7 @@ export async function lambdaHandler(
 
   const requestBody = event.body;
 
-  if (!requestBody) {
+  if (requestBody == null) {
     return badRequestResponse({
       error: "invalid_request",
       errorDescription: "Missing request body",


### PR DESCRIPTION
### What changed
- Added unit test for when the lambda parses the event body.
- Updated null check logic so it won't include an empty string in this check. Rationale is event.body will always be present in this type of request, this check is being done as typescript requires this before parsing data. An empty string isn't part of this check and therefore will fail at the parsing step.

### Why did it change
Missed test case where the event body is not valid JSON. The logic is there to handle invalid JSON is there already.


### Test output
I used the `invaldJsonCases` array so I could describe the value in the test output as opposed to stating the value itself, as I think this is easier to understand.

Using the array with descriptions of the value results in this output:

```
Given body contains invalid JSON
        ✓ Returns 400 status code with invalid_request error when body is an empty string
        ✓ Returns 400 status code with invalid_request error when body is a plain string
        ✓ Returns 400 status code with invalid_request error when body is an object with an unquoted key
        ✓ Returns 400 status code with invalid_request error when body is malformed JSON
```

As opposed to just using the value:

```
Given body contains invalid JSON
        ✓ Returns 400 status code with invalid_request error when body is ""
        ✓ Returns 400 status code with invalid_request error when body is "This is not valid JSON"
        ✓ Returns 400 status code with invalid_request error when body is "{key: 'value'}"
        ✓ Returns 400 status code with invalid_request error when body is '{"key": value}'
```

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
