### PR TITLE
DCMAW-10071: Fix micromatch vulnerability - STS Mock

### DIFF
--- a/sts-mock/package-lock.json
+++ b/sts-mock/package-lock.json
@@ -4134,11 +4134,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/sts-mock/package.json
+++ b/sts-mock/package.json
@@ -37,5 +37,8 @@
     "@aws-lambda-powertools/logger": "^2.6.0",
     "esbuild": "^0.23.0",
     "jose": "^5.6.3"
+  },
+  "overrides": {
+    "micromatch": "^4.0.8"
   }
 }


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10071

### What changed
- Created `overrides` block in `package.json` and added `micromatch` package to address vulnerability in previous version, forcing the version of `micromatch` to be at least `4.0.8`.

### Why did it change
Dependabot found a vulnerability within the `micromatch` package. CVE:

https://nvd.nist.gov/vuln/detail/CVE-2024-4067

As this is an indirect dependency, I investigated whether upgrading the direct dependency would rectify the issue however the same, vulnerable version of `micromatch` was still in use therefore forcing minimum version in `overrides` block

### Evidence

Running `npm audit` now shows 0 vulnerabilities:

<img width="858" alt="Screenshot 2024-08-30 at 15 00 18" src="https://github.com/user-attachments/assets/7385be6a-41ed-492e-95f8-90b542a0021e">

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
