### PR TITLE
[DCMAW-9786] Add dev platform assets to enable testing in codebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ samconfig.toml
 
 cf-output.txt
 docker-vars.env
+
+# VSCode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 
 # Jest test report
-report.xml 
+report.xml
 
 # Jest code coverage output
 coverage/
@@ -9,3 +9,6 @@ coverage/
 # AWS SAM
 .aws-sam/
 samconfig.toml
+
+cf-output.txt
+docker-vars.env

--- a/backend-api/Dockerfile.test
+++ b/backend-api/Dockerfile.test
@@ -16,7 +16,7 @@ RUN aws --version
 
 # Copy the CloudFormation infrastructure template and application source code to the working directory
 COPY template.yaml /
-COPY src ./
+COPY template.yaml src openApiSpecs infra-tests eslint.config.mjs jest.config.ts tsconfig.json ./
 
 # Give user, 'test', permissions to execute test script and switch the user to 'test'
 COPY run-tests.sh /

--- a/backend-api/Dockerfile.test
+++ b/backend-api/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:iron-alpine AS builder
+FROM node:iron-alpine
 
 WORKDIR /backend-api
 

--- a/backend-api/Dockerfile.test
+++ b/backend-api/Dockerfile.test
@@ -7,7 +7,7 @@ RUN adduser --disabled-password test
 RUN chown test .
 
 COPY package.json package-lock.json ./
-RUN npm install
+RUN npm install --ignore-scripts
 
 
 ## Update container and install awscli

--- a/backend-api/Dockerfile.test
+++ b/backend-api/Dockerfile.test
@@ -1,0 +1,26 @@
+FROM node:iron-alpine AS builder
+
+WORKDIR /backend-api
+
+# Create a new user 'test' to avoid running the app as a root
+RUN adduser --disabled-password test
+RUN chown test .
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+
+## Update container and install awscli
+RUN apk upgrade && apk update; apk add --no-cache aws-cli bash
+RUN aws --version
+
+# Copy the CloudFormation infrastructure template and application source code to the working directory
+COPY template.yaml /
+COPY src ./
+
+# Give user, 'test', permissions to execute test script and switch the user to 'test'
+COPY run-tests.sh /
+RUN chmod 005 /run-tests.sh
+USER test
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/backend-api/Dockerfile.test
+++ b/backend-api/Dockerfile.test
@@ -3,16 +3,14 @@ FROM node:iron-alpine AS builder
 WORKDIR /backend-api
 
 # Create a new user 'test' to avoid running the app as a root
-RUN adduser --disabled-password test
-RUN chown test .
+RUN adduser --disabled-password test && chown test .
 
 COPY package.json package-lock.json ./
 RUN npm install --ignore-scripts
 
 
-## Update container and install awscli
-RUN apk upgrade && apk update; apk add --no-cache aws-cli bash
-RUN aws --version
+## Update container, install awscli and check awscli is installed correctly
+RUN apk upgrade && apk update; apk add --no-cache bash aws-cli && aws --version
 
 # Copy the CloudFormation infrastructure template and application source code to the working directory
 COPY template.yaml /

--- a/backend-api/run-tests-locally.sh
+++ b/backend-api/run-tests-locally.sh
@@ -3,7 +3,7 @@ set -eu
 
 stack_name=${1:-mob-async-backend}
 
-echo Running test against "${stack_name}"
+echo "Running test against ${stack_name}"
 
 rm -rf docker-vars.env
 

--- a/backend-api/run-tests-locally.sh
+++ b/backend-api/run-tests-locally.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+
+stack_name=${1:-mob-async-backend}
+
+echo Running test against "${stack_name}"
+
+rm -rf docker-vars.env
+
+export AWS_DEFAULT_REGION="eu-west-2"
+TEST_REPORT_DIR="results"
+ENVIRONMENT="dev"
+
+aws cloudformation describe-stacks \
+  --stack-name "$stack_name" \
+  --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' \
+  --output text >cf-output.txt
+
+eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt >>docker-vars.env
+
+{
+  echo TEST_REPORT_DIR="$TEST_REPORT_DIR"
+  echo TEST_REPORT_ABSOLUTE_DIR="/results"
+  echo TEST_ENVIRONMENT="$ENVIRONMENT"
+  echo SAM_STACK_NAME="$stack_name"
+} >>docker-vars.env
+
+docker build --file Dockerfile.test --tag testcontainer .
+
+docker run --rm --interactive --tty \
+  --user root \
+  --env-file docker-vars.env \
+  --volume "$(pwd):/results" \
+  testcontainer

--- a/backend-api/run-tests.sh
+++ b/backend-api/run-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eu
+
+cd /backend-api
+
+mkdir -pv results
+
+if npm run test:unit --ci --silent; then
+  cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+else
+  cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+  exit 1
+fi
+
+# if [[ "$ENVIRONMENT" == "dev" ]] || [[ "$ENVIRONMENT" == "build" ]]; then
+#   if npm run test:e2e --ci --silent; then
+#     cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+#   else
+#     cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+#     exit 1
+#   fi
+# elif [[ "$ENVIRONMENT" == "staging" ]]; then
+#   if npm run test:stage --ci --silent; then
+#     cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+#   else
+#     cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+#     exit 1
+#   fi
+# fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=mobile-id-check-async
 sonar.organization=govuk-one-login
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=backend-api/src
+sonar.sources=backend-api/src,backend-api/Dockerfile.test
 sonar.javascript.lcov.reportPaths=backend-api/coverage/lcov.info
 sonar.language=ts
 sonar.exclusions=**/*.test.ts,**/*.test.js,**/testUtils/**,**/tests/mocks.ts


### PR DESCRIPTION
DCMAW-9786

This change includes building out the test container to be used in the dev, build and staging deployments. This is a pre-requisite for creating a post-merge Github action, which will be included in a subsequent PR.

