### PR TITLE
DCMAW-8264: Log when request body is invalid

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1129,37 +1129,6 @@ describe("Async Credential", () => {
       });
 
       describe("Given the session has been created", () => {
-        it("Returns 201 session created response", async () => {
-          const jwtBuilder = new MockJWTBuilder();
-          const event = buildRequest({
-            headers: { Authorization: `Bearer ${jwtBuilder.getEncodedJwt()}` },
-            body: JSON.stringify({
-              state: "mockState",
-              sub: "mockSub",
-              client_id: "mockClientId",
-              govuk_signin_journey_id: "mockGovukSigninJourneyId",
-            }),
-          });
-          dependencies.getSessionService = () =>
-            new MockSessionServiceSessionCreated(
-              env.SESSION_TABLE_NAME,
-              env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
-            );
-
-          const result = await lambdaHandler(event, dependencies);
-
-          expect(result).toStrictEqual({
-            headers: { "Content-Type": "application/json" },
-            statusCode: 201,
-            body: JSON.stringify({
-              sub: "mockSub",
-              "https://vocab.account.gov.uk/v1/credentialStatus": "pending",
-            }),
-          });
-        });
-      });
-
-      describe("Given the session has been created", () => {
         describe("Given it fails to write the DCMAW_ASYNC_CRI_START event to TxMA", () => {
           it("Logs and returns 201 session created response", async () => {
             const jwtBuilder = new MockJWTBuilder();

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -591,6 +591,13 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Missing request body",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
@@ -609,7 +616,7 @@ describe("Async Credential", () => {
         ["an object with an unquoted key", "{key: 'value'}"],
         ["malformed JSON", '{"key": value}'],
       ];
-      test.each(invalidJsonCases)(
+      it.each(invalidJsonCases)(
         "Returns 400 status code with invalid_request error when body is %s",
         async (_description, invalidJson) => {
           const jwtBuilder = new MockJWTBuilder();
@@ -624,6 +631,13 @@ describe("Async Credential", () => {
             event,
             dependencies,
           );
+
+          expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+            "REQUEST_BODY_INVALID",
+          );
+          expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+            errorMessage: "Invalid JSON in request body",
+          });
 
           expect(result).toStrictEqual({
             headers: { "Content-Type": "application/json" },
@@ -652,12 +666,19 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Missing state in request body",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description: "Missing state in request body",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -680,12 +701,19 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Missing sub in request body",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description: "Missing sub in request body",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -709,12 +737,19 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Missing client_id in request body",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description: "Missing client_id in request body",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -739,13 +774,20 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage:
+            "client_id in request body does not match value in access_token",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description:
-              "client_id in request body does not match client_id in access token",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -770,13 +812,19 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Missing govuk_signin_journey_id in request body",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description:
-              "Missing govuk_signin_journey_id in request body",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -803,12 +851,19 @@ describe("Async Credential", () => {
           dependencies,
         );
 
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "REQUEST_BODY_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "redirect_uri in request body is not a URL",
+        });
+
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
             error: "invalid_request",
-            error_description: "Invalid redirect_uri",
+            error_description: "Request body validation failed",
           }),
         });
       });
@@ -1051,9 +1106,8 @@ describe("Async Credential", () => {
               govuk_signin_journey_id: "mockGovukSigninJourneyId",
             }),
           });
-
           dependencies.getSessionService = () =>
-            new MockSessionServiceFailToCreateSession(
+            new MockSessionServiceCreateSessionFailure(
               env.SESSION_TABLE_NAME,
               env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
             );
@@ -1069,6 +1123,37 @@ describe("Async Credential", () => {
             body: JSON.stringify({
               error: "server_error",
               error_description: "Server Error",
+            }),
+          });
+        });
+      });
+
+      describe("Given the session has been created", () => {
+        it("Returns 201 session created response", async () => {
+          const jwtBuilder = new MockJWTBuilder();
+          const event = buildRequest({
+            headers: { Authorization: `Bearer ${jwtBuilder.getEncodedJwt()}` },
+            body: JSON.stringify({
+              state: "mockState",
+              sub: "mockSub",
+              client_id: "mockClientId",
+              govuk_signin_journey_id: "mockGovukSigninJourneyId",
+            }),
+          });
+          dependencies.getSessionService = () =>
+            new MockSessionServiceSessionCreated(
+              env.SESSION_TABLE_NAME,
+              env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
+            );
+
+          const result = await lambdaHandler(event, dependencies);
+
+          expect(result).toStrictEqual({
+            headers: { "Content-Type": "application/json" },
+            statusCode: 201,
+            body: JSON.stringify({
+              sub: "mockSub",
+              "https://vocab.account.gov.uk/v1/credentialStatus": "pending",
             }),
           });
         });
@@ -1310,7 +1395,7 @@ class MockSessionServiceSessionRecovered
   };
 }
 
-class MockSessionServiceFailToCreateSession
+class MockSessionServiceCreateSessionFailure
   implements IGetSessionBySub, ICreateSession
 {
   readonly tableName: string;

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1107,7 +1107,7 @@ describe("Async Credential", () => {
             }),
           });
           dependencies.getSessionService = () =>
-            new MockSessionServiceCreateSessionFailure(
+            new MockSessionServiceFailToCreateSession(
               env.SESSION_TABLE_NAME,
               env.SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME,
             );
@@ -1395,7 +1395,7 @@ class MockSessionServiceSessionRecovered
   };
 }
 
-class MockSessionServiceCreateSessionFailure
+class MockSessionServiceFailToCreateSession
   implements IGetSessionBySub, ICreateSession
 {
   readonly tableName: string;

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -81,6 +81,9 @@ export async function lambdaHandler(
   }
 
   if (event.body == null) {
+    logger.log("REQUEST_BODY_INVALID", {
+      errorMessage: "Missing request body",
+    });
     return badRequestResponse({
       error: "invalid_request",
       errorDescription: "Missing request body",
@@ -91,6 +94,9 @@ export async function lambdaHandler(
   try {
     parsedRequestBody = JSON.parse(event.body);
   } catch (error) {
+    logger.log("REQUEST_BODY_INVALID", {
+      errorMessage: "Invalid JSON in request body",
+    });
     return badRequestResponse({
       error: "invalid_request",
       errorDescription: "Invalid JSON in request body",
@@ -103,9 +109,12 @@ export async function lambdaHandler(
   );
 
   if (requestBodyValidationResponse.isError) {
+    logger.log("REQUEST_BODY_INVALID", {
+      errorMessage: requestBodyValidationResponse.value,
+    });
     return badRequestResponse({
       error: "invalid_request",
-      errorDescription: requestBodyValidationResponse.value as string,
+      errorDescription: "Request body validation failed",
     });
   }
 
@@ -359,7 +368,7 @@ const requestBodyValidator = (
 
   if (requestBody.client_id !== jwtClientId) {
     return errorResponse(
-      "client_id in request body does not match client_id in access token",
+      "client_id in request body does not match value in access_token",
     );
   }
 
@@ -371,7 +380,7 @@ const requestBodyValidator = (
     try {
       new URL(requestBody.redirect_uri);
     } catch (error) {
-      return errorResponse("Invalid redirect_uri");
+      return errorResponse("redirect_uri in request body is not a URL");
     }
   }
 

--- a/backend-api/src/functions/asyncCredential/registeredLogs.ts
+++ b/backend-api/src/functions/asyncCredential/registeredLogs.ts
@@ -9,7 +9,9 @@ export type MessageName =
   | "AUTHENTICATION_HEADER_INVALID"
   | "JWT_CLAIM_INVALID"
   | "ERROR_CREATING_SESSION"
-  | "SESSION_CREATED";
+  | "SESSION_CREATED"
+  | "REQUEST_BODY_INVALID"
+  | CommonMessageNames;
 
 export const registeredLogs: RegisteredLogMessages<MessageName> = {
   AUTHENTICATION_HEADER_INVALID: {
@@ -23,6 +25,9 @@ export const registeredLogs: RegisteredLogMessages<MessageName> = {
   },
   SESSION_CREATED: {
     messageCode: "MOBILE_ASYNC_SESSION_CREATED",
+  },
+  REQUEST_BODY_INVALID: {
+    messageCode: "MOBILE_ASYNC_REQUEST_BODY_INVALID",
   },
   ...commonMessages,
 };

--- a/backend-api/src/functions/asyncCredential/registeredLogs.ts
+++ b/backend-api/src/functions/asyncCredential/registeredLogs.ts
@@ -5,7 +5,6 @@ import {
 import { RegisteredLogMessages } from "../services/logging/types";
 
 export type MessageName =
-  | CommonMessageNames
   | "AUTHENTICATION_HEADER_INVALID"
   | "JWT_CLAIM_INVALID"
   | "ERROR_CREATING_SESSION"


### PR DESCRIPTION
​DCMAW-8264
### What changed
Log when request body for the Credential lambda does not pass validation. This does not include validation against the stored client array in SSM.

### Why did it change
Observability

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
