### PR TITLE
DCMAW-8964: Fixing parameters block indentation

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -9,6 +9,7 @@ Mappings:
     build: 
       ApiBurstLimit: 0
       ApiRateLimit: 0
+
 Parameters:
   Environment:
     Description: The name of the environment to deploy to

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -18,11 +18,11 @@ Parameters:
       - dev
       - build
 
-PermissionsBoundary:
-    Description: |
-      The ARN of the permissions boundary to apply to any role created by the template
-    Type: String
-    Default: none
+  PermissionsBoundary:
+      Description: |
+        The ARN of the permissions boundary to apply to any role created by the template
+      Type: String
+      Default: none
 
 Conditions:
   UsePermissionsBoundary: !Not


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8964

### What changed
- Updated indentation of permissions boundary block, should be within parameters

### Evidence

Linting template now shows no errors

<img width="613" alt="Screenshot 2024-09-11 at 12 21 16" src="https://github.com/user-attachments/assets/d816596b-1231-4cab-baee-232efd7d4076">


## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
