### PR TITLE
DCMAW-8264: Create session recovery service for credential lambda

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -55,7 +55,7 @@ const env = {
   ISSUER: "mockIssuer",
   SESSION_TABLE_NAME: "mockTableName",
   SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME: "mockIndexName",
-  SESSION_RECOVERY_TIMEOUT: "mockSessionRecoveryTimeout",
+  SESSION_RECOVERY_TIMEOUT: "12345",
 };
 
 describe("Async Credential", () => {
@@ -152,6 +152,25 @@ describe("Async Credential", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
         delete dependencies.env["SESSION_RECOVERY_TIMEOUT"];
+        const event = buildRequest();
+        const result = await lambdaHandler(event, dependencies);
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 500,
+          body: JSON.stringify({
+            error: "server_error",
+            error_description: "Server Error",
+          }),
+        });
+      });
+    });
+
+    describe("Given SESSION_RECOVERY_TIMEOUT value is not a number", () => {
+      it("Returns a 500 Server Error response", async () => {
+        dependencies.env = JSON.parse(JSON.stringify(env));
+        dependencies.env["SESSION_RECOVERY_TIMEOUT"] =
+          "mockInvalidSessionRecoveryTimeout";
         const event = buildRequest();
         const result = await lambdaHandler(event, dependencies);
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -914,7 +914,7 @@ describe("Async Credential", () => {
   });
 
   describe("Session recovery service", () => {
-    describe("Given service returns an unexpected error", () => {
+    describe("Given service returns an error response", () => {
       it("Returns 500 Server Error", async () => {
         const event = buildRequest({
           headers: { Authorization: `Bearer ${mockValidJwt}` },
@@ -944,61 +944,63 @@ describe("Async Credential", () => {
       });
     });
 
-    describe("Given service returns success response where value contains authSessionId string", () => {
-      it("Returns 200 session recovered response", async () => {
-        const event = buildRequest({
-          headers: { Authorization: `Bearer ${mockValidJwt}` },
-          body: JSON.stringify({
-            state: "mockState",
-            sub: "mockSub",
-            client_id: "mockClientId",
-            govuk_signin_journey_id: "mockGovukSigninJourneyId",
-          }),
-        });
-        dependencies.getRecoverSessionService = () =>
-          new MockSessionRecoveredRecoverSessionService(
-            env.SESSION_TABLE_NAME,
-            env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
-          );
+    describe("Given service returns success response", () => {
+      describe("Given response value is the authSessionId string", () => {
+        it("Returns 200 session recovered response", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockValidJwt}` },
+            body: JSON.stringify({
+              state: "mockState",
+              sub: "mockSub",
+              client_id: "mockClientId",
+              govuk_signin_journey_id: "mockGovukSigninJourneyId",
+            }),
+          });
+          dependencies.getRecoverSessionService = () =>
+            new MockSessionRecoveredRecoverSessionService(
+              env.SESSION_TABLE_NAME,
+              env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
+            );
 
-        const result = await lambdaHandler(event, dependencies);
+          const result = await lambdaHandler(event, dependencies);
 
-        expect(result).toStrictEqual({
-          headers: { "Content-Type": "application/json" },
-          statusCode: 200,
-          body: JSON.stringify({
-            sub: "mockSub",
-            "https://vocab.account.gov.uk/v1/credentialStatus": "pending",
-          }),
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 200,
+            body: JSON.stringify({
+              sub: "mockSub",
+              "https://vocab.account.gov.uk/v1/credentialStatus": "pending",
+            }),
+          });
         });
       });
-    });
 
-    describe("Given service returns success response where value is null", () => {
-      it("Returns 200 Hello World response", async () => {
-        const event = buildRequest({
-          headers: { Authorization: `Bearer ${mockValidJwt}` },
-          body: JSON.stringify({
-            state: "mockState",
-            sub: "mockSub",
-            client_id: "mockClientId",
-            govuk_signin_journey_id: "mockGovukSigninJourneyId",
-          }),
-        });
-        dependencies.getRecoverSessionService = () =>
-          new MockNoRecoverableSessionRecoverSessionService(
-            env.SESSION_TABLE_NAME,
-            env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
-          );
+      describe("Given response value is null", () => {
+        it("Returns 200 Hello World response", async () => {
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${mockValidJwt}` },
+            body: JSON.stringify({
+              state: "mockState",
+              sub: "mockSub",
+              client_id: "mockClientId",
+              govuk_signin_journey_id: "mockGovukSigninJourneyId",
+            }),
+          });
+          dependencies.getRecoverSessionService = () =>
+            new MockNoRecoverableSessionRecoverSessionService(
+              env.SESSION_TABLE_NAME,
+              env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
+            );
 
-        const result = await lambdaHandler(event, dependencies);
+          const result = await lambdaHandler(event, dependencies);
 
-        expect(result).toStrictEqual({
-          headers: { "Content-Type": "application/json" },
-          statusCode: 200,
-          body: JSON.stringify({
-            message: "Hello World",
-          }),
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 200,
+            body: JSON.stringify({
+              message: "Hello World",
+            }),
+          });
         });
       });
     });

--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -55,6 +55,7 @@ const env = {
   ISSUER: "mockIssuer",
   SESSION_TABLE_NAME: "mockTableName",
   SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME: "mockIndexName",
+  SESSION_RECOVERY_TIMEOUT: "mockSessionRecoveryTimeout",
 };
 
 describe("Async Credential", () => {
@@ -133,6 +134,24 @@ describe("Async Credential", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
         delete dependencies.env["SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME"];
+        const event = buildRequest();
+        const result = await lambdaHandler(event, dependencies);
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 500,
+          body: JSON.stringify({
+            error: "server_error",
+            error_description: "Server Error",
+          }),
+        });
+      });
+    });
+
+    describe("Given SESSION_RECOVERY_TIMEOUT is missing", () => {
+      it("Returns a 500 Server Error response", async () => {
+        dependencies.env = JSON.parse(JSON.stringify(env));
+        delete dependencies.env["SESSION_RECOVERY_TIMEOUT"];
         const event = buildRequest();
         const result = await lambdaHandler(event, dependencies);
 

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -12,6 +12,7 @@ import {
   successResponse,
 } from "../types/errorOrValue";
 import { IJwtPayload } from "../types/jwt";
+import { IRecoverAuthSession } from "./recoverSessionService/recoverSessionService";
 
 export async function lambdaHandler(
   event: APIGatewayProxyEvent,
@@ -141,6 +142,24 @@ export async function lambdaHandler(
       error: "invalid_client",
       errorDescription: "Invalid aud claim",
     });
+  }
+
+  const recoverSessionService = dependencies.getRecoverSessionService(
+    "mockTableName",
+    "mockIndexName",
+  );
+  const recoverSessionServiceResponse =
+    await recoverSessionService.getAuthSessionBySub(
+      parsedRequestBody.sub,
+      parsedRequestBody.state,
+      3600,
+    );
+  if (recoverSessionServiceResponse.isError) {
+    return serverError500Responses;
+  }
+
+  if (recoverSessionServiceResponse.value) {
+    return sessionRecoveredResponse(parsedRequestBody.sub);
   }
 
   return {
@@ -298,6 +317,17 @@ const serverError500Responses: APIGatewayProxyResult = {
   }),
 };
 
+const sessionRecoveredResponse = (sub: string): APIGatewayProxyResult => {
+  return {
+    headers: { "Content-Type": "application/json" },
+    statusCode: 200,
+    body: JSON.stringify({
+      sub,
+      "https://vocab.account.gov.uk/v1/credentialStatus": "pending",
+    }),
+  };
+};
+
 export interface ICredentialRequestBody {
   sub: string;
   govuk_signin_journey_id: string;
@@ -310,5 +340,9 @@ export interface Dependencies {
   tokenService: () => TokenService;
   clientCredentialsService: () => ClientCredentialsService;
   ssmService: () => IGetClientCredentials;
+  getRecoverSessionService: (
+    tableName: string,
+    indexName: string,
+  ) => IRecoverAuthSession;
   env: NodeJS.ProcessEnv;
 }

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -164,7 +164,7 @@ export async function lambdaHandler(
     await recoverSessionService.getAuthSessionBySub(
       parsedRequestBody.sub,
       parsedRequestBody.state,
-      sessionRecoveryTimeout, //TODO Get this dynamically
+      sessionRecoveryTimeout,
     );
   if (recoverSessionServiceResponse.isError) {
     return serverError500Responses;

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -19,18 +19,21 @@ export async function lambdaHandler(
   dependencies: Dependencies,
 ): Promise<APIGatewayProxyResult> {
   let keyId;
+  let issuer;
+  let sessionTableName;
+  let sessionTableSubIndexName;
   try {
     keyId = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
+    issuer = validOrThrow(dependencies.env, "ISSUER");
+    sessionTableName = validOrThrow(dependencies.env, "SESSION_TABLE_NAME");
+    sessionTableSubIndexName = validOrThrow(
+      dependencies.env,
+      "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME",
+    );
   } catch (error) {
     return serverError500Responses;
   }
 
-  let issuer;
-  try {
-    issuer = validOrThrow(dependencies.env, "ISSUER");
-  } catch (error) {
-    return serverError500Responses;
-  }
   const authorizationHeader = event.headers["Authorization"];
 
   if (authorizationHeader == null) {
@@ -145,8 +148,8 @@ export async function lambdaHandler(
   }
 
   const recoverSessionService = dependencies.getRecoverSessionService(
-    "mockTableName",
-    "mockIndexName",
+    sessionTableName,
+    sessionTableSubIndexName,
   );
 
   const recoverSessionServiceResponse =

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -22,6 +22,7 @@ export async function lambdaHandler(
   let issuer;
   let sessionTableName;
   let sessionTableSubIndexName;
+  let sessionRecoveryTimeout;
   try {
     keyId = validOrThrow(dependencies.env, "SIGNING_KEY_ID");
     issuer = validOrThrow(dependencies.env, "ISSUER");
@@ -29,6 +30,9 @@ export async function lambdaHandler(
     sessionTableSubIndexName = validOrThrow(
       dependencies.env,
       "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME",
+    );
+    sessionRecoveryTimeout = parseInt(
+      validOrThrow(dependencies.env, "SESSION_RECOVERY_TIMEOUT"),
     );
   } catch (error) {
     return serverError500Responses;
@@ -156,7 +160,7 @@ export async function lambdaHandler(
     await recoverSessionService.getAuthSessionBySub(
       parsedRequestBody.sub,
       parsedRequestBody.state,
-      3600, //TODO Get this dynamically
+      sessionRecoveryTimeout, //TODO Get this dynamically
     );
   if (recoverSessionServiceResponse.isError) {
     return serverError500Responses;

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -34,6 +34,10 @@ export async function lambdaHandler(
     sessionRecoveryTimeout = parseInt(
       validOrThrow(dependencies.env, "SESSION_RECOVERY_TIMEOUT"),
     );
+
+    if (!sessionRecoveryTimeout) {
+      throw new Error("Invalid SESSION_RECOVERY_TIMEOUT value - not a number");
+    }
   } catch (error) {
     return serverError500Responses;
   }

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -148,11 +148,12 @@ export async function lambdaHandler(
     "mockTableName",
     "mockIndexName",
   );
+
   const recoverSessionServiceResponse =
     await recoverSessionService.getAuthSessionBySub(
       parsedRequestBody.sub,
       parsedRequestBody.state,
-      3600,
+      3600, //TODO Get this dynamically
     );
   if (recoverSessionServiceResponse.isError) {
     return serverError500Responses;

--- a/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
+++ b/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
@@ -1,0 +1,13 @@
+import { DynamoDBClient, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+
+const config: DynamoDBClientConfig = {
+  region: "eu-west-2",
+  maxAttempts: 2,
+  requestHandler: new NodeHttpHandler({
+    connectionTimeout: 29000,
+    requestTimeout: 29000,
+  }),
+};
+
+export const dbClient = new DynamoDBClient(config);

--- a/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
+++ b/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
@@ -2,8 +2,7 @@ import { DynamoDBClient, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 
 const config: DynamoDBClientConfig = {
-  //TODO: Get region dynamically
-  region: "eu-west-2",
+  region: process.env.REGION,
   maxAttempts: 2,
   requestHandler: new NodeHttpHandler({
     connectionTimeout: 29000,
@@ -11,5 +10,4 @@ const config: DynamoDBClientConfig = {
   }),
 };
 
-//TODO: Check if we are using X-ray
 export const dbClient = new DynamoDBClient(config);

--- a/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
+++ b/src/functions/asyncCredential/recoverSessionService/dynamoDbClient.ts
@@ -2,6 +2,7 @@ import { DynamoDBClient, DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 
 const config: DynamoDBClientConfig = {
+  //TODO: Get region dynamically
   region: "eu-west-2",
   maxAttempts: 2,
   requestHandler: new NodeHttpHandler({
@@ -10,4 +11,5 @@ const config: DynamoDBClientConfig = {
   }),
 };
 
+//TODO: Check if we are using X-ray
 export const dbClient = new DynamoDBClient(config);

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -15,7 +15,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockValidState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(true);
@@ -37,7 +37,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockValidState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(false);
@@ -57,7 +57,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockValidState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(false);
@@ -85,7 +85,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(false);
@@ -114,7 +114,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(false);
@@ -143,7 +143,7 @@ describe("Recover Session Service", () => {
       const result = await service.getAuthSessionBySub(
         "mockSub",
         "mockState",
-        1000,
+        3600,
       );
 
       expect(result.isError).toBe(false);

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -84,7 +84,7 @@ describe("Recover Session Service", () => {
 
       const result = await service.getAuthSessionBySub(
         "mockSub",
-        "mockState",
+        "mockValidState",
         3600,
       );
 
@@ -113,7 +113,7 @@ describe("Recover Session Service", () => {
 
       const result = await service.getAuthSessionBySub(
         "mockSub",
-        "mockState",
+        "mockValidState",
         3600,
       );
 
@@ -142,7 +142,7 @@ describe("Recover Session Service", () => {
 
       const result = await service.getAuthSessionBySub(
         "mockSub",
-        "mockState",
+        "mockValidState",
         3600,
       );
 

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { recoverSessionService } from "./recoverSessionService";
 import { mockClient } from "aws-sdk-client-mock";
+
 describe("Recover Session Service", () => {
   describe("Given there is an unexpected error when calling Dynamo DB", () => {
     it("Returns error response", async () => {

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -13,7 +13,7 @@ describe("Recover Session Service", () => {
 
       const result = await service.getAuthSessionBySub(
         "mockSub",
-        "mockState",
+        "mockValidState",
         1000,
       );
 
@@ -21,6 +21,132 @@ describe("Recover Session Service", () => {
       expect(result.value).toEqual(
         "Unexpected error when querying session table whilst checking for recoverable session",
       );
+    });
+  });
+
+  describe("Given Items array is missing", () => {
+    it("Returns success response will value of null", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).resolves({});
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockValidState",
+        1000,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.value).toEqual(null);
+    });
+  });
+
+  describe("Given Items array is empty", () => {
+    it("Returns success response will value of null", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockValidState",
+        1000,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.value).toEqual(null);
+    });
+  });
+
+  describe("Given Items array is missing sessionId", () => {
+    it("Returns success response will value of null", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            sub: { S: "mockSub" },
+            state: { S: "mockValidState" },
+          },
+        ],
+      });
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockState",
+        1000,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.value).toEqual(null);
+    });
+  });
+
+  describe("Given sessionId value in Items array is empty", () => {
+    it("Returns success response will value of null", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            sub: { S: "mockSub" },
+            state: { S: "mockValidState" },
+            sessionId: { S: "" },
+          },
+        ],
+      });
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockState",
+        1000,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.value).toEqual(null);
+    });
+  });
+
+  describe("Given a valid recoverable session is found", () => {
+    it("Returns a success response with sessionId as value", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            sub: { S: "mockSub" },
+            state: { S: "mockValidState" },
+            sessionId: { S: "mockSessionId" },
+          },
+        ],
+      });
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockState",
+        1000,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.value).toEqual("mockSessionId");
     });
   });
 });

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -3,12 +3,13 @@ import { recoverSessionService } from "./recoverSessionService";
 import { mockClient } from "aws-sdk-client-mock";
 
 describe("Recover Session Service", () => {
+  let service: recoverSessionService;
+  beforeEach(() => {
+    service = new recoverSessionService("mockTableName", "mockIndexName");
+  });
+
   describe("Given there is an unexpected error when calling Dynamo DB", () => {
     it("Returns error response", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).rejects("Mock DB Error");
 
@@ -27,10 +28,6 @@ describe("Recover Session Service", () => {
 
   describe("Given Items array is missing", () => {
     it("Returns success response will value of null", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).resolves({});
 
@@ -47,10 +44,6 @@ describe("Recover Session Service", () => {
 
   describe("Given Items array is empty", () => {
     it("Returns success response will value of null", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).resolves({ Items: [] });
 
@@ -67,11 +60,6 @@ describe("Recover Session Service", () => {
 
   describe("Given Items array is missing sessionId", () => {
     it("Returns success response will value of null", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
-
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).resolves({
         Items: [
@@ -95,11 +83,6 @@ describe("Recover Session Service", () => {
 
   describe("Given sessionId value in Items array is empty", () => {
     it("Returns success response will value of null", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
-
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).resolves({
         Items: [
@@ -124,11 +107,6 @@ describe("Recover Session Service", () => {
 
   describe("Given a valid recoverable session is found", () => {
     it("Returns a success response with sessionId as value", async () => {
-      const service = new recoverSessionService(
-        "mockTableName",
-        "mockIndexName",
-      );
-
       const dbMock = mockClient(DynamoDBClient);
       dbMock.on(QueryCommand).resolves({
         Items: [

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -1,11 +1,11 @@
 import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
-import { recoverSessionService } from "./recoverSessionService";
+import { RecoverSessionService } from "./recoverSessionService";
 import { mockClient } from "aws-sdk-client-mock";
 
 describe("Recover Session Service", () => {
-  let service: recoverSessionService;
+  let service: RecoverSessionService;
   beforeEach(() => {
-    service = new recoverSessionService("mockTableName", "mockIndexName");
+    service = new RecoverSessionService("mockTableName", "mockIndexName");
   });
 
   describe("Given there is an unexpected error when calling Dynamo DB", () => {

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.test.ts
@@ -1,0 +1,26 @@
+import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
+import { recoverSessionService } from "./recoverSessionService";
+import { mockClient } from "aws-sdk-client-mock";
+describe("Recover Session Service", () => {
+  describe("Given there is an unexpected error when calling Dynamo DB", () => {
+    it("Returns error response", async () => {
+      const service = new recoverSessionService(
+        "mockTableName",
+        "mockIndexName",
+      );
+      const dbMock = mockClient(DynamoDBClient);
+      dbMock.on(QueryCommand).rejects("Mock DB Error");
+
+      const result = await service.getAuthSessionBySub(
+        "mockSub",
+        "mockState",
+        1000,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.value).toEqual(
+        "Unexpected error when querying session table whilst checking for recoverable session",
+      );
+    });
+  });
+});

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -57,11 +57,22 @@ export class RecoverSessionService implements IRecoverAuthSession {
       );
     }
 
-    if (!hasValidSession(result)) {
+    if (!this.hasValidSession(result)) {
       return successResponse(null);
     }
 
     return successResponse(result.Items[0].sessionId.S);
+  }
+
+  private hasValidSession(
+    result: IQueryCommandOutputType,
+  ): result is { Items: [{ sessionId: { S: string } }] } {
+    return (
+      Array.isArray(result.Items) &&
+      result.Items.length > 0 &&
+      result.Items[0].sessionId != null &&
+      result.Items[0].sessionId.S !== ""
+    );
   }
 }
 
@@ -76,14 +87,3 @@ export interface IRecoverAuthSession {
 type IQueryCommandOutputType = {
   Items?: { sessionId?: { S: string } }[];
 };
-
-function hasValidSession(
-  result: IQueryCommandOutputType,
-): result is { Items: [{ sessionId: { S: string } }] } {
-  return (
-    Array.isArray(result.Items) &&
-    result.Items.length > 0 &&
-    result.Items[0].sessionId != null &&
-    result.Items[0].sessionId.S !== ""
-  );
-}

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -16,10 +16,7 @@ export class recoverSessionService implements IRecoverAuthSession {
   readonly indexName: string;
   readonly dbClient: DynamoDBClient;
 
-  constructor(
-    tableName: string,
-    indexName: string,
-  ) {
+  constructor(tableName: string, indexName: string) {
     this.tableName = tableName;
     this.indexName = indexName;
     this.dbClient = dbClient;

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -36,7 +36,7 @@ export class RecoverSessionService implements IRecoverAuthSession {
         "authSessionState = :authSessionState and #state <> :state",
       ExpressionAttributeValues: {
         ":subjectIdentifier": { S: sub },
-        ":authSessionState": { S: "mockValidState" }, //TODO Get dynamically
+        ":authSessionState": { S: "ASYNC_AUTH_SESSION_CREATED" },
         ":issuedOn": { S: (Date.now() - sessionRecoveryTimeout).toString() },
         ":state": { S: state },
       },

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -64,7 +64,8 @@ export class recoverSessionService implements IRecoverAuthSession {
     if (
       result.Items &&
       result.Items.length > 0 &&
-      result.Items[0].sessionId.S !== undefined
+      result.Items[0].sessionId !== undefined &&
+      result.Items[0].sessionId.S
     ) {
       return successResponse(result.Items[0].sessionId.S);
     }

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -11,7 +11,7 @@ import {
   successResponse,
 } from "../../types/errorOrValue";
 
-export class recoverSessionService implements IRecoverAuthSession {
+export class RecoverSessionService implements IRecoverAuthSession {
   readonly tableName: string;
   readonly indexName: string;
   readonly dbClient: DynamoDBClient;

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -36,7 +36,7 @@ export class recoverSessionService implements IRecoverAuthSession {
         "authSessionState = :authSessionState and #state <> :state",
       ExpressionAttributeValues: {
         ":subjectIdentifier": { S: sub },
-        ":authSessionState": { S: "mockValidState" },
+        ":authSessionState": { S: "mockValidState" }, //TODO Get dynamically
         ":issuedOn": { S: (Date.now() - sessionRecoveryTimeout).toString() },
         ":state": { S: state },
       },

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -19,11 +19,10 @@ export class recoverSessionService implements IRecoverAuthSession {
   constructor(
     tableName: string,
     indexName: string,
-    overrideDbClient?: DynamoDBClient,
   ) {
     this.tableName = tableName;
     this.indexName = indexName;
-    this.dbClient = overrideDbClient ?? dbClient;
+    this.dbClient = dbClient;
   }
 
   async getAuthSessionBySub(

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -57,16 +57,11 @@ export class RecoverSessionService implements IRecoverAuthSession {
       );
     }
 
-    if (
-      result.Items &&
-      result.Items.length > 0 &&
-      result.Items[0].sessionId !== undefined &&
-      result.Items[0].sessionId.S
-    ) {
-      return successResponse(result.Items[0].sessionId.S);
+    if (!hasValidSession(result)) {
+      return successResponse(null);
     }
 
-    return successResponse(null);
+    return successResponse(result.Items[0].sessionId.S);
   }
 }
 
@@ -76,4 +71,19 @@ export interface IRecoverAuthSession {
     state: string,
     sessionRecoveryTimeout: number,
   ) => Promise<ErrorOrSuccess<string | null>>;
+}
+
+type IQueryCommandOutputType = {
+  Items?: { sessionId?: { S: string } }[];
+};
+
+function hasValidSession(
+  result: IQueryCommandOutputType,
+): result is { Items: [{ sessionId: { S: string } }] } {
+  return (
+    Array.isArray(result.Items) &&
+    result.Items.length > 0 &&
+    result.Items[0].sessionId != null &&
+    result.Items[0].sessionId.S !== ""
+  );
 }

--- a/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
+++ b/src/functions/asyncCredential/recoverSessionService/recoverSessionService.ts
@@ -1,0 +1,82 @@
+import {
+  DynamoDBClient,
+  QueryCommand,
+  QueryCommandInput,
+  QueryCommandOutput,
+} from "@aws-sdk/client-dynamodb";
+import { dbClient } from "./dynamoDbClient";
+import {
+  ErrorOrSuccess,
+  errorResponse,
+  successResponse,
+} from "../../types/errorOrValue";
+
+export class recoverSessionService implements IRecoverAuthSession {
+  readonly tableName: string;
+  readonly indexName: string;
+  readonly dbClient: DynamoDBClient;
+
+  constructor(
+    tableName: string,
+    indexName: string,
+    overrideDbClient?: DynamoDBClient,
+  ) {
+    this.tableName = tableName;
+    this.indexName = indexName;
+    this.dbClient = overrideDbClient ?? dbClient;
+  }
+
+  async getAuthSessionBySub(
+    sub: string,
+    state: string,
+    sessionRecoveryTimeout: number,
+  ): Promise<ErrorOrSuccess<string | null>> {
+    const queryCommandInput: QueryCommandInput = {
+      TableName: this.tableName,
+      IndexName: this.indexName,
+      KeyConditionExpression:
+        "subjectIdentifier = :subjectIdentifier and issuedOn > :issuedOn",
+      FilterExpression:
+        "authSessionState = :authSessionState and #state <> :state",
+      ExpressionAttributeValues: {
+        ":subjectIdentifier": { S: sub },
+        ":authSessionState": { S: "mockValidState" },
+        ":issuedOn": { S: (Date.now() - sessionRecoveryTimeout).toString() },
+        ":state": { S: state },
+      },
+      ExpressionAttributeNames: {
+        "#state": "state",
+      },
+      ProjectionExpression: "sessionId",
+      Limit: 1,
+      ScanIndexForward: false,
+    };
+
+    let result: QueryCommandOutput;
+    try {
+      result = await dbClient.send(new QueryCommand(queryCommandInput));
+    } catch (error) {
+      return errorResponse(
+        "Unexpected error when querying session table whilst checking for recoverable session",
+      );
+    }
+
+    if (
+      result.Items &&
+      result.Items.length > 0 &&
+      result.Items[0].sessionId.S !== undefined
+    ) {
+      return successResponse(result.Items[0].sessionId.S);
+    }
+
+    return successResponse(null);
+  }
+}
+
+export interface IRecoverAuthSession {
+  getAuthSessionBySub: (
+    sub: string,
+    state: string,
+    sessionRecoveryTimeout: number,
+  ) => Promise<ErrorOrSuccess<string | null>>;
+}

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -1,4 +1,8 @@
-export type EnvVars = "SIGNING_KEY_ID" | "ISSUER";
+export type EnvVars =
+  | "SIGNING_KEY_ID"
+  | "ISSUER"
+  | "SESSION_TABLE_NAME"
+  | "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME";
 
 // Get static variables
 export const validOrThrow = (

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -3,7 +3,8 @@ export type EnvVars =
   | "ISSUER"
   | "SESSION_TABLE_NAME"
   | "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME"
-  | "SESSION_RECOVERY_TIMEOUT";
+  | "SESSION_RECOVERY_TIMEOUT"
+  | "REGION";
 
 // Get static variables
 export const validOrThrow = (

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -2,7 +2,8 @@ export type EnvVars =
   | "SIGNING_KEY_ID"
   | "ISSUER"
   | "SESSION_TABLE_NAME"
-  | "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME";
+  | "SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME"
+  | "SESSION_RECOVERY_TIMEOUT";
 
 // Get static variables
 export const validOrThrow = (

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.4.0",
+        "@aws-sdk/client-dynamodb": "^3.614.0",
         "@aws-sdk/client-kms": "3.614.0",
         "@aws-sdk/client-ssm": "3.614.0",
         "@aws-sdk/node-http-handler": "3.374.0",
@@ -184,6 +185,60 @@
         "@middy/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.614.0.tgz",
+      "integrity": "sha512-/Qhpim9Y6GfsZ4tcHgXo+YrBR44WGU6ON1PuT8X8D31aIb1mmtcHCF1c86QQ97sGkgmnCcaTWhQYjLNiJOZkbA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.614.0",
+        "@aws-sdk/client-sts": "3.614.0",
+        "@aws-sdk/core": "3.614.0",
+        "@aws-sdk/credential-provider-node": "3.614.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.614.0",
+        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.6",
+        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.3",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.2",
+        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.9",
+        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kms": {
@@ -583,6 +638,34 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-sts": "^3.609.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.572.0.tgz",
+      "integrity": "sha512-CzuRWMj/xtN9p9eP915nlPmlyniTzke732Ow/M60++gGgB3W+RtZyFftw3TEx+NzNhd1tH54dEcGiWdiNaBz3Q==",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.614.0.tgz",
+      "integrity": "sha512-xEe9a3aaAzzo5RlRz4SSsGYpYiju29SdYDQYsm1v3syWGOqNzFlJE7aFuSP0/WYgdwB6svILLdAeZs8w2fj3GQ==",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.572.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
@@ -5643,6 +5726,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
@@ -5723,6 +5814,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/src/package.json
+++ b/src/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.4.0",
+    "@aws-sdk/client-dynamodb": "^3.614.0",
     "@aws-sdk/client-kms": "3.614.0",
     "@aws-sdk/client-ssm": "3.614.0",
     "@aws-sdk/node-http-handler": "3.374.0",


### PR DESCRIPTION
### What changed
Create service to check if user already has a valid session, if so return success response with the `sub` from the `JAR` and "https://vocab.account.gov.uk/v1/credentialStatus": "pending"

### Why did it change
Following tech design which is found on ticket: DCMAW-8264

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
