### PR TITLE
DCMAW-10182: Fixes path-to-regexp security vulnerability in backend-api

### DIFF
--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -6015,6 +6015,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.11.tgz",
+      "integrity": "sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ext": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
@@ -8119,6 +8126,13 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.11.tgz",
+      "integrity": "sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "license": "(BSD-3-Clause OR GPL-2.0)",
@@ -8390,13 +8404,6 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -39,7 +39,7 @@
         "aws4-axios": "^3.3.8",
         "axios-retry": "^4.5.0",
         "eslint": "^9.10.0",
-        "express": "^4.20.0",
+        "express": "^4.21.0",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "prettier": "3.3.3",
@@ -6015,13 +6015,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ext": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
@@ -8401,7 +8394,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -8126,13 +8126,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.11.tgz",
-      "integrity": "sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "license": "(BSD-3-Clause OR GPL-2.0)",
@@ -8406,6 +8399,16 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -64,7 +64,7 @@
   },
   "overrides": {
     "express": {
-      "path-to-regexp": "0.1.11"
+      "path-to-regexp": "^0.1.11"
     },
     "micromatch": "^4.0.8",
     "path-to-regexp": "^8.1.0"

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -34,7 +34,7 @@
     "aws-sdk-client-mock": "4.0.1",
     "aws4-axios": "^3.3.8",
     "eslint": "^9.10.0",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "prettier": "3.3.3",
@@ -63,6 +63,7 @@
     "node-jose": "2.2.0"
   },
   "overrides": {
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "path-to-regexp": "^6.3.0"
   }
 }

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -63,7 +63,10 @@
     "node-jose": "2.2.0"
   },
   "overrides": {
+    "express": {
+      "path-to-regexp": "0.1.11"
+    },
     "micromatch": "^4.0.8",
-    "path-to-regexp": "^0.1.11"
+    "path-to-regexp": "^8.1.0"
   }
 }

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -64,6 +64,6 @@
   },
   "overrides": {
     "micromatch": "^4.0.8",
-    "path-to-regexp": "^6.3.0"
+    "path-to-regexp": "^0.1.11"
   }
 }


### PR DESCRIPTION
### What changed

- Adds `path-to-regexp` to `package.json` overrides block
  - Forcing version `0.1.11` or above for `express` only due to compatibility
  - There are higher major versions (6.X and 8.X are active) but not currently compatible with `express`. Forcing version 8.X for all other packages using `path-to-regexp`
- Updates express package which also uses `path-to-regexp`

### Why did it change

Indirect dependency and direct package has not patched this yet. Therefore have added `path-to-regexp` to overrides so only patched versions of this can be used

### Evidence

Running `npm audit` shows there are no longer any vulnerabilities
<img width="818" alt="Screenshot 2024-09-17 at 12 04 27" src="https://github.com/user-attachments/assets/dd119897-4ec3-4200-981f-9678379d5beb">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
- [DCMAW-10182](https://govukverify.atlassian.net/browse/DCMAW-10182)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


[DCMAW-10182]: https://govukverify.atlassian.net/browse/DCMAW-10182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ