### PR TITLE
DCMAW-9906: Fix token-issued txma event schema

### DIFF
--- a/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
@@ -102,6 +102,7 @@ export async function lambdaHandlerConstructor(
     componentId: config.ISSUER,
     getNowInMilliseconds: Date.now,
     eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
+    clientId: clientCredentials.clientId,
   });
   if (writeEventResult.isError) {
     logger.log("ERROR_WRITING_AUDIT_EVENT", {

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -61,10 +61,15 @@ export class EventService implements IEventService {
   private buildCredentialTokenIssuedEvent = (
     eventConfig: CredentialTokenIssuedEventConfig,
   ): CredentialTokenIssuedEvent => {
+    const timestampInMillis = eventConfig.getNowInMilliseconds();
     return {
       event_name: eventConfig.eventName,
       component_id: eventConfig.componentId,
-      timestamp: eventConfig.getNowInMilliseconds(),
+      timestamp: Math.floor(timestampInMillis / 1000),
+      event_timestamp_ms: timestampInMillis,
+      extensions: {
+        client_id: eventConfig.clientId,
+      },
     };
   };
 }
@@ -104,12 +109,17 @@ export interface GenericEventConfig {
 
 interface CredentialTokenIssuedEvent {
   timestamp: number;
+  event_timestamp_ms: number;
   event_name: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED";
   component_id: string;
+  extensions: {
+    client_id: string;
+  };
 }
 
 export interface CredentialTokenIssuedEventConfig {
   getNowInMilliseconds: () => number;
   componentId: string;
   eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED";
+  clientId: string;
 }

--- a/backend-api/src/functions/services/events/tests/eventService.test.ts
+++ b/backend-api/src/functions/services/events/tests/eventService.test.ts
@@ -86,9 +86,10 @@ describe("Event Service", () => {
           sqsMock.on(SendMessageCommand).rejects("Failed to write to SQS");
 
           const result = await eventWriter.writeCredentialTokenIssuedEvent({
-            getNowInMilliseconds: () => 1609462861,
+            getNowInMilliseconds: () => 1609462861000,
             componentId: "mockComponentId",
             eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
+            clientId: "mockClientId",
           });
 
           expect(result.isError).toBe(true);
@@ -102,6 +103,10 @@ describe("Event Service", () => {
               event_name: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
               component_id: "mockComponentId",
               timestamp: 1609462861,
+              event_timestamp_ms: 1609462861000,
+              extensions: {
+                client_id: "mockClientId",
+              },
             }),
             QueueUrl: "mockSqsQueue",
           });
@@ -115,9 +120,10 @@ describe("Event Service", () => {
           sqsMock.on(SendMessageCommand).resolves({});
 
           const result = await eventWriter.writeCredentialTokenIssuedEvent({
-            getNowInMilliseconds: () => 1609462861,
+            getNowInMilliseconds: () => 1609462861000,
             componentId: "mockComponentId",
             eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
+            clientId: "mockClientId",
           });
 
           expect(result.isError).toBe(false);
@@ -128,6 +134,10 @@ describe("Event Service", () => {
               event_name: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
               component_id: "mockComponentId",
               timestamp: 1609462861,
+              event_timestamp_ms: 1609462861000,
+              extensions: {
+                client_id: "mockClientId",
+              },
             }),
             QueueUrl: "mockSqsQueue",
           });


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-9906
### What changed
The CLIENT_CREDENTIALS_TOKEN_ISSUED event is being registered with TxMA. This:
- Adds the client_id into the event
- Fixes the mock timestamp naming

### Why did it change
Align to schema

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
