### PR TITLE
DCMAW-8265: Add test coverage for valid redirect_uri

### DIFF
--- a/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1009,7 +1009,7 @@ class MockFailingClientCredentialsServiceGetClientCredentialsById
   validateTokenRequest(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
@@ -1021,7 +1021,7 @@ class MockPassingClientCredentialsService implements IClientCredentialsService {
   validateTokenRequest(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
@@ -1038,7 +1038,7 @@ class MockFailingClientCredentialsService implements IClientCredentialsService {
   validateTokenRequest(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return errorResponse("mockClientCredentialServiceError");
   }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {

--- a/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -138,7 +138,7 @@ export async function lambdaHandler(
 
   if (parsedRequestBody.redirect_uri) {
     const validateClientCredentialsResult =
-      clientCredentialsService.validateCredentialRequest(
+      clientCredentialsService.validateRedirectUri(
         clientCredentials,
         parsedRequestBody,
       );

--- a/src/functions/asyncToken/asyncTokenHandler.test.ts
+++ b/src/functions/asyncToken/asyncTokenHandler.test.ts
@@ -326,7 +326,7 @@ class MockPassingClientCredentialsService implements IClientCredentialsService {
   validateTokenRequest(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
@@ -345,7 +345,7 @@ class MockFailingClientCredentialsServiceGetClientCredentialsById
   validateTokenRequest(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
   getClientCredentialsById(): ErrorOrSuccess<IClientCredentials> {
@@ -359,7 +359,7 @@ class MockFailingClientCredentialsServiceValidation
   validateTokenRequest(): ErrorOrSuccess<null> {
     return errorResponse("Client secrets not valid");
   }
-  validateCredentialRequest(): ErrorOrSuccess<null> {
+  validateRedirectUri(): ErrorOrSuccess<null> {
     return successResponse(null);
   }
   getClientCredentialsById() {

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.test.ts
@@ -8,7 +8,7 @@ import {
 describe("Client Credentials Service", () => {
   let clientCredentialsService: ClientCredentialsService;
   let mockTokenSuppliedClientCredentials: IDecodedClientCredentials;
-  let mockCredentialSuppliedClientCredentials: ICredentialRequestBody;
+  let mockSuppliedClientCredentials: ICredentialRequestBody;
   let mockStoredClientCredentialsArray: IClientCredentials[];
   let mockStoredClientCredentials: IClientCredentials;
 
@@ -18,7 +18,7 @@ describe("Client Credentials Service", () => {
       clientId: "mockClientId",
       clientSecret: "mockClientSecret",
     };
-    mockCredentialSuppliedClientCredentials = {
+    mockSuppliedClientCredentials = {
       sub: "mockSub",
       govuk_signin_journey_id: "mockGovukSigninJourneyId",
       client_id: "mockClientId",
@@ -126,9 +126,9 @@ describe("Client Credentials Service", () => {
         it("Returns a log", () => {
           mockStoredClientCredentials.redirect_uri = "";
 
-          const result = clientCredentialsService.validateCredentialRequest(
+          const result = clientCredentialsService.validateRedirectUri(
             mockStoredClientCredentials,
-            mockCredentialSuppliedClientCredentials,
+            mockSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
@@ -140,9 +140,9 @@ describe("Client Credentials Service", () => {
         it("Returns a log", () => {
           mockStoredClientCredentials.redirect_uri = "mockInvalidURL";
 
-          const result = clientCredentialsService.validateCredentialRequest(
+          const result = clientCredentialsService.validateRedirectUri(
             mockStoredClientCredentials,
-            mockCredentialSuppliedClientCredentials,
+            mockSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
@@ -152,16 +152,30 @@ describe("Client Credentials Service", () => {
 
       describe("Given supplied redirect_uri does not match stored redirect_uri", () => {
         it("Returns a log", () => {
-          mockCredentialSuppliedClientCredentials.redirect_uri =
+          mockSuppliedClientCredentials.redirect_uri =
             "https://mockInvalidRedirectUri.com";
 
-          const result = clientCredentialsService.validateCredentialRequest(
+          const result = clientCredentialsService.validateRedirectUri(
             mockStoredClientCredentials,
-            mockCredentialSuppliedClientCredentials,
+            mockSuppliedClientCredentials,
           );
 
           expect(result.isError).toBe(true);
           expect(result.value).toBe("Unregistered redirect_uri");
+        });
+      });
+
+      describe("Given redirect_uri is present and registered", () => {
+        it("Returns a value of null", () => {
+          mockSuppliedClientCredentials.redirect_uri =
+            "https://mockRedirectUri.com";
+          const result = clientCredentialsService.validateRedirectUri(
+            mockStoredClientCredentials,
+            mockSuppliedClientCredentials,
+          );
+
+          expect(result.isError).toBe(false);
+          expect(result.value).toBe(null);
         });
       });
     });

--- a/src/functions/services/clientCredentialsService/clientCredentialsService.ts
+++ b/src/functions/services/clientCredentialsService/clientCredentialsService.ts
@@ -39,7 +39,7 @@ export class ClientCredentialsService implements IClientCredentialsService {
     return successResponse(null);
   };
 
-  validateCredentialRequest = (
+  validateRedirectUri = (
     storedCredentials: IClientCredentials,
     suppliedCredentials: ICredentialRequestBody,
   ): ErrorOrSuccess<null> => {
@@ -85,7 +85,7 @@ export interface IClientCredentialsService {
     suppliedCredentials: IDecodedClientCredentials,
   ) => ErrorOrSuccess<null>;
 
-  validateCredentialRequest: (
+  validateRedirectUri: (
     storedCredentials: IClientCredentials,
     suppliedCredentials: ICredentialRequestBody,
   ) => ErrorOrSuccess<null>;


### PR DESCRIPTION
​DCMAW-8265
### What changed
Adds test coverage for when the supplied redirect_uri is registered in the ClientCredentials Array

### Why did it change
Flagged by Sonar

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
