### PR TITLE
DCMAW-8264: Write issuedOn field when creating new session

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -231,6 +231,7 @@ export async function lambdaHandler(
     govukSigninJourneyId: govuk_signin_journey_id,
     redirectUri: redirect_uri,
     issuer: iss,
+    issuedOn: Date.now().toString(),
     sessionState: "ASYNC_AUTH_SESSION_CREATED",
   };
 

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
@@ -118,6 +118,7 @@ describe("Session Service", () => {
           redirectUri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
           sessionState: "mockSessionState",
+          issuedOn: "mockIssuedOn",
         });
 
         expect(result.isError).toBe(true);
@@ -145,6 +146,7 @@ describe("Session Service", () => {
           redirectUri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
           sessionState: "mockSessionState",
+          issuedOn: "mockIssuedOn",
         });
 
         expect(result.isError).toBe(true);
@@ -169,6 +171,7 @@ describe("Session Service", () => {
           redirectUri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
           sessionState: "mockSessionState",
+          issuedOn: "mockIssuedOn",
         });
 
         expect(result.isError).toBe(true);
@@ -193,6 +196,7 @@ describe("Session Service", () => {
             govukSigninJourneyId: "mockJourneyId",
             issuer: "mockIssuer",
             sessionState: "mockSessionState",
+            issuedOn: "mockIssuedOn",
           });
 
           expect(result.isError).toBe(false);
@@ -215,6 +219,7 @@ describe("Session Service", () => {
             redirectUri: "https://mockRedirectUri.com",
             issuer: "mockIssuer",
             sessionState: "mockSessionState",
+            issuedOn: "mockIssuedOn",
           });
 
           expect(result.isError).toBe(false);

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -84,6 +84,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
         govukSigninJourneyId: { S: sessionConfig.govukSigninJourneyId },
         issuer: { S: sessionConfig.issuer },
         sessionState: { S: sessionConfig.sessionState },
+        issuedOn: { S: sessionConfig.issuedOn },
       },
     };
 
@@ -154,6 +155,7 @@ interface IAuthSession {
   govukSigninJourneyId: string;
   issuer: string;
   sessionState: string;
+  issuedOn: string;
   redirectUri?: string;
 }
 
@@ -167,6 +169,7 @@ interface IPutAuthSessionConfig {
     govukSigninJourneyId: { S: string };
     issuer: { S: string };
     sessionState: { S: string };
+    issuedOn: { S: string };
     redirectUri?: { S: string };
   };
 }


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8264
### What changed
Write `issuedOn` value into session

### Why did it change
This value will be used when the lambda initially checks for any active sessions before creating a new session

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
