### PR TITLE
DCMAW-10218: Roll back dev platform upload GHA bump

### DIFF
--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -138,7 +138,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the DEV artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_DEV_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
@@ -234,7 +234,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the BUILD artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10218

### What changed
Rolls back `govuk-one-login/devplatform-upload-action` to the most recent version pinned in this repository (https://github.com/govuk-one-login/mobile-id-check-async/pull/118)

### Why did it change
Bug in latest commit - https://gds.slack.com/archives/C02U78Y5J3H/p1726220823459709

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
