### PR TITLE
[DCMAW-8964] Update async pipelines config

### DIFF
--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -98,6 +98,10 @@ jobs:
       run: |
         docker push $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
 
+    - name: Sign the image
+      run: |
+        cosign sign --key awskms:///$DEV_CONTAINER_SIGN_KMS_KEY $BACKEND_API_DEV_TEST_IMAGE_REPOSITORY:$IMAGE_TAG
+
     - name: SAM validate and lint
       run: |
         echo "SAM_CLI_TELEMETRY=0" >> $GITHUB_ENV

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -75,6 +75,11 @@ jobs:
         cache: npm
         cache-dependency-path: backend-api/package-lock.json
 
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #main
+      with:
+        cosign-release: 'v1.9.0'
+
     - name: Setup SAM CLI
       uses: aws-actions/setup-sam@2360ef6d90015369947b45b496193ab9976a9b04 #main
       with:

--- a/infra/terraform/secure_pipelines/main.tf
+++ b/infra/terraform/secure_pipelines/main.tf
@@ -64,3 +64,15 @@ data "aws_cloudformation_stack" "signer_build" {
   count    = contains(["build", "staging", "integration", "production"], var.environment) ? 1 : 0
   name     = "devplatform-signer"
 }
+
+data "aws_cloudformation_stack" "container_signer_dev" {
+  provider = aws.dev
+  count    = contains(["dev"], var.environment) ? 1 : 0
+  name     = "devplatform-container-signer"
+}
+
+data "aws_cloudformation_stack" "container_signer_build" {
+  provider = aws.build
+  count    = contains(["build"], var.environment) ? 1 : 0
+  name     = "devplatform-container-signer"
+}

--- a/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
+++ b/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
@@ -26,7 +26,7 @@ resource "aws_cloudformation_stack" "mob_async_backend_pl" {
 }
 
 locals {
-  // Define environemnt specific parameters here. Will be merged and take precedence over the
+  // Define environment specific parameters here. Will be merged and take precedence over the
   // parameters defined in the resource above.
   // https://developer.hashicorp.com/terraform/language/functions/merge
   // https://developer.hashicorp.com/terraform/language/functions/one
@@ -35,6 +35,9 @@ locals {
       OneLoginRepositoryName = "mobile-id-check-async"
 
       IncludePromotion = "No"
+
+      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
+      RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
@@ -47,6 +50,9 @@ locals {
 
       IncludePromotion = "Yes"
       AllowedAccounts  = local.account_vars.staging.account_id
+
+      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
+      RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -36,6 +36,9 @@ locals {
 
       IncludePromotion = "No"
 
+      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
+      RequireTestContainerSignatureValidation = "Yes"
+
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
 
@@ -47,6 +50,9 @@ locals {
 
       IncludePromotion = "No"
       AllowedAccounts  = local.account_vars.staging.account_id
+
+      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
+      RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])


### PR DESCRIPTION
### What changed
Update `sts-mock` and `async-backend` pipelines to allow the GitHub Actions role to sign test container.

### Why did it change
Previous configuration didn't allow the GitHub Actions pipeline role to sign the container.

Successfully deployed to Dev and tested in GitHub Actions and CodePipeline:

Github Actions:

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/3e465aff-aea8-4d12-bf8a-24fcf75d2cc4">

CodePipeline Validation stage working:

![image](https://github.com/user-attachments/assets/b82b83ea-603d-4666-b754-b36ae786bda7)


CloudFormation stack:

![image](https://github.com/user-attachments/assets/5cbec647-8453-425f-be96-23b6e340b9ee)


[DCMAW-8964](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/438?selectedIssue=DCMAW-8964)




[DCMAW-8964]: https://govukverify.atlassian.net/browse/DCMAW-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ