### PR TITLE
DCMAW-10009: Temporarily update private api access logs LogGroupName

### DIFF
--- a/backend-api/infra-tests/application.test.ts
+++ b/backend-api/infra-tests/application.test.ts
@@ -232,8 +232,7 @@ describe("Backend application infrastructure", () => {
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 30,
         LogGroupName: {
-          "Fn::Sub":
-            "/aws/apigateway/${AWS::StackName}-public-api-access-logs",
+          "Fn::Sub": "/aws/apigateway/${AWS::StackName}-public-api-access-logs",
         },
       });
     });

--- a/backend-api/infra-tests/application.test.ts
+++ b/backend-api/infra-tests/application.test.ts
@@ -121,7 +121,7 @@ describe("Backend application infrastructure", () => {
         RetentionInDays: 30,
         LogGroupName: {
           "Fn::Sub":
-            "/aws/apigateway/${AWS::StackName}-private-api-access-logs",
+            "/aws/apigateway/${AWS::StackName}-private-api-access-logs-2",
         },
       });
     });
@@ -233,7 +233,7 @@ describe("Backend application infrastructure", () => {
         RetentionInDays: 30,
         LogGroupName: {
           "Fn::Sub":
-            "/aws/apigateway/${AWS::StackName}-private-api-access-logs",
+            "/aws/apigateway/${AWS::StackName}-public-api-access-logs",
         },
       });
     });

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -170,7 +170,7 @@ Resources:
   AsyncCredentialPrivateApiAccessLogs:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs-2
       RetentionInDays: 30
 
       ### Token lambda


### PR DESCRIPTION
### What changed

`LogGroupName` in `AsyncCredentialPrivateApiAccessLogs` resource updated

### Why did it change
Resource name changed in this PR however as the LogGroupName of the resource did not change, we encounterd an error when deploying to main:

```
/aws/apigateway/mob async-backena private api-access-logs already exists in stack arn:aws: cloudfor mation:eu-west-2:21112 5300205: stack/mob async-backend/383028e0 -502f-11ef-8a42-0afd13 d555cd
```

Strategy is to update the `LogGroupName` temporarily and merge. Once a deployment is success I will raise another PR to revert the `LogGroupName`

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
