### PR TITLE
DCMAW-9802: Refactor session creation

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1407,8 +1407,8 @@ class MockSessionServiceGetSessionBySubFailure
     return errorResponse("Mock failing DB call");
   };
 
-  createSession = async (): Promise<ErrorOrSuccess<null>> => {
-    return successResponse(null);
+  createSession = async (): Promise<ErrorOrSuccess<string>> => {
+    return successResponse("mockSessionId");
   };
 }
 
@@ -1426,8 +1426,8 @@ class MockSessionServiceNoActiveSession
     return successResponse(null);
   };
 
-  createSession = async (): Promise<ErrorOrSuccess<null>> => {
-    return successResponse(null);
+  createSession = async (): Promise<ErrorOrSuccess<string>> => {
+    return successResponse("mockSessionId");
   };
 }
 
@@ -1446,8 +1446,8 @@ class MockSessionServiceActiveSessionFound
     return successResponse("mockSessionId");
   };
 
-  createSession = async (): Promise<ErrorOrSuccess<null>> => {
-    return successResponse(null);
+  createSession = async (): Promise<ErrorOrSuccess<string>> => {
+    return successResponse("mockSessionId");
   };
 }
 
@@ -1466,7 +1466,7 @@ class MockSessionServiceFailToCreateSession
     return successResponse(null);
   };
 
-  createSession = async (): Promise<ErrorOrSuccess<null>> => {
+  createSession = async (): Promise<ErrorOrSuccess<string>> => {
     return errorResponse("Mock error");
   };
 }
@@ -1486,7 +1486,7 @@ class MockSessionServiceSessionCreated
     return successResponse(null);
   };
 
-  createSession = async (): Promise<ErrorOrSuccess<null>> => {
-    return successResponse(null);
+  createSession = async (): Promise<ErrorOrSuccess<string>> => {
+    return successResponse("mockSessionId");
   };
 }

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -1272,7 +1272,7 @@ describe("Async Credential", () => {
             );
 
             expect(mockLogger.getLogMessages()[0].logMessage.sessionId).toEqual(
-              expect.any(String),
+              "mockSessionId",
             );
 
             expect(result).toStrictEqual({

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -14,7 +14,6 @@ import {
   ICreateSession,
   IGetActiveSession,
 } from "./sessionService/sessionService";
-import { randomUUID } from "crypto";
 import { Logger } from "../services/logging/logger";
 import { MessageName } from "./registeredLogs";
 import { IGetClientCredentials } from "../asyncToken/ssmService/ssmService";
@@ -189,12 +188,12 @@ export async function lambdaHandler(
     return activeSessionFoundResponse(requestBody.sub);
   }
 
-  const sessionId = randomUUID();
   const sessionServiceCreateSessionResult = await sessionService.createSession(
-    sessionId,
     requestBody,
     jwtPayload.iss,
   );
+
+  const sessionId = sessionServiceCreateSessionResult.value;
 
   const eventService = dependencies.eventService(config.SQS_QUEUE);
 

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -188,10 +188,10 @@ export async function lambdaHandler(
     return activeSessionFoundResponse(requestBody.sub);
   }
 
-  const sessionServiceCreateSessionResult = await sessionService.createSession(
-    requestBody,
-    jwtPayload.iss,
-  );
+  const sessionServiceCreateSessionResult = await sessionService.createSession({
+    ...requestBody,
+    issuer: jwtPayload.iss,
+  });
 
   const sessionId = sessionServiceCreateSessionResult.value;
 

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
@@ -109,17 +109,17 @@ describe("Session Service", () => {
         const dbMock = mockClient(DynamoDBClient);
         dbMock.on(GetItemCommand).rejects("Mock DB Error");
 
-        const result = await service.createSession({
-          sessionId: "137d5a4b-3046-456d-986a-147e0469cf62",
-          state: "mockValidState",
-          sub: "mockSub",
-          clientId: "mockClientId",
-          govukSigninJourneyId: "mockJourneyId",
-          redirectUri: "https://mockRedirectUri.com",
-          issuer: "mockIssuer",
-          sessionState: "mockSessionState",
-          issuedOn: "mockIssuedOn",
-        });
+        const result = await service.createSession(
+          "137d5a4b-3046-456d-986a-147e0469cf62",
+          {
+            state: "mockValidState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockJourneyId",
+            redirect_uri: "https://mockRedirectUri.com",
+          },
+          "mockIssuer",
+        );
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -137,17 +137,17 @@ describe("Session Service", () => {
           },
         });
 
-        const result = await service.createSession({
-          sessionId: "137d5a4b-3046-456d-986a-147e0469cf62",
-          state: "mockValidState",
-          sub: "mockSub",
-          clientId: "mockClientId",
-          govukSigninJourneyId: "mockJourneyId",
-          redirectUri: "https://mockRedirectUri.com",
-          issuer: "mockIssuer",
-          sessionState: "mockSessionState",
-          issuedOn: "mockIssuedOn",
-        });
+        const result = await service.createSession(
+          "137d5a4b-3046-456d-986a-147e0469cf62",
+          {
+            state: "mockValidState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockJourneyId",
+            redirect_uri: "https://mockRedirectUri.com",
+          },
+          "mockIssuer",
+        );
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -162,17 +162,17 @@ describe("Session Service", () => {
         dbMock.on(GetItemCommand).resolves({});
         dbMock.on(PutItemCommand).rejects("Mock DB Error");
 
-        const result = await service.createSession({
-          sessionId: "137d5a4b-3046-456d-986a-147e0469cf62",
-          state: "mockValidState",
-          sub: "mockSub",
-          clientId: "mockClientId",
-          govukSigninJourneyId: "mockJourneyId",
-          redirectUri: "https://mockRedirectUri.com",
-          issuer: "mockIssuer",
-          sessionState: "mockSessionState",
-          issuedOn: "mockIssuedOn",
-        });
+        const result = await service.createSession(
+          "137d5a4b-3046-456d-986a-147e0469cf62",
+          {
+            state: "mockValidState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockJourneyId",
+            redirect_uri: "https://mockRedirectUri.com",
+          },
+          "mockIssuer",
+        );
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -188,16 +188,16 @@ describe("Session Service", () => {
           dbMock.on(GetItemCommand).resolves({});
           dbMock.on(PutItemCommand).resolves({});
 
-          const result = await service.createSession({
-            sessionId: "137d5a4b-3046-456d-986a-147e0469cf62",
-            state: "mockValidState",
-            sub: "mockSub",
-            clientId: "mockClientId",
-            govukSigninJourneyId: "mockJourneyId",
-            issuer: "mockIssuer",
-            sessionState: "mockSessionState",
-            issuedOn: "mockIssuedOn",
-          });
+          const result = await service.createSession(
+            "137d5a4b-3046-456d-986a-147e0469cf62",
+            {
+              state: "mockValidState",
+              sub: "mockSub",
+              client_id: "mockClientId",
+              govuk_signin_journey_id: "mockJourneyId",
+            },
+            "mockIssuer",
+          );
 
           expect(result.isError).toBe(false);
           expect(result.value).toEqual(null);
@@ -210,17 +210,17 @@ describe("Session Service", () => {
           dbMock.on(GetItemCommand).resolves({});
           dbMock.on(PutItemCommand).resolves({});
 
-          const result = await service.createSession({
-            sessionId: "137d5a4b-3046-456d-986a-147e0469cf62",
-            state: "mockValidState",
-            sub: "mockSub",
-            clientId: "mockClientId",
-            govukSigninJourneyId: "mockJourneyId",
-            redirectUri: "https://mockRedirectUri.com",
-            issuer: "mockIssuer",
-            sessionState: "mockSessionState",
-            issuedOn: "mockIssuedOn",
-          });
+          const result = await service.createSession(
+            "137d5a4b-3046-456d-986a-147e0469cf62",
+            {
+              state: "mockValidState",
+              sub: "mockSub",
+              client_id: "mockClientId",
+              govuk_signin_journey_id: "mockJourneyId",
+              redirect_uri: "https://mockRedirectUri.com",
+            },
+            "mockIssuer",
+          );
 
           expect(result.isError).toBe(false);
           expect(result.value).toEqual(null);

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
@@ -109,16 +109,14 @@ describe("Session Service", () => {
         const dbMock = mockClient(DynamoDBClient);
         dbMock.on(GetItemCommand).rejects("Mock DB Error");
 
-        const result = await service.createSession(
-          {
-            state: "mockValidState",
-            sub: "mockSub",
-            client_id: "mockClientId",
-            govuk_signin_journey_id: "mockJourneyId",
-            redirect_uri: "https://mockRedirectUri.com",
-          },
-          "mockIssuer",
-        );
+        const result = await service.createSession({
+          state: "mockValidState",
+          sub: "mockSub",
+          client_id: "mockClientId",
+          govuk_signin_journey_id: "mockJourneyId",
+          redirect_uri: "https://mockRedirectUri.com",
+          issuer: "mockIssuer",
+        });
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -136,16 +134,14 @@ describe("Session Service", () => {
           },
         });
 
-        const result = await service.createSession(
-          {
-            state: "mockValidState",
-            sub: "mockSub",
-            client_id: "mockClientId",
-            govuk_signin_journey_id: "mockJourneyId",
-            redirect_uri: "https://mockRedirectUri.com",
-          },
-          "mockIssuer",
-        );
+        const result = await service.createSession({
+          state: "mockValidState",
+          sub: "mockSub",
+          client_id: "mockClientId",
+          govuk_signin_journey_id: "mockJourneyId",
+          redirect_uri: "https://mockRedirectUri.com",
+          issuer: "mockIssuer",
+        });
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -160,16 +156,14 @@ describe("Session Service", () => {
         dbMock.on(GetItemCommand).resolves({});
         dbMock.on(PutItemCommand).rejects("Mock DB Error");
 
-        const result = await service.createSession(
-          {
-            state: "mockValidState",
-            sub: "mockSub",
-            client_id: "mockClientId",
-            govuk_signin_journey_id: "mockJourneyId",
-            redirect_uri: "https://mockRedirectUri.com",
-          },
-          "mockIssuer",
-        );
+        const result = await service.createSession({
+          state: "mockValidState",
+          sub: "mockSub",
+          client_id: "mockClientId",
+          govuk_signin_journey_id: "mockJourneyId",
+          redirect_uri: "https://mockRedirectUri.com",
+          issuer: "mockIssuer",
+        });
 
         expect(result.isError).toBe(true);
         expect(result.value).toEqual(
@@ -185,15 +179,13 @@ describe("Session Service", () => {
           dbMock.on(GetItemCommand).resolves({});
           dbMock.on(PutItemCommand).resolves({});
 
-          const result = await service.createSession(
-            {
-              state: "mockValidState",
-              sub: "mockSub",
-              client_id: "mockClientId",
-              govuk_signin_journey_id: "mockJourneyId",
-            },
-            "mockIssuer",
-          );
+          const result = await service.createSession({
+            state: "mockValidState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockJourneyId",
+            issuer: "mockIssuer",
+          });
 
           expect(result.isError).toBe(false);
           expect(typeof result.value).toBe("string");
@@ -206,16 +198,14 @@ describe("Session Service", () => {
           dbMock.on(GetItemCommand).resolves({});
           dbMock.on(PutItemCommand).resolves({});
 
-          const result = await service.createSession(
-            {
-              state: "mockValidState",
-              sub: "mockSub",
-              client_id: "mockClientId",
-              govuk_signin_journey_id: "mockJourneyId",
-              redirect_uri: "https://mockRedirectUri.com",
-            },
-            "mockIssuer",
-          );
+          const result = await service.createSession({
+            state: "mockValidState",
+            sub: "mockSub",
+            client_id: "mockClientId",
+            govuk_signin_journey_id: "mockJourneyId",
+            redirect_uri: "https://mockRedirectUri.com",
+            issuer: "mockIssuer",
+          });
 
           expect(result.isError).toBe(false);
           expect(typeof result.value).toBe("string");

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.test.ts
@@ -110,7 +110,6 @@ describe("Session Service", () => {
         dbMock.on(GetItemCommand).rejects("Mock DB Error");
 
         const result = await service.createSession(
-          "137d5a4b-3046-456d-986a-147e0469cf62",
           {
             state: "mockValidState",
             sub: "mockSub",
@@ -138,7 +137,6 @@ describe("Session Service", () => {
         });
 
         const result = await service.createSession(
-          "137d5a4b-3046-456d-986a-147e0469cf62",
           {
             state: "mockValidState",
             sub: "mockSub",
@@ -163,7 +161,6 @@ describe("Session Service", () => {
         dbMock.on(PutItemCommand).rejects("Mock DB Error");
 
         const result = await service.createSession(
-          "137d5a4b-3046-456d-986a-147e0469cf62",
           {
             state: "mockValidState",
             sub: "mockSub",
@@ -189,7 +186,6 @@ describe("Session Service", () => {
           dbMock.on(PutItemCommand).resolves({});
 
           const result = await service.createSession(
-            "137d5a4b-3046-456d-986a-147e0469cf62",
             {
               state: "mockValidState",
               sub: "mockSub",
@@ -200,7 +196,7 @@ describe("Session Service", () => {
           );
 
           expect(result.isError).toBe(false);
-          expect(result.value).toEqual(null);
+          expect(typeof result.value).toBe("string");
         });
       });
 
@@ -211,7 +207,6 @@ describe("Session Service", () => {
           dbMock.on(PutItemCommand).resolves({});
 
           const result = await service.createSession(
-            "137d5a4b-3046-456d-986a-147e0469cf62",
             {
               state: "mockValidState",
               sub: "mockSub",
@@ -223,7 +218,7 @@ describe("Session Service", () => {
           );
 
           expect(result.isError).toBe(false);
-          expect(result.value).toEqual(null);
+          expect(typeof result.value).toBe("string");
         });
       });
     });

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -113,7 +113,10 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     );
   }
 
-  private buildPutItemCommandInput(sessionId: string, config: ICreateSessionConfig) {
+  private buildPutItemCommandInput(
+    sessionId: string,
+    config: ICreateSessionConfig,
+  ) {
     const {
       state,
       sub,

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -85,7 +85,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       issuer,
     } = config;
 
-    const putAuthSessionConfig: IPutAuthSessionConfig = {
+    const putSessionConfig: IPutSessionConfig = {
       TableName: this.tableName,
       Item: {
         sessionId: { S: sessionId },
@@ -100,7 +100,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     };
 
     if (redirect_uri) {
-      putAuthSessionConfig.Item.redirectUri = { S: redirect_uri };
+      putSessionConfig.Item.redirectUri = { S: redirect_uri };
     }
 
     let doesSessionExist;
@@ -117,7 +117,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     }
 
     try {
-      await this.putSessionInDb(putAuthSessionConfig);
+      await this.putSessionInDb(putSessionConfig);
     } catch (error) {
       return errorResponse(
         "Unexpected error when querying session table whilst creating a session",
@@ -151,12 +151,12 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     return output.Item != null;
   }
 
-  private async putSessionInDb(config: IPutAuthSessionConfig) {
+  private async putSessionInDb(config: IPutSessionConfig) {
     await dbClient.send(new PutItemCommand(config));
   }
 }
 
-interface IPutAuthSessionConfig {
+interface IPutSessionConfig {
   TableName: string;
   Item: {
     sessionId: { S: string };

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -76,32 +76,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     config: ICreateSessionConfig,
   ): Promise<ErrorOrSuccess<string>> {
     const sessionId = randomUUID();
-    const {
-      state,
-      sub,
-      client_id,
-      govuk_signin_journey_id,
-      redirect_uri,
-      issuer,
-    } = config;
-
-    const putSessionConfig: IPutSessionConfig = {
-      TableName: this.tableName,
-      Item: {
-        sessionId: { S: sessionId },
-        state: { S: state },
-        sub: { S: sub },
-        clientId: { S: client_id },
-        govukSigninJourneyId: { S: govuk_signin_journey_id },
-        issuer: { S: issuer },
-        sessionState: { S: "ASYNC_AUTH_SESSION_CREATED" },
-        issuedOn: { S: Date.now().toString() },
-      },
-    };
-
-    if (redirect_uri) {
-      putSessionConfig.Item.redirectUri = { S: redirect_uri };
-    }
+    const putSessionConfig = this.buildSession(sessionId, config);
 
     let doesSessionExist;
     try {
@@ -136,6 +111,37 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       result.Items[0].sessionId != null &&
       result.Items[0].sessionId.S !== ""
     );
+  }
+
+  private buildSession(sessionId: string, config: ICreateSessionConfig) {
+    const {
+      state,
+      sub,
+      client_id,
+      govuk_signin_journey_id,
+      redirect_uri,
+      issuer,
+    } = config;
+
+    const putSessionConfig: IPutSessionConfig = {
+      TableName: this.tableName,
+      Item: {
+        sessionId: { S: sessionId },
+        state: { S: state },
+        sub: { S: sub },
+        clientId: { S: client_id },
+        govukSigninJourneyId: { S: govuk_signin_journey_id },
+        issuer: { S: issuer },
+        sessionState: { S: "ASYNC_AUTH_SESSION_CREATED" },
+        issuedOn: { S: Date.now().toString() },
+      },
+    };
+
+    if (redirect_uri) {
+      putSessionConfig.Item.redirectUri = { S: redirect_uri };
+    }
+
+    return putSessionConfig;
   }
 
   private async checkSessionsExists(sessionId: string): Promise<boolean> {

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -85,7 +85,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       issuer,
     } = config;
 
-    const putItemCommandConfig: IPutAuthSessionConfig = {
+    const putAuthSessionConfig: IPutAuthSessionConfig = {
       TableName: this.tableName,
       Item: {
         sessionId: { S: sessionId },
@@ -100,7 +100,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     };
 
     if (redirect_uri) {
-      putItemCommandConfig.Item.redirectUri = { S: redirect_uri };
+      putAuthSessionConfig.Item.redirectUri = { S: redirect_uri };
     }
 
     let doesSessionExist;
@@ -117,7 +117,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     }
 
     try {
-      await this.putSessionInDb(putItemCommandConfig);
+      await this.putSessionInDb(putAuthSessionConfig);
     } catch (error) {
       return errorResponse(
         "Unexpected error when querying session table whilst creating a session",

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -13,6 +13,7 @@ import {
   successResponse,
 } from "../../types/errorOrValue";
 import { IRequestBody } from "../asyncCredentialHandler";
+import { randomUUID } from "crypto";
 
 export class SessionService implements IGetActiveSession, ICreateSession {
   readonly tableName: string;
@@ -73,12 +74,12 @@ export class SessionService implements IGetActiveSession, ICreateSession {
   }
 
   async createSession(
-    sessionId: string,
     requestBody: IRequestBody,
     issuer: string,
-  ): Promise<ErrorOrSuccess<null>> {
+  ): Promise<ErrorOrSuccess<string>> {
     const { sub, client_id, govuk_signin_journey_id, redirect_uri, state } =
       requestBody;
+    const sessionId = randomUUID();
 
     const config: IPutAuthSessionConfig = {
       TableName: this.tableName,
@@ -119,7 +120,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       );
     }
 
-    return successResponse(null);
+    return successResponse(sessionId);
   }
 
   private hasValidSession(
@@ -175,10 +176,9 @@ export interface IGetActiveSession {
 
 export interface ICreateSession {
   createSession: (
-    sessionId: string,
     requestBody: IRequestBody,
     issuer: string,
-  ) => Promise<ErrorOrSuccess<null>>;
+  ) => Promise<ErrorOrSuccess<string>>;
 }
 
 type IQueryCommandOutputType = {

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -76,7 +76,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     config: ICreateSessionConfig,
   ): Promise<ErrorOrSuccess<string>> {
     const sessionId = randomUUID();
-    const putSessionConfig = this.buildSession(sessionId, config);
+    const putSessionConfig = this.buildPutItemCommandInput(sessionId, config);
 
     let doesSessionExist;
     try {
@@ -113,7 +113,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
     );
   }
 
-  private buildSession(sessionId: string, config: ICreateSessionConfig) {
+  private buildPutItemCommandInput(sessionId: string, config: ICreateSessionConfig) {
     const {
       state,
       sub,


### PR DESCRIPTION
​DCMAW-9802

### What changed

- Refactors creating a session to reduce the length of the /credential Lambda by moving logic to the Session Service.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
