### PR TITLE
DCMAW-10100: Reverts govuk-one-login/devplatform-upload-action version in GitHub workflows

### DIFF
--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -117,7 +117,7 @@ jobs:
         sam build
 
     - name: Upload SAM artifact into the S3 artifact bucket
-      uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+      uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
       with:
         artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
         signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
@@ -191,7 +191,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the S3 artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.BACKEND_API_BUILD_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME}}

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -138,7 +138,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the DEV artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_DEV_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
@@ -234,7 +234,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the BUILD artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10100

### What changed
Reverts `govuk-one-login/devplatform-upload-action`

### Why did it change
Issue with current version block deployment. Reverting for the time being to unblock deployments
- [Pipeline failure](https://gds.slack.com/archives/C04RSBGJH6D/p1726216850516919)
- [Another team with a similar issue reporting it to dev-platform](https://gds.slack.com/archives/C02U78Y5J3H/p1726154783127229)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
