### PR TITLE
DCMAW-9906: remove client-id from events

### DIFF
--- a/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
@@ -103,7 +103,6 @@ export async function lambdaHandlerConstructor(
     componentId: config.ISSUER,
     getNowInMilliseconds: Date.now,
     eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
-    clientId: clientCredentials.clientId,
   });
   if (writeEventResult.isError) {
     logger.log("ERROR_WRITING_AUDIT_EVENT", {

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -67,9 +67,6 @@ export class EventService implements IEventService {
       component_id: eventConfig.componentId,
       timestamp: Math.floor(timestampInMillis / 1000),
       event_timestamp_ms: timestampInMillis,
-      extensions: {
-        client_id: eventConfig.clientId,
-      },
     };
   };
 }
@@ -112,14 +109,10 @@ interface CredentialTokenIssuedEvent {
   event_timestamp_ms: number;
   event_name: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED";
   component_id: string;
-  extensions: {
-    client_id: string;
-  };
 }
 
 export interface CredentialTokenIssuedEventConfig {
   getNowInMilliseconds: () => number;
   componentId: string;
   eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED";
-  clientId: string;
 }

--- a/backend-api/src/functions/services/events/tests/eventService.test.ts
+++ b/backend-api/src/functions/services/events/tests/eventService.test.ts
@@ -89,7 +89,6 @@ describe("Event Service", () => {
             getNowInMilliseconds: () => 1609462861000,
             componentId: "mockComponentId",
             eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
-            clientId: "mockClientId",
           });
 
           expect(result.isError).toBe(true);
@@ -104,9 +103,6 @@ describe("Event Service", () => {
               component_id: "mockComponentId",
               timestamp: 1609462861,
               event_timestamp_ms: 1609462861000,
-              extensions: {
-                client_id: "mockClientId",
-              },
             }),
             QueueUrl: "mockSqsQueue",
           });
@@ -123,7 +119,6 @@ describe("Event Service", () => {
             getNowInMilliseconds: () => 1609462861000,
             componentId: "mockComponentId",
             eventName: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
-            clientId: "mockClientId",
           });
 
           expect(result.isError).toBe(false);
@@ -135,9 +130,6 @@ describe("Event Service", () => {
               component_id: "mockComponentId",
               timestamp: 1609462861,
               event_timestamp_ms: 1609462861000,
-              extensions: {
-                client_id: "mockClientId",
-              },
             }),
             QueueUrl: "mockSqsQueue",
           });


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-9906

### What changed
Removes client id from audit events

### Why did it change
Agreed that this shouldn't be included in schema - https://github.com/govuk-one-login/event-catalogue/pull/206#discussion_r1757145424

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
