### PR TITLE
DCMAW-10254: add STS mock Token function to VPC

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -159,7 +159,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: !Sub ${AWS::StackName}-token-sg
-      GroupDescription: Lambda Security group ruleset.
+      GroupDescription: Lambda Security group ruleset
       SecurityGroupEgress:
         - CidrIp: !ImportValue devplatform-vpc-VpcCidr
           Description: TCP HTTPS outbound to vpc.
@@ -193,7 +193,7 @@ Resources:
             Path: /token
             Method: post
             RestApiId: !Ref StsMockApi
-      Role: !GetAtt TokenFunctionLambdaRole.Arn
+      Role: !GetAtt TokenFunctionRole.Arn
       Environment:
         Variables:
           STS_MOCK_BASE_URL: !Sub https://${StsMockApiDomainName}
@@ -222,7 +222,7 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-token
 
-  TokenFunctionLambdaRole:
+  TokenFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       Description: Execution role for the token function

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -64,7 +64,6 @@ Conditions:
       - none
 
 Resources:
-### Public API gateway for STS Mock
   StsMockApi:
     Type: AWS::Serverless::Api
     Properties:
@@ -146,7 +145,7 @@ Resources:
               Service: apigateway.amazonaws.com
         Version: 2012-10-17
       Policies:
-        - PolicyName: JwksBucketPolicy
+        - PolicyName: S3Policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -156,7 +155,19 @@ Resources:
                 Resource:
                   - !Sub ${JwksBucket.Arn}/.well-known/jwks.json
 
-### Token Lambda
+  TokenFunctionSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub ${AWS::StackName}-token-sg
+      GroupDescription: Lambda Security group ruleset.
+      SecurityGroupEgress:
+        - CidrIp: !ImportValue devplatform-vpc-VpcCidr
+          Description: TCP HTTPS outbound to vpc.
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      VpcId: !ImportValue devplatform-vpc-VpcId
+
   TokenFunction:
     DependsOn:
       - TokenFunctionLogGroup
@@ -188,6 +199,13 @@ Resources:
           STS_MOCK_BASE_URL: !Sub https://${StsMockApiDomainName}
           ASYNC_BACKEND_BASE_URL: !Sub https://sessions-mob-async-backend.review-b-async.${Environment}.account.gov.uk
           KEY_STORAGE_BUCKET_NAME: !Ref JwksBucket
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
+        SecurityGroupIds:
+          - !Ref TokenFunctionSecurityGroup
 
   TokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -221,7 +239,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: TokenFunctionLogsPolicy
+        - PolicyName: LogsPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -231,7 +249,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: arn:aws:logs:*:*:*
-        - PolicyName: TokenFunctionS3Policy
+        - PolicyName: S3Policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -242,6 +260,16 @@ Resources:
                   - !Sub
                     - arn:aws:s3:::${TargetBucket}/*
                     - TargetBucket: !Ref JwksBucket
+        - PolicyName: ENIPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: '*'
 
   JwksBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10254

### What changed
- Associate the STS mock Token function with the `devplatform-vpc`
- Remove some comments from the SAM template
- Rename some policies

Stack deployed to `dev` and tested by sending a POST request to `/token`:

![Screenshot 2024-09-24 at 18 09 41](https://github.com/user-attachments/assets/a128ab3f-f7cd-4517-849c-e81162c0034c)

![Screenshot 2024-09-24 at 18 12 07](https://github.com/user-attachments/assets/4d973557-b994-4568-9935-b76ebbaa9eb1)


### Why did it change
- It is a security best practice to restrict access to the function

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
