### PR TITLE
DCMAW-8964: Adding permission boundaries and role names for STS Mock IAM roles

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -56,6 +56,11 @@ Resources:
   JwksBucketApiRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub ${AWS::StackName}-jwks-bucket-api
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
@@ -120,8 +125,12 @@ Resources:
   TokenFunctionLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-token
       Description: Execution role for the token function
+      RoleName: !Sub ${AWS::StackName}-token
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -18,6 +18,18 @@ Parameters:
       - dev
       - build
 
+PermissionsBoundary:
+    Description: |
+      The ARN of the permissions boundary to apply to any role created by the template
+    Type: String
+    Default: none
+
+Conditions:
+  UsePermissionsBoundary: !Not
+    - !Equals
+      - !Ref PermissionsBoundary
+      - none
+
 Resources:
 ### Public API gateway for STS Mock
   StsMockApi:


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8964

### What changed
- Adds permission boundaries and role names to IAM roles
- Adds infra test to check the above is present for every IAM role in template

### Why did it change
- `sam build` is currently failing in the pipeline to not having correct permissions, see thread [here](https://gds.slack.com/archives/C04RSBGJH6D/p1726047618614799)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
