### PR TITLE
DCMAW-10071: Fix micromatch vulnerability - Infra

### DIFF
--- a/infra/templates/dns-records/infra-test/package-lock.json
+++ b/infra/templates/dns-records/infra-test/package-lock.json
@@ -4229,9 +4229,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/infra/templates/dns-records/infra-test/package.json
+++ b/infra/templates/dns-records/infra-test/package.json
@@ -36,6 +36,9 @@
     "tough-cookie": "^4.1.3",
     "yarn": "^1.22.22"
   },
+  "overrides": {
+    "micromatch": "^4.0.8"
+  },
   "jest": {
     "moduleFileExtensions": [
       "js"

--- a/infra/templates/dns/infra-test/package-lock.json
+++ b/infra/templates/dns/infra-test/package-lock.json
@@ -4280,9 +4280,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/infra/templates/dns/infra-test/package.json
+++ b/infra/templates/dns/infra-test/package.json
@@ -36,6 +36,9 @@
     "tough-cookie": "^4.1.3",
     "yarn": "^1.22.22"
   },
+  "overrides": {
+    "micromatch": "^4.0.8"
+  },
   "jest": {
     "moduleFileExtensions": [
       "js"


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10071

### What changed
- Created `overrides` block in `package.json` in both `infra/templates/dns/infra-test/` and `infra/templates/dns-records/infra-test`
-  Added `micromatch` package to overrides block to address vulnerability in previous version, forcing the version of `micromatch` to be at least `4.0.8`.

### Why did it change
Dependabot found a vulnerability within the `micromatch` package. CVE:

https://nvd.nist.gov/vuln/detail/CVE-2024-4067

As this is an indirect dependency, I investigated whether upgrading the direct dependency would rectify the issue however the same, vulnerable version of `micromatch` was still in use therefore forcing minimum version in `overrides` block

### Evidence

Running `npm audit` now shows `micromatch` vulnerabilities has gone (unrelated `semver` vulnerability still showing):

From `infra/templates/dns/infra-test/`
<img width="1226" alt="Screenshot 2024-08-30 at 15 08 41" src="https://github.com/user-attachments/assets/9c80d260-b033-4151-8d07-0b597e6134d0">

From `infra/templates/dns-records/infra-test`
<img width="1235" alt="Screenshot 2024-08-30 at 15 12 14" src="https://github.com/user-attachments/assets/d46f1775-f6d1-492b-9486-45d075eeb071">


## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
