### PR TITLE
DCMAW-8264: Log when jwt claims are invalid

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -239,6 +239,13 @@ describe("Async Credential", () => {
             dependencies,
           );
 
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Missing exp claim",
+          });
+
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
@@ -264,6 +271,13 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "exp claim is in the past",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
@@ -294,6 +308,12 @@ describe("Async Credential", () => {
             dependencies,
           );
 
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "iat claim is in the future",
+          });
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
@@ -323,6 +343,12 @@ describe("Async Credential", () => {
             dependencies,
           );
 
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "nbf claim is in the future",
+          });
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
@@ -351,6 +377,12 @@ describe("Async Credential", () => {
             dependencies,
           );
 
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Missing iss claim",
+          });
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
@@ -376,13 +408,21 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage:
+              "iss claim does not match ISSUER environment variable",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
             statusCode: 400,
             body: JSON.stringify({
               error: "invalid_token",
-              error_description: "iss claim does not match registered issuer",
+              error_description:
+                "iss claim does not match ISSUER environment variable",
             }),
           });
         });
@@ -404,6 +444,12 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Missing scope claim",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
@@ -430,6 +476,12 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Invalid scope claim",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
@@ -458,6 +510,12 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Missing client_id claim",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
@@ -486,6 +544,12 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "JWT_CLAIM_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Missing aud claim",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -53,7 +53,7 @@ export async function lambdaHandler(
 
   // JWT Claim validation
   const encodedJwt = authorizationHeader.split(" ")[1];
-  console.log("ENCODEDJWT", encodedJwt);
+
   // Replace with const [header, payload, signature] = encodedJwt.split(".") when needed
   const payload = encodedJwt.split(".")[1];
   const jwtPayload = JSON.parse(
@@ -64,7 +64,7 @@ export async function lambdaHandler(
     jwtPayload,
     config.ISSUER,
   );
-  console.log("JWT PAYLOAD", jwtPayload);
+
   if (jwtClaimValidationResponse.isError) {
     logger.log("JWT_CLAIM_INVALID", {
       errorMessage: jwtClaimValidationResponse.value,

--- a/src/functions/asyncCredential/registeredLogs.ts
+++ b/src/functions/asyncCredential/registeredLogs.ts
@@ -4,11 +4,17 @@ import {
 } from "../services/logging/commonRegisteredLogs";
 import { RegisteredLogMessages } from "../services/logging/types";
 
-export type MessageName = "AUTHENTICATION_HEADER_INVALID" | CommonMessageNames;
+export type MessageName =
+  | "AUTHENTICATION_HEADER_INVALID"
+  | "JWT_CLAIM_INVALID"
+  | CommonMessageNames;
 
 export const registeredLogs: RegisteredLogMessages<MessageName> = {
   AUTHENTICATION_HEADER_INVALID: {
     messageCode: "MOBILE_ASYNC_AUTHENTICATION_HEADER_INVALID",
+  },
+  JWT_CLAIM_INVALID: {
+    messageCode: "MOBILE_ASYNC_JWT_CLAIM_INVALID",
   },
   ...commonMessages,
 };


### PR DESCRIPTION
​DCMAW-8264
### What changed
Logs when JWT claims are missing or do not pass validation https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3917447301/Strategic+App+DCMAW-7690+Implementing+Client+Credentials+Grant+Flow+and+Asynchronous+CRI+credential+requests

### Why did it change
Observability

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
