### PR TITLE
DCMAW-10100: Updates timeToLive field in session to be represented in seconds

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -100,8 +100,7 @@ describe("Async Credential", () => {
           "ENVIRONMENT_VARIABLE_MISSING",
         );
         expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
-          errorMessage:
-            "SESSION_DURATION_IN_SECONDS is not a valid number",
+          errorMessage: "SESSION_DURATION_IN_SECONDS is not a valid number",
         });
 
         expect(result).toStrictEqual({

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -39,7 +39,7 @@ const env = {
   SIGNING_KEY_ID: "mockKid",
   ISSUER: "mockIssuer",
   SESSION_TABLE_NAME: "mockTableName",
-  SESSION_DURATION_IN_MILLISECONDS: "12345",
+  SESSION_DURATION_IN_SECONDS: "12345",
   TXMA_SQS: "mockSqsQueue",
   CLIENT_REGISTRY_SECRET_NAME: "mockParmaterName",
 };
@@ -88,10 +88,10 @@ describe("Async Credential", () => {
       });
     });
 
-    describe("Given SESSION_DURATION_IN_MILLISECONDS value is not a number", () => {
+    describe("Given SESSION_DURATION_IN_SECONDS value is not a number", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
-        dependencies.env["SESSION_DURATION_IN_MILLISECONDS"] =
+        dependencies.env["SESSION_DURATION_IN_SECONDS"] =
           "mockInvalidSessionTtlMs";
         const event = buildRequest();
         const result = await lambdaHandlerConstructor(dependencies, event);
@@ -101,7 +101,7 @@ describe("Async Credential", () => {
         );
         expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
           errorMessage:
-            "SESSION_DURATION_IN_MILLISECONDS is not a valid number",
+            "SESSION_DURATION_IN_SECONDS is not a valid number",
         });
 
         expect(result).toStrictEqual({

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.test.ts
@@ -92,7 +92,7 @@ describe("Async Credential", () => {
       it("Returns a 500 Server Error response", async () => {
         dependencies.env = JSON.parse(JSON.stringify(env));
         dependencies.env["SESSION_DURATION_IN_SECONDS"] =
-          "mockInvalidSessionTtlMs";
+          "mockInvalidSessionTtlSecs";
         const event = buildRequest();
         const result = await lambdaHandlerConstructor(dependencies, event);
 

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -170,7 +170,7 @@ export async function lambdaHandlerConstructor(
   const createSessionResult = await sessionService.createSession({
     ...requestBody,
     issuer: jwtPayload.iss,
-    sessionDurationInMilliseconds: config.SESSION_DURATION_IN_MILLISECONDS,
+    sessionDurationInMilliseconds: config.SESSION_DURATION_IN_SECONDS,
   });
 
   if (createSessionResult.isError) {

--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -170,7 +170,7 @@ export async function lambdaHandlerConstructor(
   const createSessionResult = await sessionService.createSession({
     ...requestBody,
     issuer: jwtPayload.iss,
-    sessionDurationInMilliseconds: config.SESSION_DURATION_IN_SECONDS,
+    sessionDurationInSeconds: config.SESSION_DURATION_IN_SECONDS,
   });
 
   if (createSessionResult.isError) {

--- a/backend-api/src/functions/asyncCredential/configService/configService.ts
+++ b/backend-api/src/functions/asyncCredential/configService/configService.ts
@@ -5,7 +5,7 @@ export interface Config {
   SIGNING_KEY_ID: string;
   ISSUER: string;
   SESSION_TABLE_NAME: string;
-  SESSION_DURATION_IN_MILLISECONDS: number;
+  SESSION_DURATION_IN_SECONDS: number;
   TXMA_SQS: string;
   CLIENT_REGISTRY_SECRET_NAME: string;
 }
@@ -27,14 +27,14 @@ export class ConfigService implements IGetConfig<Config> {
         errorMessage: "No SESSION_TABLE_NAME",
         errorCategory: "SERVER_ERROR",
       });
-    if (!env.SESSION_DURATION_IN_MILLISECONDS)
+    if (!env.SESSION_DURATION_IN_SECONDS)
       return errorResult({
-        errorMessage: "No SESSION_DURATION_IN_MILLISECONDS",
+        errorMessage: "No SESSION_DURATION_IN_SECONDS",
         errorCategory: "SERVER_ERROR",
       });
-    if (isNaN(Number(env.SESSION_DURATION_IN_MILLISECONDS)))
+    if (isNaN(Number(env.SESSION_DURATION_IN_SECONDS)))
       return errorResult({
-        errorMessage: "SESSION_DURATION_IN_MILLISECONDS is not a valid number",
+        errorMessage: "SESSION_DURATION_IN_SECONDS is not a valid number",
         errorCategory: "SERVER_ERROR",
       });
     if (!env.TXMA_SQS)
@@ -52,8 +52,8 @@ export class ConfigService implements IGetConfig<Config> {
       SIGNING_KEY_ID: env.SIGNING_KEY_ID,
       ISSUER: env.ISSUER,
       SESSION_TABLE_NAME: env.SESSION_TABLE_NAME,
-      SESSION_DURATION_IN_MILLISECONDS: parseInt(
-        env.SESSION_DURATION_IN_MILLISECONDS,
+      SESSION_DURATION_IN_SECONDS: parseInt(
+        env.SESSION_DURATION_IN_SECONDS,
       ),
       TXMA_SQS: env.TXMA_SQS,
       CLIENT_REGISTRY_SECRET_NAME: env.CLIENT_REGISTRY_SECRET_NAME,

--- a/backend-api/src/functions/asyncCredential/configService/configService.ts
+++ b/backend-api/src/functions/asyncCredential/configService/configService.ts
@@ -52,9 +52,7 @@ export class ConfigService implements IGetConfig<Config> {
       SIGNING_KEY_ID: env.SIGNING_KEY_ID,
       ISSUER: env.ISSUER,
       SESSION_TABLE_NAME: env.SESSION_TABLE_NAME,
-      SESSION_DURATION_IN_SECONDS: parseInt(
-        env.SESSION_DURATION_IN_SECONDS,
-      ),
+      SESSION_DURATION_IN_SECONDS: parseInt(env.SESSION_DURATION_IN_SECONDS),
       TXMA_SQS: env.TXMA_SQS,
       CLIENT_REGISTRY_SECRET_NAME: env.CLIENT_REGISTRY_SECRET_NAME,
     });

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -130,7 +130,7 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       sub,
     } = attributes;
 
-    const currentTimeInSeconds = Math.floor(Date.now() / 1000)
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
     const timeToLive = currentTimeInSeconds + sessionDurationInSeconds;
 
     const putSessionConfig: ISessionPutItemCommandInput = {

--- a/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/sessionService.ts
@@ -22,13 +22,13 @@ export class SessionService implements IGetActiveSession, ICreateSession {
   async getActiveSession(
     subjectIdentifier: string,
   ): Promise<Result<string | null>> {
-    const currentTimeInMs = Date.now();
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
 
     const queryCommandInput: QueryCommandInput = {
       TableName: this.tableName,
       IndexName: "subjectIdentifier-timeToLive-index",
       KeyConditionExpression:
-        "#subjectIdentifier = :subjectIdentifier and :currentTimeInMs < #timeToLive",
+        "#subjectIdentifier = :subjectIdentifier and :currentTimeInSeconds < #timeToLive",
       FilterExpression: "#sessionState = :sessionState",
       ExpressionAttributeNames: {
         "#timeToLive": "timeToLive",
@@ -39,8 +39,8 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       ExpressionAttributeValues: {
         ":subjectIdentifier": { S: subjectIdentifier },
         ":sessionState": { S: "ASYNC_AUTH_SESSION_CREATED" },
-        ":currentTimeInMs": {
-          N: currentTimeInMs.toString(),
+        ":currentTimeInSeconds": {
+          N: currentTimeInSeconds.toString(),
         },
       },
       ProjectionExpression: "#sessionId",
@@ -125,12 +125,13 @@ export class SessionService implements IGetActiveSession, ICreateSession {
       govuk_signin_journey_id,
       issuer,
       redirect_uri,
-      sessionDurationInMilliseconds,
+      sessionDurationInSeconds,
       state,
       sub,
     } = attributes;
 
-    const timeToLive = Date.now() + sessionDurationInMilliseconds;
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000)
+    const timeToLive = currentTimeInSeconds + sessionDurationInSeconds;
 
     const putSessionConfig: ISessionPutItemCommandInput = {
       TableName: this.tableName,
@@ -195,7 +196,7 @@ interface ICreateSessionAttributes {
   govuk_signin_journey_id: string;
   issuer: string;
   redirect_uri?: string;
-  sessionDurationInMilliseconds: number;
+  sessionDurationInSeconds: number;
   state: string;
   sub: string;
 }

--- a/backend-api/src/functions/asyncCredential/sessionService/tests/sessionService.test.ts
+++ b/backend-api/src/functions/asyncCredential/sessionService/tests/sessionService.test.ts
@@ -119,7 +119,7 @@ describe("Session Service", () => {
           govuk_signin_journey_id: "mockJourneyId",
           redirect_uri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
-          sessionDurationInMilliseconds: 12345,
+          sessionDurationInSeconds: 12345,
         });
 
         expect(result.isError).toBe(true);
@@ -145,7 +145,7 @@ describe("Session Service", () => {
           sub: "mockSub",
           client_id: "mockClientId",
           govuk_signin_journey_id: "mockJourneyId",
-          sessionDurationInMilliseconds: 12345,
+          sessionDurationInSeconds: 12345,
           redirect_uri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
         });
@@ -169,7 +169,7 @@ describe("Session Service", () => {
           sub: "mockSub",
           client_id: "mockClientId",
           govuk_signin_journey_id: "mockJourneyId",
-          sessionDurationInMilliseconds: 12345,
+          sessionDurationInSeconds: 12345,
           redirect_uri: "https://mockRedirectUri.com",
           issuer: "mockIssuer",
         });
@@ -196,7 +196,7 @@ describe("Session Service", () => {
             client_id: "mockClientId",
             govuk_signin_journey_id: "mockJourneyId",
             issuer: "mockIssuer",
-            sessionDurationInMilliseconds: 12345,
+            sessionDurationInSeconds: 12345,
           });
 
           expect(result.isError).toBe(false);
@@ -217,7 +217,7 @@ describe("Session Service", () => {
             govuk_signin_journey_id: "mockJourneyId",
             redirect_uri: "https://mockRedirectUri.com",
             issuer: "mockIssuer",
-            sessionDurationInMilliseconds: 12345,
+            sessionDurationInSeconds: 12345,
           });
 
           expect(result.isError).toBe(false);

--- a/backend-api/src/functions/tests/pact/dependencies/asyncCredentialDependencies.ts
+++ b/backend-api/src/functions/tests/pact/dependencies/asyncCredentialDependencies.ts
@@ -15,7 +15,7 @@ const defaultPassingDependencies = {
     ISSUER: "mockIssuer",
     SESSION_TABLE_NAME: "mockTableName",
     SESSION_TABLE_SUBJECT_IDENTIFIER_INDEX_NAME: "mockIndexName",
-    SESSION_DURATION_IN_MILLISECONDS: "12345",
+    SESSION_DURATION_IN_SECONDS: "12345",
     TXMA_SQS: "mockSqsQueue",
     CLIENT_REGISTRY_SECRET_NAME: "mockParmaterName",
   },

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -343,7 +343,7 @@ Resources:
       Environment:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
-          SESSION_DURATION_IN_MILLISECONDS: 3600000 #Used to set time to live when creating sessions. Set to 1 day.
+          SESSION_DURATION_IN_SECONDS: 3600 #Used to set time to live when creating sessions. Set to 1 hour.
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10100

### What changed
- Updates session service:
  - `createSession` now uses epoch time in seconds for `timeToLive` field. 
  - `getActiveSession` now compares current time in seconds to `timeToLive` field
- Updates environment variable for session duration to be in seconds rather than milliseconds
  - Name change; `SESSION_DURATION_IN_MILLISECONDS` => `SESSION_DURATION_IN_SECONDS`
  - Value changed from 3600000 => 3600

### Why did it change
AWS docs state that field we use as the official `ttl` must be in seconds:

_"To use TTL, first enable it on a table and then define a specific attribute to store the TTL expiration timestamp. The timestamp must be stored in [Unix epoch time format](https://en.wikipedia.org/wiki/Unix_time) at the seconds granularity. Each time an item is created or updated, you can compute the expiration time and save it in the TTL attribute."_
See more info [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html)

### Evidence

Deployed a stack where the session duration was one minute. Created a session and got a 201 back and check the table and saw the item there.

<img width="1390" alt="Screenshot 2024-09-18 at 14 07 45" src="https://github.com/user-attachments/assets/0b861900-220d-40dd-86a7-d92fcd311324">

Checked after around 15 minutes and confirmed that the entry had been deleted from the table

<img width="1391" alt="Screenshot 2024-09-18 at 14 07 55" src="https://github.com/user-attachments/assets/117f954b-2b99-4b23-a62f-d3734dea4e33">

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
