### PR TITLE
DCMAW-8229: Adds Auth header validation to asyncActiveSession lambda

### DIFF
--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
@@ -8,12 +8,12 @@ import { Logger } from "../services/logging/logger";
 
 describe("Async Active Session", () => {
   let dependencies: IAsyncActiveSessionDependencies;
-  let mockLogger: MockLoggingAdapter<MessageName>;
+  let mockLoggingAdapter: MockLoggingAdapter<MessageName>;
 
   beforeEach(() => {
-    mockLogger = new MockLoggingAdapter();
+    mockLoggingAdapter = new MockLoggingAdapter();
     dependencies = {
-      logger: () => new Logger(mockLogger, registeredLogs),
+      logger: () => new Logger(mockLoggingAdapter, registeredLogs),
     };
   });
 
@@ -27,10 +27,10 @@ describe("Async Active Session", () => {
           event,
         );
 
-        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+        expect(mockLoggingAdapter.getLogMessages()[0].logMessage.message).toBe(
           "AUTHENTICATION_HEADER_INVALID",
         );
-        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+        expect(mockLoggingAdapter.getLogMessages()[0].data).toStrictEqual({
           errorMessage: "No Authentication header present",
         });
 
@@ -56,10 +56,10 @@ describe("Async Active Session", () => {
           event,
         );
 
-        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+        expect(mockLoggingAdapter.getLogMessages()[0].logMessage.message).toBe(
           "AUTHENTICATION_HEADER_INVALID",
         );
-        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+        expect(mockLoggingAdapter.getLogMessages()[0].data).toStrictEqual({
           errorMessage:
             "Invalid authentication header format - does not start with Bearer",
         });
@@ -86,10 +86,10 @@ describe("Async Active Session", () => {
           event,
         );
 
-        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+        expect(mockLoggingAdapter.getLogMessages()[0].logMessage.message).toBe(
           "AUTHENTICATION_HEADER_INVALID",
         );
-        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+        expect(mockLoggingAdapter.getLogMessages()[0].data).toStrictEqual({
           errorMessage:
             "Invalid authentication header format - contains spaces",
         });
@@ -116,10 +116,10 @@ describe("Async Active Session", () => {
           event,
         );
 
-        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+        expect(mockLoggingAdapter.getLogMessages()[0].logMessage.message).toBe(
           "AUTHENTICATION_HEADER_INVALID",
         );
-        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+        expect(mockLoggingAdapter.getLogMessages()[0].data).toStrictEqual({
           errorMessage: "Invalid authentication header format - missing token",
         });
 

--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
@@ -1,13 +1,47 @@
-import { lambdaHandler } from "./asyncActiveSessionHandler";
+import { APIGatewayProxyResult } from "aws-lambda";
+import { buildRequest } from "../testUtils/mockRequest";
+import { lambdaHandlerConstructor } from "./asyncActiveSessionHandler";
+import { IAsyncActiveSessionDependencies } from "./handlerDependencies";
+import { MockLoggingAdapter } from "../services/logging/tests/mockLogger";
+import { MessageName, registeredLogs } from "./registeredLogs";
+import { Logger } from "../services/logging/logger";
 
 describe("Async Active Session", () => {
-  describe("Given a request is received", () => {
-    it("Returns 200 response", async () => {
-      const result = await lambdaHandler();
+  let dependencies: IAsyncActiveSessionDependencies;
+  let mockLogger: MockLoggingAdapter<MessageName>;
 
-      expect(result).toStrictEqual({
-        statusCode: 200,
-        body: "Hello, World",
+  beforeEach(() => {
+    mockLogger = new MockLoggingAdapter();
+    dependencies = {
+      logger: () => new Logger(mockLogger, registeredLogs),
+    };
+  });
+
+  describe("Access token validation", () => {
+    describe("Given Authentication header is missing", () => {
+      it("Returns 401 Unauthorized", async () => {
+        const event = buildRequest();
+
+        const result: APIGatewayProxyResult = await lambdaHandlerConstructor(
+          dependencies,
+          event,
+        );
+
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "AUTHENTICATION_HEADER_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "No Authentication header present",
+        });
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
+        });
       });
     });
   });

--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
@@ -44,5 +44,94 @@ describe("Async Active Session", () => {
         });
       });
     });
+
+    describe("Given access token does not start with Bearer", () => {
+      it("Returns 401 Unauthorized", async () => {
+        const event = buildRequest({
+          headers: { Authorization: "noBearerString mockToken" },
+        });
+
+        const result: APIGatewayProxyResult = await lambdaHandlerConstructor(
+          dependencies,
+          event,
+        );
+
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "AUTHENTICATION_HEADER_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage:
+            "Invalid authentication header format - does not start with Bearer",
+        });
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
+        });
+      });
+    });
+
+    describe("Given Bearer token is not in expected format - contains spaces", () => {
+      it("Returns 401 Unauthorized", async () => {
+        const event = buildRequest({
+          headers: { Authorization: "Bearer mock token" },
+        });
+
+        const result: APIGatewayProxyResult = await lambdaHandlerConstructor(
+          dependencies,
+          event,
+        );
+
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "AUTHENTICATION_HEADER_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage:
+            "Invalid authentication header format - contains spaces",
+        });
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
+        });
+      });
+    });
+
+    describe("Given Bearer token is not in expected format - missing token", () => {
+      it("Returns 401 Unauthorized", async () => {
+        const event = buildRequest({
+          headers: { Authorization: "Bearer " },
+        });
+
+        const result: APIGatewayProxyResult = await lambdaHandlerConstructor(
+          dependencies,
+          event,
+        );
+
+        expect(mockLogger.getLogMessages()[0].logMessage.message).toBe(
+          "AUTHENTICATION_HEADER_INVALID",
+        );
+        expect(mockLogger.getLogMessages()[0].data).toStrictEqual({
+          errorMessage: "Invalid authentication header format - missing token",
+        });
+
+        expect(result).toStrictEqual({
+          headers: { "Content-Type": "application/json" },
+          statusCode: 401,
+          body: JSON.stringify({
+            error: "Unauthorized",
+            error_description: "Invalid token",
+          }),
+        });
+      });
+    });
   });
 });

--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.ts
@@ -22,7 +22,7 @@ export async function lambdaHandlerConstructor(
     });
     return unauthorizedResponse;
   }
-  // const authorizationHeader = authorizationHeaderResult.value;
+
   return {
     statusCode: 200,
     body: "Hello, World",

--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.ts
@@ -1,8 +1,41 @@
-import { APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { RequestService } from "./requestService/requestService";
+import {
+  dependencies,
+  IAsyncActiveSessionDependencies,
+} from "./handlerDependencies";
 
-export async function lambdaHandler(): Promise<APIGatewayProxyResult> {
+export async function lambdaHandlerConstructor(
+  dependencies: IAsyncActiveSessionDependencies,
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> {
+  const logger = dependencies.logger();
+
+  const requestService = new RequestService();
+
+  const authorizationHeaderResult = requestService.getAuthorizationHeader(
+    event.headers["Authorization"] ?? event.headers["authorization"],
+  );
+  if (authorizationHeaderResult.isError) {
+    logger.log("AUTHENTICATION_HEADER_INVALID", {
+      errorMessage: authorizationHeaderResult.value.errorMessage,
+    });
+    return unauthorizedResponse;
+  }
+  // const authorizationHeader = authorizationHeaderResult.value;
   return {
     statusCode: 200,
     body: "Hello, World",
   };
 }
+
+export const lambdaHandler = lambdaHandlerConstructor.bind(null, dependencies);
+
+const unauthorizedResponse = {
+  headers: { "Content-Type": "application/json" },
+  statusCode: 401,
+  body: JSON.stringify({
+    error: "Unauthorized",
+    error_description: "Invalid token",
+  }),
+};

--- a/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
+++ b/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
@@ -1,0 +1,11 @@
+import { Logger } from "../services/logging/logger";
+import { Logger as PowertoolsLogger } from "@aws-lambda-powertools/logger";
+import { MessageName, registeredLogs } from "./registeredLogs";
+
+export interface IAsyncActiveSessionDependencies {
+  logger: () => Logger<MessageName>;
+}
+
+export const dependencies: IAsyncActiveSessionDependencies = {
+  logger: () => new Logger<MessageName>(new PowertoolsLogger(), registeredLogs),
+};

--- a/backend-api/src/functions/asyncActiveSession/registeredLogs.ts
+++ b/backend-api/src/functions/asyncActiveSession/registeredLogs.ts
@@ -1,0 +1,14 @@
+import {
+  CommonMessageNames,
+  commonMessages,
+} from "../services/logging/commonRegisteredLogs";
+import { RegisteredLogMessages } from "../services/logging/types";
+
+export type MessageName = "AUTHENTICATION_HEADER_INVALID" | CommonMessageNames;
+
+export const registeredLogs: RegisteredLogMessages<MessageName> = {
+  AUTHENTICATION_HEADER_INVALID: {
+    messageCode: "MOBILE_ASYNC_AUTHENTICATION_HEADER_INVALID",
+  },
+  ...commonMessages,
+};

--- a/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
+++ b/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
@@ -1,0 +1,44 @@
+import { errorResult, Result, successResult } from "../../utils/result";
+
+export class RequestService implements IRequestService {
+  getAuthorizationHeader = (
+    authorizationHeader: string | undefined,
+  ): Result<string> => {
+    if (authorizationHeader == null) {
+      return errorResult({
+        errorMessage: "No Authentication header present",
+        errorCategory: "CLIENT_ERROR",
+      });
+    }
+
+    // if (!authorizationHeader.startsWith("Bearer ")) {
+    //   return errorResult({
+    //     errorMessage:
+    //       "Invalid authentication header format - does not start with Bearer",
+    //     errorCategory: "CLIENT_ERROR",
+    //   });
+    // }
+
+    // if (authorizationHeader.split(" ").length !== 2) {
+    //   return errorResult({
+    //     errorMessage: "Invalid authentication header format - contains spaces",
+    //     errorCategory: "CLIENT_ERROR",
+    //   });
+    // }
+
+    // if (authorizationHeader.split(" ")[1].length == 0) {
+    //   return errorResult({
+    //     errorMessage: "Invalid authentication header format - missing token",
+    //     errorCategory: "CLIENT_ERROR",
+    //   });
+    // }
+
+    return successResult(authorizationHeader);
+  };
+}
+
+export interface IRequestService {
+  getAuthorizationHeader: (
+    authorizationHeader: string | undefined,
+  ) => Result<string>;
+}

--- a/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
+++ b/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
@@ -11,27 +11,27 @@ export class RequestService implements IRequestService {
       });
     }
 
-    // if (!authorizationHeader.startsWith("Bearer ")) {
-    //   return errorResult({
-    //     errorMessage:
-    //       "Invalid authentication header format - does not start with Bearer",
-    //     errorCategory: "CLIENT_ERROR",
-    //   });
-    // }
+    if (!authorizationHeader.startsWith("Bearer ")) {
+      return errorResult({
+        errorMessage:
+          "Invalid authentication header format - does not start with Bearer",
+        errorCategory: "CLIENT_ERROR",
+      });
+    }
 
-    // if (authorizationHeader.split(" ").length !== 2) {
-    //   return errorResult({
-    //     errorMessage: "Invalid authentication header format - contains spaces",
-    //     errorCategory: "CLIENT_ERROR",
-    //   });
-    // }
+    if (authorizationHeader.split(" ").length !== 2) {
+      return errorResult({
+        errorMessage: "Invalid authentication header format - contains spaces",
+        errorCategory: "CLIENT_ERROR",
+      });
+    }
 
-    // if (authorizationHeader.split(" ")[1].length == 0) {
-    //   return errorResult({
-    //     errorMessage: "Invalid authentication header format - missing token",
-    //     errorCategory: "CLIENT_ERROR",
-    //   });
-    // }
+    if (authorizationHeader.split(" ")[1].length == 0) {
+      return errorResult({
+        errorMessage: "Invalid authentication header format - missing token",
+        errorCategory: "CLIENT_ERROR",
+      });
+    }
 
     return successResult(authorizationHeader);
   };

--- a/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
+++ b/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
@@ -1,39 +1,9 @@
-import { errorResult, Result, successResult } from "../../utils/result";
+import { getBearerTokenFromHeader } from "../../services/utils/requestService";
+import { Result } from "../../utils/result";
 
 export class RequestService implements IRequestService {
-  getAuthorizationHeader = (
-    authorizationHeader: string | undefined,
-  ): Result<string> => {
-    if (authorizationHeader == null) {
-      return errorResult({
-        errorMessage: "No Authentication header present",
-        errorCategory: "CLIENT_ERROR",
-      });
-    }
-
-    if (!authorizationHeader.startsWith("Bearer ")) {
-      return errorResult({
-        errorMessage:
-          "Invalid authentication header format - does not start with Bearer",
-        errorCategory: "CLIENT_ERROR",
-      });
-    }
-
-    if (authorizationHeader.split(" ").length !== 2) {
-      return errorResult({
-        errorMessage: "Invalid authentication header format - contains spaces",
-        errorCategory: "CLIENT_ERROR",
-      });
-    }
-
-    if (authorizationHeader.split(" ")[1].length == 0) {
-      return errorResult({
-        errorMessage: "Invalid authentication header format - missing token",
-        errorCategory: "CLIENT_ERROR",
-      });
-    }
-
-    return successResult(authorizationHeader);
+  getAuthorizationHeader = (authorizationHeader: string | undefined) => {
+    return getBearerTokenFromHeader(authorizationHeader);
   };
 }
 


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed
- Adds request service for lambda to consume, validates Authorization header and returns it to lambda
- Adds handler dependencies
- Adds registered logs

### Why did it change
Building out link session

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
