### PR TITLE
DCMAW-9911: Return 400 when access token signature is invalid

### DIFF
--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "one-login-async-credentials",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.7.0",

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -596,7 +596,7 @@ describe("Async Credential", () => {
         );
         expect(result).toStrictEqual({
           headers: { "Content-Type": "application/json" },
-          statusCode: 401,
+          statusCode: 400,
           body: JSON.stringify({
             error: "Unauthorized",
             error_description: "Invalid signature",

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -598,7 +598,7 @@ describe("Async Credential", () => {
           headers: { "Content-Type": "application/json" },
           statusCode: 400,
           body: JSON.stringify({
-            error: "Unauthorized",
+            error: "invalid_request",
             error_description: "Invalid signature",
           }),
         });

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -76,7 +76,10 @@ export async function lambdaHandlerConstructor(
     logger.log("TOKEN_SIGNATURE_INVALID", {
       errorMessage: verifyTokenSignatureResult.value.errorMessage,
     });
-    return unauthorizedResponseInvalidSignature;
+    return badRequestResponse({
+      error: "invalid_request",
+      errorDescription: "Invalid signature",
+    });
   }
 
   // Fetching issuer and redirect_uri from client registry using the client_id from the incoming jwt
@@ -316,15 +319,6 @@ const unauthorizedResponse = {
   body: JSON.stringify({
     error: "Unauthorized",
     error_description: "Invalid token",
-  }),
-};
-
-const unauthorizedResponseInvalidSignature = {
-  headers: { "Content-Type": "application/json" },
-  statusCode: 401,
-  body: JSON.stringify({
-    error: "Unauthorized",
-    error_description: "Invalid signature",
   }),
 };
 


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-9911
### What changed
When access token signature is invalid (POST /credential) return a 400 status code 

### Why did it change
It fits closest to a client error (400). 401 is being used when the access token is not present (not this scenario).

Decision point: https://gds.slack.com/archives/C066GM0H5GS/p1723197566263159

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
