### PR TITLE
chore(DCMAW): revert devplatform-upload-action to older version

### DIFF
--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -126,7 +126,7 @@ jobs:
         sam build
 
     - name: Upload SAM artifact into the S3 artifact bucket
-      uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+      uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
       with:
         artifact-bucket-name: ${{ secrets.BACKEND_API_DEV_ARTIFACT_BUCKET }}
         signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -236,7 +236,7 @@ jobs:
           sam build --cached
 
       - name: Upload SAM artifact into the BUILD artifact bucket
-        uses: govuk-one-login/devplatform-upload-action@b7994fb959f70cc1440295de9e823f317ffa197e #main
+        uses: govuk-one-login/devplatform-upload-action@6985ccbaa306e2320a8826252c922af65242b283 #main
         with:
           artifact-bucket-name: ${{ secrets.STS_MOCK_BUILD_ARTIFACT_BUCKET }}
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-XXXXX

### What changed
Relates to https://github.com/govuk-one-login/mobile-id-check-async/pull/170
- Change `devplatform-upload-action` back to `6985ccbaa306e2320a8826252c922af65242b283`

### Why did it change
- `b7994fb959f70cc1440295de9e823f317ffa197e` is broken

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
