### PR TITLE
DCMAW-8964: Temporarily rename jwks access log s3 bucket

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -237,7 +237,7 @@ Resources:
   JwksBucketAccessLogs:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub ${AWS::StackName}-jwks-access-logs
+      BucketName: !Sub ${AWS::StackName}-jwks-access-logs-2
       VersioningConfiguration:
         Status: Enabled
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8964

### What changed
- Temporarily rename jwks access log s3 bucket

### Why did it change
- sam deploy in pipeline says bucket already exists therefore will rename in this PR. Will revert name change in follow-up PR.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
