### PR TITLE
[DCMAW-8964] Set up infra to deploy sts-mock stack

### DIFF
--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -49,7 +49,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  build-and-push-test-image:
+  build-and-push-test-image-to-dev:
+    name: 'Build, tag and push docker test image to registry in Dev'
     needs: sonar-scan
     runs-on: ubuntu-latest
     env:
@@ -94,7 +95,7 @@ jobs:
     #   run: |
     #     cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
 
-  build-and-upload-sam-artifact:
+  build-and-upload-sam-artifact-to-dev:
     name: Validate & upload S3 artifact to dev
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -141,6 +141,6 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
           template-file: .aws-sam/build/template.yaml
           working-directory: backend-api

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BACKEND_API_DEV_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_DEV_TEST_IMAGE_REPOSITORY }}
-      BACKEND_API_DEV_COSIGN_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+      DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
       IMAGE_TAG: latest
     defaults:
       run:

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -99,7 +99,7 @@ jobs:
     name: Validate & upload S3 artifact to dev
     runs-on: ubuntu-latest
     needs:
-      - build-and-push-test-image
+      - build-and-push-test-image-to-dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BACKEND_API_DEV_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_DEV_TEST_IMAGE_REPOSITORY }}
-      BACKEND_API_DEV_COSIGN_KEY: ${{secrets.BACKEND_API_DEV_COSIGN_KEY}}
+      BACKEND_API_DEV_COSIGN_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
       IMAGE_TAG: latest
     defaults:
       run:
@@ -92,7 +92,7 @@ jobs:
     # Commenting out due to AWS permission issues
     # - name: Sign the image in DEV
     #   run: |
-    #     cosign sign --key awskms:///$BACKEND_API_DEV_COSIGN_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+    #     cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
 
   build-and-upload-sam-artifact:
     name: Validate & upload S3 artifact to dev
@@ -141,6 +141,6 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE }}
           template-file: .aws-sam/build/template.yaml
           working-directory: backend-api

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -1,0 +1,146 @@
+name: sts-mock push to main
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "sts-mock/**"
+      - ".github/workflows/sts-mock-push-to-main.yml"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sonar-scan:
+    name: Sonar main branch scan
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: sts-mock
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace #main
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sts-mock/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      # Generate test coverage report for Sonar main branch analysis
+      - name: Run Tests
+        run: npm run test:unit
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  build-and-push-test-image:
+    needs: sonar-scan
+    runs-on: ubuntu-latest
+    env:
+      BACKEND_API_DEV_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_DEV_TEST_IMAGE_REPOSITORY }}
+      BACKEND_API_DEV_COSIGN_KEY: ${{secrets.BACKEND_API_DEV_COSIGN_KEY}}
+      IMAGE_TAG: latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: sts-mock
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Build test image
+      run: |
+        docker build -t $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG . 
+
+    - name: Configure AWS credentials for DEV
+      uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+      with:
+        aws-region: eu-west-2
+        role-to-assume: ${{ secrets.BACKEND_API_DEV_GH_ACTIONS_ROLE_ARN }}
+
+    - name: Login to Amazon ECR DEV
+      uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
+
+    - name: Push image to DEV
+      run: |
+        docker push $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
+      with:
+        cosign-release: 'v1.9.0'
+
+    # Commenting out due to AWS permission issues
+    # - name: Sign the image in DEV
+    #   run: |
+    #     cosign sign --key awskms:///$BACKEND_API_DEV_COSIGN_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+
+  build-and-upload-sam-artifact:
+    name: Validate & upload S3 artifact to dev
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-push-test-image
+    defaults:
+      run:
+        shell: bash
+        working-directory: sts-mock
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sts-mock/package-lock.json
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@2360ef6d90015369947b45b496193ab9976a9b04 #main
+        with:
+          use-installer: true
+          version: 1.123.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.BACKEND_API_DEV_GH_ACTIONS_ROLE_ARN }}
+
+      - name: Sam Validate
+        run: |
+          echo "SAM_CLI_TELEMETRY=0" >> $GITHUB_ENV
+          sam validate --lint
+
+      - name: Sam Build
+        run: |
+          sam build --cached
+
+      - name: Upload SAM artifact into the DEV artifact bucket
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
+        with:
+          artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
+          signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
+          template-file: .aws-sam/build/template.yaml
+          working-directory: sts-mock

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -38,14 +38,14 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
-      # Generate test coverage report for Sonar main branch analysis
+      
       - name: Run Tests
         run: npm run test:unit
 
       - name: Run infra Tests
         run: npm run test:infra
 
+      # Generate test coverage report for Sonar main branch analysis
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master
         env:

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -15,8 +15,8 @@ permissions:
   id-token: write
 
 jobs:
-  sonar-scan:
-    name: Sonar main branch scan
+  sts-mock-tests-and-sonar-scan:
+    name: Run tests and Sonar scan
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -43,18 +43,23 @@ jobs:
       - name: Run Tests
         run: npm run test:unit
 
+      - name: Run infra Tests
+        run: npm run test:infra
+
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  build-and-push-test-image:
-    needs: sonar-scan
+  build-and-push-test-image-to-dev:
+    name: Build and push test image to Dev
+    needs: sts-mock-tests-and-sonar-scan
     runs-on: ubuntu-latest
     env:
-      BACKEND_API_DEV_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_DEV_TEST_IMAGE_REPOSITORY }}
+      STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}
       BACKEND_API_DEV_COSIGN_KEY: ${{secrets.BACKEND_API_DEV_COSIGN_KEY}}
+      DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
       IMAGE_TAG: latest
     defaults:
       run:
@@ -69,36 +74,36 @@ jobs:
 
     - name: Build test image
       run: |
-        docker build -t $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG . 
+        docker build -t $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
 
     - name: Configure AWS credentials for DEV
       uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
       with:
         aws-region: eu-west-2
-        role-to-assume: ${{ secrets.BACKEND_API_DEV_GH_ACTIONS_ROLE_ARN }}
+        role-to-assume: ${{ secrets.STS_MOCK_DEV_GH_ACTIONS_ROLE_ARN }}
 
     - name: Login to Amazon ECR DEV
       uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
 
     - name: Push image to DEV
       run: |
-        docker push $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+        docker push $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
       with:
         cosign-release: 'v1.9.0'
 
-    # Commenting out due to AWS permission issues
-    # - name: Sign the image in DEV
-    #   run: |
-    #     cosign sign --key awskms:///$BACKEND_API_DEV_COSIGN_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+    - name: Code sign the Docker image
+      id: cosign-image             
+      run: |
+        cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
-  build-and-upload-sam-artifact:
+  build-and-upload-sam-artifact-to-dev:
     name: Validate & upload S3 artifact to dev
     runs-on: ubuntu-latest
     needs:
-      - build-and-push-test-image
+      - build-and-push-test-image-to-dev
     defaults:
       run:
         shell: bash
@@ -126,7 +131,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
         with:
           aws-region: eu-west-2
-          role-to-assume: ${{ secrets.BACKEND_API_DEV_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.STS_MOCK_DEV_GH_ACTIONS_ROLE_ARN }}
 
       - name: Sam Validate
         run: |
@@ -140,7 +145,108 @@ jobs:
       - name: Upload SAM artifact into the DEV artifact bucket
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
-          artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
+          artifact-bucket-name: ${{ secrets.STS_MOCK_DEV_ARTIFACT_BUCKET }}
+          signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
+          template-file: .aws-sam/build/template.yaml
+          working-directory: sts-mock
+
+  build-and-push-test-image-to-build:
+    name: Build and push test image to Build
+    needs: 
+      - sts-mock-tests-and-sonar-scan
+      - build-and-push-test-image-to-dev
+    runs-on: ubuntu-latest
+    env:
+      STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}
+      BACKEND_API_BUILD_COSIGN_KEY: ${{secrets.BACKEND_API_BUILD_COSIGN_KEY}}
+      BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+      IMAGE_TAG: latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: sts-mock
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Build test image
+      run: |
+        docker build -t $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
+
+    - name: Configure AWS credentials for BUILD
+      uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+      with:
+        aws-region: eu-west-2
+        role-to-assume: ${{ secrets.STS_MOCK_BUILD_GH_ACTIONS_ROLE_ARN }}
+
+    - name: Login to Amazon ECR BUILD
+      uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
+
+    - name: Push image to BUILD
+      run: |
+        docker push $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
+      with:
+        cosign-release: 'v1.9.0'
+
+    - name: Code sign the Docker image
+      id: cosign-image             
+      run: |
+        cosign sign --key awskms:///$BUILD_CONTAINER_SIGN_KMS_KEY $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+
+  build-and-upload-sam-artifact-to-build:
+    name: Validate & upload S3 artifact to Build
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-push-test-image-to-build
+      - build-and-upload-sam-artifact-to-dev
+    defaults:
+      run:
+        shell: bash
+        working-directory: sts-mock
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup nodeJS v20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sts-mock/package-lock.json
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@2360ef6d90015369947b45b496193ab9976a9b04 #main
+        with:
+          use-installer: true
+          version: 1.123.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.STS_MOCK_BUILD_GH_ACTIONS_ROLE_ARN }}
+
+      - name: Sam Validate
+        run: |
+          echo "SAM_CLI_TELEMETRY=0" >> $GITHUB_ENV
+          sam validate --lint
+
+      - name: Sam Build
+        run: |
+          sam build --cached
+
+      - name: Upload SAM artifact into the BUILD artifact bucket
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
+        with:
+          artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -46,11 +46,11 @@ jobs:
         run: npm run test:infra
 
       # Generate test coverage report for Sonar main branch analysis
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # - name: SonarCloud Scan
+      #   uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # build-and-push-test-image-to-dev:
   #   name: Build and push test image to Dev

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -145,7 +145,7 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_DEV_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock
 
@@ -245,6 +245,6 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -57,8 +57,7 @@ jobs:
     needs: sts-mock-tests-and-sonar-scan
     runs-on: ubuntu-latest
     env:
-      STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}
-      BACKEND_API_DEV_COSIGN_KEY: ${{secrets.BACKEND_API_DEV_COSIGN_KEY}}
+      STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}      
       DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
       IMAGE_TAG: latest
     defaults:
@@ -146,7 +145,7 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_DEV_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE }}
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock
 
@@ -157,8 +156,7 @@ jobs:
       - build-and-push-test-image-to-dev
     runs-on: ubuntu-latest
     env:
-      STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}
-      BACKEND_API_BUILD_COSIGN_KEY: ${{secrets.BACKEND_API_BUILD_COSIGN_KEY}}
+      STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}      
       BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
       IMAGE_TAG: latest
     defaults:
@@ -247,6 +245,6 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
-          signing-profile-name: ${{ secrets.BACKEND_API_DEV_SIGNING_PROFILE }}
+          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE }}
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -52,57 +52,57 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  build-and-push-test-image-to-dev:
-    name: Build and push test image to Dev
-    needs: sts-mock-tests-and-sonar-scan
-    runs-on: ubuntu-latest
-    env:
-      STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}      
-      DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
-      IMAGE_TAG: latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: sts-mock
-    steps:
-    - name: Check out repository code
-      uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
-      with:
-        submodules: true
-        fetch-depth: 0
+  # build-and-push-test-image-to-dev:
+  #   name: Build and push test image to Dev
+  #   needs: sts-mock-tests-and-sonar-scan
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}      
+  #     DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+  #     IMAGE_TAG: latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: sts-mock
+  #   steps:
+  #   - name: Check out repository code
+  #     uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
 
-    - name: Build test image
-      run: |
-        docker build -t $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
+  #   - name: Build test image
+  #     run: |
+  #       docker build -t $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
 
-    - name: Configure AWS credentials for DEV
-      uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
-      with:
-        aws-region: eu-west-2
-        role-to-assume: ${{ secrets.STS_MOCK_DEV_GH_ACTIONS_ROLE_ARN }}
+  #   - name: Configure AWS credentials for DEV
+  #     uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+  #     with:
+  #       aws-region: eu-west-2
+  #       role-to-assume: ${{ secrets.STS_MOCK_DEV_GH_ACTIONS_ROLE_ARN }}
 
-    - name: Login to Amazon ECR DEV
-      uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
+  #   - name: Login to Amazon ECR DEV
+  #     uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
 
-    - name: Push image to DEV
-      run: |
-        docker push $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+  #   - name: Push image to DEV
+  #     run: |
+  #       docker push $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
-      with:
-        cosign-release: 'v1.9.0'
+  #   - name: Install Cosign
+  #     uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
+  #     with:
+  #       cosign-release: 'v1.9.0'
 
-    - name: Code sign the Docker image
-      id: cosign-image             
-      run: |
-        cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+  #   - name: Code sign the Docker image
+  #     id: cosign-image             
+  #     run: |
+  #       cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
   build-and-upload-sam-artifact-to-dev:
     name: Validate & upload S3 artifact to dev
     runs-on: ubuntu-latest
-    needs:
-      - build-and-push-test-image-to-dev
+    # needs:
+    #   - build-and-push-test-image-to-dev
     defaults:
       run:
         shell: bash
@@ -149,59 +149,59 @@ jobs:
           template-file: .aws-sam/build/template.yaml
           working-directory: sts-mock
 
-  build-and-push-test-image-to-build:
-    name: Build and push test image to Build
-    needs: 
-      - sts-mock-tests-and-sonar-scan
-      - build-and-push-test-image-to-dev
-    runs-on: ubuntu-latest
-    env:
-      STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}      
-      BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
-      IMAGE_TAG: latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: sts-mock
-    steps:
-    - name: Check out repository code
-      uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
-      with:
-        submodules: true
-        fetch-depth: 0
+  # build-and-push-test-image-to-build:
+  #   name: Build and push test image to Build
+  #   needs: 
+  #     - sts-mock-tests-and-sonar-scan
+  #     - build-and-push-test-image-to-dev
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}      
+  #     BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+  #     IMAGE_TAG: latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: sts-mock
+  #   steps:
+  #   - name: Check out repository code
+  #     uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 #main
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
 
-    - name: Build test image
-      run: |
-        docker build -t $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
+  #   - name: Build test image
+  #     run: |
+  #       docker build -t $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG . 
 
-    - name: Configure AWS credentials for BUILD
-      uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
-      with:
-        aws-region: eu-west-2
-        role-to-assume: ${{ secrets.STS_MOCK_BUILD_GH_ACTIONS_ROLE_ARN }}
+  #   - name: Configure AWS credentials for BUILD
+  #     uses: aws-actions/configure-aws-credentials@55f725fcb586ca16a5ed5b0d75d464defbfa831b #main
+  #     with:
+  #       aws-region: eu-west-2
+  #       role-to-assume: ${{ secrets.STS_MOCK_BUILD_GH_ACTIONS_ROLE_ARN }}
 
-    - name: Login to Amazon ECR BUILD
-      uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
+  #   - name: Login to Amazon ECR BUILD
+  #     uses: aws-actions/amazon-ecr-login@a81a5945e74802f35ca53aa274a9e00436e6210e #main
 
-    - name: Push image to BUILD
-      run: |
-        docker push $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+  #   - name: Push image to BUILD
+  #     run: |
+  #       docker push $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
-      with:
-        cosign-release: 'v1.9.0'
+  #   - name: Install Cosign
+  #     uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
+  #     with:
+  #       cosign-release: 'v1.9.0'
 
-    - name: Code sign the Docker image
-      id: cosign-image             
-      run: |
-        cosign sign --key awskms:///$BUILD_CONTAINER_SIGN_KMS_KEY $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
+  #   - name: Code sign the Docker image
+  #     id: cosign-image             
+  #     run: |
+  #       cosign sign --key awskms:///$BUILD_CONTAINER_SIGN_KMS_KEY $STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI:$IMAGE_TAG
 
   build-and-upload-sam-artifact-to-build:
     name: Validate & upload S3 artifact to Build
     runs-on: ubuntu-latest
     needs:
-      - build-and-push-test-image-to-build
+      # - build-and-push-test-image-to-build
       - build-and-upload-sam-artifact-to-dev
     defaults:
       run:

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -101,8 +101,7 @@ jobs:
   build-and-upload-sam-artifact-to-dev:
     name: Validate & upload S3 artifact to dev
     runs-on: ubuntu-latest
-    # needs:
-    #   - build-and-push-test-image-to-dev
+    # needs: build-and-push-test-image-to-dev
     defaults:
       run:
         shell: bash
@@ -151,9 +150,7 @@ jobs:
 
   # build-and-push-test-image-to-build:
   #   name: Build and push test image to Build
-  #   needs: 
-  #     - sts-mock-tests-and-sonar-scan
-  #     - build-and-push-test-image-to-dev
+  #   needs: sts-mock-tests-and-sonar-scan  
   #   runs-on: ubuntu-latest
   #   env:
   #     STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}      
@@ -200,9 +197,7 @@ jobs:
   build-and-upload-sam-artifact-to-build:
     name: Validate & upload S3 artifact to Build
     runs-on: ubuntu-latest
-    needs:
-      # - build-and-push-test-image-to-build
-      - build-and-upload-sam-artifact-to-dev
+    # needs: build-and-push-test-image-to-build      
     defaults:
       run:
         shell: bash

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Run Tests
         run: npm run test:unit
 
-      - name: Run infra Tests
-        run: npm run test:infra
-
       # Generate test coverage report for Sonar main branch analysis
       # - name: SonarCloud Scan
       #   uses: sonarsource/sonarcloud-github-action@f5003fc9688ade81ce47b57a3fa97a8d3f12de4c #master

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -1,0 +1,57 @@
+resource "aws_cloudformation_stack" "mob_sts_mock_pipeline" {
+    name = "mob-sts-mock-pipeline"
+
+    template_url = format(local.preformat_template_url,
+    "sam-deploy-pipeline",             # https://github.com/govuk-one-login/devplatform-deploy/tree/main/sam-deploy-pipeline
+    "VsTCw4M76yOZXOvXrX6_DrRBGcSFwqRk" # v2.66.0
+  )
+
+  // Default parameters. Can be overwritten by using the locals below.
+  parameters = merge(
+    {
+      Environment  = var.environment
+      SAMStackName = "sts-mock"
+
+      VpcStackName                     = "devplatform-vpc"
+      CustomKmsKeyArns                 = "arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe" # To support Dynatrace
+      AdditionalCodeSigningVersionArns = "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq"
+
+      BuildNotificationStackName = "devplatform-build-notifications"
+      SlackNotificationType      = "All"
+    },
+    local.mob_sts_mock_pipeline[var.environment]
+  )
+
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+}
+
+locals {
+  // Define environment specific parameters here. Will be merged and take precedence over the
+  // parameters defined in the resource above.
+  // https://developer.hashicorp.com/terraform/language/functions/merge
+  // https://developer.hashicorp.com/terraform/language/functions/one
+  mob_sts_mock_pipeline = {
+    dev = {
+      OneLoginRepositoryName = "mobile-id-check-async"
+
+      IncludePromotion = "No"
+
+      SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
+      SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
+
+      TestImageRepositoryUri = "211125300205.dkr.ecr.eu-west-2.amazonaws.com/mob-sts-mock-tir-testrunnerimagerepository-poubsup3aw8j"
+    }
+
+    build = {
+      OneLoginRepositoryName = "mobile-id-check-async"
+
+      IncludePromotion = "No"
+      AllowedAccounts  = local.account_vars.staging.account_id
+
+      SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
+      SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
+
+      # TestImageRepositoryUri = To be added after pipeline and tir is deployed in Build
+    }
+  }
+}

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudformation_stack" "mob_sts_mock_pipeline" {
-    name = "mob-sts-mock-pipeline"
+    name = "mob-sts-mock-pl"
 
     template_url = format(local.preformat_template_url,
     "sam-deploy-pipeline",             # https://github.com/govuk-one-login/devplatform-deploy/tree/main/sam-deploy-pipeline
@@ -10,7 +10,7 @@ resource "aws_cloudformation_stack" "mob_sts_mock_pipeline" {
   parameters = merge(
     {
       Environment  = var.environment
-      SAMStackName = "sts-mock"
+      SAMStackName = "mob-sts-mock"
 
       VpcStackName                     = "devplatform-vpc"
       CustomKmsKeyArns                 = "arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe" # To support Dynatrace
@@ -39,7 +39,7 @@ locals {
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
 
-      TestImageRepositoryUri = "211125300205.dkr.ecr.eu-west-2.amazonaws.com/mob-sts-mock-tir-testrunnerimagerepository-poubsup3aw8j"
+      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     build = {
@@ -51,7 +51,7 @@ locals {
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
 
-      # TestImageRepositoryUri = To be added after pipeline and tir is deployed in Build
+      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
   }
 }

--- a/infra/terraform/secure_pipelines/mob_sts_mock_tir.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_tir.tf
@@ -11,7 +11,7 @@ resource "aws_cloudformation_stack" "mob_sts_mock_tir" {
   // Default parameters. Can be overwritten by using the locals below.
   parameters = merge(
     {
-      PipelineStackName  = "mob-sts-mock-pipeline"
+      PipelineStackName  = "mob-sts-mock-pl"
       RetainedImageCount = 25
     }
   )

--- a/infra/terraform/secure_pipelines/mob_sts_mock_tir.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_tir.tf
@@ -1,0 +1,20 @@
+resource "aws_cloudformation_stack" "mob_sts_mock_tir" {
+  count = contains(["dev", "build"], var.environment) ? 1 : 0
+
+  name = "mob-sts-mock-tir"
+
+  template_url = format(local.preformat_template_url,
+    "test-image-repository",           # https://github.com/govuk-one-login/devplatform-deploy/tree/main/test-image-repository
+    "Vnlbt5pKPSiqbLLRTxPRo1VzHZ1nyHsJ" # v1.2.0
+  )
+
+  // Default parameters. Can be overwritten by using the locals below.
+  parameters = merge(
+    {
+      PipelineStackName  = "mob-sts-mock-pipeline"
+      RetainedImageCount = 25
+    }
+  )
+
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+}


### PR DESCRIPTION
### What changed

Set up secure pipelines to deploy `sts-mock` in Dev and Build environments.
Create test image repository to store test Dockerfile. 
Create `sts-mock-push-to-main` workflow to kick off Dev and Build pipelines and push test Dockerfile to ECR.
I have commented out the jobs for pushing images to ECR for Dev and Build as no test Dockerfile currently exists within the repo.
Updated the workflow job names to reference their environment so their purpose is clearer when viewing the jobs on GitHub.

Ticket:

[DCMAW-8964](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/438?selectedIssue=DCMAW-8964)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DCMAW-8964]: https://govukverify.atlassian.net/browse/DCMAW-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ