### PR TITLE
[DCMAW-8964]Quick fix to amend pipeline config to not include test container step…

### DIFF
--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -36,13 +36,15 @@ locals {
 
       IncludePromotion = "No"
 
+      # Test image and container values commented out here until Dockerfile.test is created and we can run the tests in the pipeline
+
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
       #RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
 
-      #TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     build = {
@@ -50,6 +52,8 @@ locals {
 
       IncludePromotion = "No"
       AllowedAccounts  = local.account_vars.staging.account_id
+
+      # Test image and container values commented out here until Dockerfile.test is created and we can run the tests in the pipeline
 
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_build[*].outputs["ContainerSignerKmsKeyArn"])
       #RequireTestContainerSignatureValidation = "Yes"

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -37,12 +37,12 @@ locals {
       IncludePromotion = "No"
 
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
-      RequireTestContainerSignatureValidation = "Yes"
+      #RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
 
-      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      #TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     build = {
@@ -52,12 +52,12 @@ locals {
       AllowedAccounts  = local.account_vars.staging.account_id
 
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_build[*].outputs["ContainerSignerKmsKeyArn"])
-      RequireTestContainerSignatureValidation = "Yes"
+      #RequireTestContainerSignatureValidation = "Yes"
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
 
-      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      #TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
   }
 }

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -36,7 +36,7 @@ locals {
 
       IncludePromotion = "No"
 
-      # Test image and container values commented out here until Dockerfile.test is created and we can run the tests in the pipeline
+      # Test signing and container values commented out here until Dockerfile.test is created, signed and we can run the tests in the pipeline
 
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
       #RequireTestContainerSignatureValidation = "Yes"

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -53,7 +53,7 @@ locals {
       IncludePromotion = "No"
       AllowedAccounts  = local.account_vars.staging.account_id
 
-      # Test image and container values commented out here until Dockerfile.test is created and we can run the tests in the pipeline
+      # Test signing and container values commented out here until Dockerfile.test is created, signed and we can run the tests in the pipeline
 
       ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_build[*].outputs["ContainerSignerKmsKeyArn"])
       #RequireTestContainerSignatureValidation = "Yes"


### PR DESCRIPTION
Amend pipeline config to comment out test container test and signature validation steps to clear up pipeline messages as the pipelines show failures


### Why did it change
Fixes pipeline notifications

[DCMAW-8964](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/438?selectedIssue=DCMAW-8964)



[DCMAW-8964]: https://govukverify.atlassian.net/browse/DCMAW-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ