### PR TITLE
DCMAW-9848: Fix npm package.json path in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "npm"
-    directory: "src"
+    directory: "backend-api/src"
     schedule:
       interval: "weekly"
       day: "tuesday"


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-9848] PR Title` -->
​DCMAW-9848
### What changed
Updated dependabot config

### Why did it change
package.json location has moved

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DCMAW-9848]: https://govukverify.atlassian.net/browse/DCMAW-9848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ