### PR TITLE
fix: change TokenFunctionRole name temporarily

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -226,7 +226,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: Execution role for the token function
-      RoleName: !Sub ${AWS::StackName}-token
+      RoleName: !Sub ${AWS::StackName}-token-2
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10254

Relates to https://github.com/govuk-one-login/mobile-id-check-async/pull/177

### What changed
Temporarily change `TokenFunctionRole` name from `${AWS::StackName}-token` to `${AWS::StackName}-token-2` - this change will be reverted in another PR

### Why did it change
To fix CodePipeline failure

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
