### PR TITLE
[DCMAW-9808] Supporting infra - alarms

### DIFF
--- a/infra/templates/alarms-chatbot/template.yaml
+++ b/infra/templates/alarms-chatbot/template.yaml
@@ -1,0 +1,165 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Connects SNS topics used for alarts to Slack chatbot
+
+Parameters:
+  Environment:
+    Description: The environment type
+    Type: String
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+    Default: dev
+
+  SlackWorkspaceId:
+    Description: |
+      The ID of the Slack workspace where notification messages are posted.
+    Type: String
+    AllowedPattern: \w+
+    ConstraintDescription: Must be an AWS Chatbot Slack workspace ID
+
+  SlackChannelIdWarning:
+    Description: |
+      The ID of the Slack channel where Warning notifications are posted
+    Type: String
+    AllowedPattern: \w+
+    ConstraintDescription: Must be a Slack Channel ID
+
+  SlackChannelIdCritical:
+    Description: |
+      The ID of the Slack channel where Critical notifications are posted
+    Type: String
+    AllowedPattern: \w+
+    ConstraintDescription: Must be a Slack Channel ID
+
+  SlackChannelId2ndLine:
+    Description: |
+      The ID of the Slack channel where Critical notifications are posted - 2nd Line
+    Type: String
+    Default: none
+    AllowedPattern: \w+
+    ConstraintDescription: Must be a Slack Channel ID
+
+  SNSTopicsCritical:
+    Description: Comma delimited list of SNS Topics for the Alert chatbot.
+    Type: CommaDelimitedList
+    Default: none
+
+  SNSTopicsWarning:
+    Description: Comma delimited list of SNS Topics for the Warning chatbot.
+    Type: CommaDelimitedList
+    Default: none
+
+  InitialNotificationStack:
+    Description: '(Optional) Is this the first notification stack to be created in
+      this account? Controls the creation of the service linked role which only needs to be created once.
+      '
+    Type: String
+    Default: 'Yes'
+    AllowedValues:
+    - 'Yes'
+    - 'No'
+
+Conditions:
+  Deploy2ndLineConfiguration: !And
+    - !Not
+      - !Equals
+        - !Ref SlackChannelId2ndLine
+        - none
+    - !Not
+      - !Equals
+        - !Select
+          - 0
+          - !Ref SNSTopicsCritical
+        - none
+
+  DeployCriticalConfiguration: !Not
+    - !Equals
+      - !Select
+        - 0
+        - !Ref SNSTopicsCritical
+      - none
+
+  DeployWarningConfiguration: !Not
+    - !Equals
+      - !Select
+        - 0
+        - !Ref SNSTopicsWarning
+      - none
+
+  DeployServiceLinkedRole: !Equals
+    - !Ref InitialNotificationStack
+    - 'Yes'
+
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  ChatbotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: chatbot.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-ChatbotRole
+        - Key: Product
+          Value: Gov.UK Sign On
+        - Key: System
+          Value: Document Checking App
+        - Key: Environment
+          Value: !Ref Environment
+
+  ChatbotChannelCriticalConfiguration:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: DeployCriticalConfiguration
+    Properties:
+      ConfigurationName: !Sub ${AWS::StackName}-critical-notifications
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SlackChannelId: !Ref SlackChannelIdCritical
+      LoggingLevel: INFO
+      SnsTopicArns: !Ref SNSTopicsCritical
+
+  ChatbotChannelAlertConfigurationDi2ndLine:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: Deploy2ndLineConfiguration
+    Properties:
+      ConfigurationName: !Sub ${AWS::StackName}-2nd-line-notifications
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SlackChannelId: !Ref SlackChannelId2ndLine
+      LoggingLevel: INFO
+      SnsTopicArns: !Ref SNSTopicsCritical
+
+  ChatbotChannelWarningConfiguration:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: DeployWarningConfiguration
+    Properties:
+      ConfigurationName: !Sub ${AWS::StackName}-warning-notifications
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SlackChannelId: !Ref SlackChannelIdWarning
+      LoggingLevel: INFO
+      SnsTopicArns: !Ref SNSTopicsWarning
+
+  ChatbotServiceLinkedRole:
+    Condition: DeployServiceLinkedRole
+    DeletionPolicy: Retain
+    Type: AWS::IAM::ServiceLinkedRole
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3011 # The UpdateReplacePolicy does not apply to this resource
+    Properties:
+      AWSServiceName: management.chatbot.amazonaws.com

--- a/infra/templates/alarms-sns/template.yaml
+++ b/infra/templates/alarms-sns/template.yaml
@@ -1,0 +1,119 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Create SNS topics for configuring alerting systems, e.g. Slack
+
+Parameters:
+  Environment:
+    Description: The environment type
+    Type: String
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+    Default: dev
+
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  AlarmCriticalSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub ${AWS::StackName}-critical
+      KmsMasterKeyId: !Ref AlarmSNSTopicKey
+      FifoTopic: false
+      Tags:
+        - Key: Product
+          Value: Gov.UK Sign On
+        - Key: System
+          Value: Document Checking App
+        - Key: Environment
+          Value: !Ref Environment
+      TopicName: !Sub ${AWS::StackName}-critical
+
+  AlarmWarningSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub ${AWS::StackName}-warning
+      KmsMasterKeyId: !Ref AlarmSNSTopicKey
+      FifoTopic: false
+      Tags:
+        - Key: Product
+          Value: Gov.UK Sign On
+        - Key: System
+          Value: Document Checking App
+        - Key: Environment
+          Value: !Ref Environment
+      TopicName: !Sub ${AWS::StackName}-warning
+
+  AlarmCriticalSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref AlarmCriticalSNSTopic
+      PolicyDocument:
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Resource: !Ref AlarmCriticalSNSTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+
+  AlarmWarningSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref AlarmWarningSNSTopic
+      PolicyDocument:
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Resource: !Ref AlarmWarningSNSTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+
+  AlarmSNSTopicKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: Allow Cloudwatch to enqueue encrypted messages
+            Effect: Allow
+            Resource: '*'
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Principal:
+              Service: cloudwatch.amazonaws.com
+          - Sid: Allow the account to manage the key
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-topics
+        - Key: Product
+          Value: Gov.UK Sign On
+        - Key: System
+          Value: Document Checking App
+        - Key: Environment
+          Value: !Ref Environment
+
+Outputs:
+  AlarmWarningSNSTopic:
+    Description: The SNS Arn of the Warnings Alarm Topic
+    Value: !Ref AlarmWarningSNSTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-topic-warning
+
+  AlarmCriticalSNSTopic:
+    Description: The SNS Arn of the Critical Alarm Topic
+    Value: !Ref AlarmCriticalSNSTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-topic-critical

--- a/infra/templates/kms/template.yaml
+++ b/infra/templates/kms/template.yaml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: |
+  kms
   A set of KMS resources to handle Encryption and Signing at account level
 
 Parameters:


### PR DESCRIPTION
Ticket: https://govukverify.atlassian.net/browse/DCMAW-9808 

This copies across the templates required to create sns topics and chatbot integrations used for slack notifications. There have been some changes to the templates to remove hardcoding the slack channel IDs. 

