### PR TITLE
DCMAW-10013: pin sam cli version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 <!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
-​DCMAW-XXXX
+​DCMAW-XXXXX
+
 ### What changed
 <!-- Describe the changes in detail - the "what"-->
 

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -120,6 +120,7 @@ jobs:
         uses: aws-actions/setup-sam@2360ef6d90015369947b45b496193ab9976a9b04 #main
         with:
           use-installer: true
+          version: 1.123.0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -137,7 +137,7 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource:
-                  - !Sub "arn:aws:secretsmanager${AWS::Region}:${AWS::AccountId}:secret:SECRET_NAME-12345"
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SECRET_NAME-12345"
                   
         - PolicyName: AsyncTokenFunctionKmsPolicy
           PolicyDocument:
@@ -216,7 +216,7 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource:
-                  - !Sub "arn:aws:secretsmanager${AWS::Region}:${AWS::AccountId}:secret:SECRET_NAME-12345"
+                  - !Sub "arn:aws:secretsmanager$:{AWS::Region}:${AWS::AccountId}:secret:SECRET_NAME-12345"
                   
         - PolicyName: AsyncTokenFunctionKmsPolicy
           PolicyDocument:


### PR DESCRIPTION
​DCMAW-10013

### What changed

- Pins the version of SAM CLI in the push-to-main action for the backend-api stack
- Addresses linting issues the latest version of the SAM CLI highlights
### Why did it change
Fix pipeline and prevent future breaking changes

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
