### PR TITLE
fix: remove DependsOn from sts-mock SAM template

### DIFF
--- a/.github/workflows/sts-mock-pull-request.yml
+++ b/.github/workflows/sts-mock-pull-request.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run tests 
         run: npm run test
 
+      - name: Validate SAM template
+        run: sam validate --lint
+
       - name: "Run SonarCloud Scan"
         uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b # master
         env:

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -114,7 +114,6 @@ Resources:
 
   StsMockApiBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
-    DependsOn: StsMockApiDomainName
     Properties:
       DomainName: !Sub ${StsMockApiDomainName}
       RestApiId: !Ref StsMockApi


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
Relates to ​DCMAW-8965

### What changed
- Remove unnecessary `DependsOn` from the sts-mock SAM template
- Add `sam validate --lint` to GHA on pull request

### Why did it change
- To ensure template is valid before merging
- To fix GHA failure

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
