### PR TITLE
DCMAW-8456: add environment suffix to s3 access bucket name

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -709,7 +709,7 @@ Resources:
   JsonWebKeysBucketAccessLogs:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub ${AWS::StackName}-jwks-keys-access-logs
+      BucketName: !Sub ${AWS::StackName}-jwks-keys-access-logs-${Environment}
       VersioningConfiguration:
         Status: Enabled
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8456

### What changed
Add the environment suffix to access log bucket name

### Why did it change
S3 bucket names are globally unique. 

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
