### PR TITLE
DCMAW-9802: Remove client id from txma events

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -252,7 +252,6 @@ export async function lambdaHandler(
     sub,
     sessionId,
     govukSigninJourneyId: govuk_signin_journey_id,
-    clientId: client_id,
     getNowInMilliseconds: Date.now,
     componentId: config.ISSUER,
   });

--- a/backend-api/src/functions/services/events/eventService.test.ts
+++ b/backend-api/src/functions/services/events/eventService.test.ts
@@ -16,7 +16,6 @@ describe("Event Service", () => {
           sub: "mockSub",
           sessionId: "mockSessionId",
           govukSigninJourneyId: "mockGovukSigninJourneyId",
-          clientId: "mockClientId",
           getNowInMilliseconds: () => 1609462861,
           componentId: "mockComponentId",
         });
@@ -37,7 +36,6 @@ describe("Event Service", () => {
           sub: "mockSub",
           sessionId: "mockSessionId",
           govukSigninJourneyId: "mockGovukSigninJourneyId",
-          clientId: "mockClientId",
           getNowInMilliseconds: () => 1609462861,
           componentId: "mockComponentId",
         });

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -42,7 +42,6 @@ export class EventService implements IEventService {
         session_id: eventConfig.sessionId,
         govuk_signin_journey_id: eventConfig.govukSigninJourneyId,
       },
-      client_id: eventConfig.clientId,
       timestamp: eventConfig.getNowInMilliseconds(),
       event_name: eventConfig.eventName,
       component_id: eventConfig.componentId,
@@ -63,7 +62,6 @@ interface ITxmaEvent {
     session_id: string;
     govuk_signin_journey_id: string;
   };
-  client_id: string;
   timestamp: number;
   event_name: EventName;
   component_id: string;
@@ -74,7 +72,6 @@ export interface IEventConfig {
   sub: string;
   sessionId: string;
   govukSigninJourneyId: string;
-  clientId: string;
   getNowInMilliseconds: () => number;
   componentId: string;
 }


### PR DESCRIPTION
​DCMAW-9802
### What changed
Removed the client id field from TxMA events

### Why did it change
TxMA have requested that this field should only be used for including the ID for external RPs (not IPVCore). TxMA have confirmed that this field is optional so removing it entirely,.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [x] Demo to a BA, TA, and the team.
- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
