### PR TITLE
DCMAW-8964:  Setting permissions boundary as a global function parameter for STS Mock

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
+
 Transform: AWS::Serverless-2016-10-31
+
 Description: SAM template for the STS mock
+
 Mappings:
   StsMockApiGateway:
     dev: 
@@ -9,6 +12,13 @@ Mappings:
     build: 
       ApiBurstLimit: 0
       ApiRateLimit: 0
+
+Globals:
+  Function:
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
 
 Parameters:
   Environment:


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8964

### What changed
- Creates new Globals section of template with Function property
  - Add permission boundary to give correct permissions as detailed [here](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3059908609/How+to+deploy+a+SAM+application+with+secure+pipelines#Support-permissions-boundary)

### Why did it change
- Fix pipeline failure

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
