### PR TITLE
[DCMAW-8456] Update secure pipelines version to 2.68.1

### DIFF
--- a/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
+++ b/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
@@ -3,7 +3,7 @@ resource "aws_cloudformation_stack" "mob_async_backend_pl" {
 
   template_url = format(local.preformat_template_url,
     "sam-deploy-pipeline",             # https://github.com/govuk-one-login/devplatform-deploy/tree/main/sam-deploy-pipeline
-    "NGOxM_hPmNoY1pTz6vo8P_El2EqVz6sa" # v2.61.1
+    "T6TI2U6b_eZjNorsTP6sDXGa4zfdOKAL" # v2.68.1
   )
 
   // Default parameters. Can be overwritten by using the locals below.

--- a/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
+++ b/infra/terraform/secure_pipelines/mob_sts_mock_pipeline.tf
@@ -3,7 +3,7 @@ resource "aws_cloudformation_stack" "mob_sts_mock_pipeline" {
 
     template_url = format(local.preformat_template_url,
     "sam-deploy-pipeline",             # https://github.com/govuk-one-login/devplatform-deploy/tree/main/sam-deploy-pipeline
-    "VsTCw4M76yOZXOvXrX6_DrRBGcSFwqRk" # v2.66.0
+    "T6TI2U6b_eZjNorsTP6sDXGa4zfdOKAL" # v2.68.1
   )
 
   // Default parameters. Can be overwritten by using the locals below.
@@ -44,7 +44,7 @@ locals {
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
 
-      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      #TestImageRepositoryUri = one(aws_cloudformation_stack.mob_sts_mock_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     build = {


### PR DESCRIPTION
​DCMAW-8456

### What changed
Update secure pipelines for async account to version 2.68.1

Comment out test image repository uri for sts-mock-pl as its not in use currently

