### PR TITLE
DCMAW-10254: fix VPC configuration and Token VPC configuration

### DIFF
--- a/infra/terraform/base_stacks/main.tf
+++ b/infra/terraform/base_stacks/main.tf
@@ -30,5 +30,6 @@ terraform {
   backend "s3" {
    # "bucket" name provided at run time. Check the ./terraform/README.md for details.
     key = "tf/base-stacks.tfstate"
+    region = "eu-west-2"
   }
 }

--- a/infra/terraform/base_stacks/vpc.tf
+++ b/infra/terraform/base_stacks/vpc.tf
@@ -14,7 +14,9 @@ resource "aws_cloudformation_stack" "vpc" {
     DynamoDBApiEnabled       = "Yes"
     ExecuteApiGatewayEnabled = "Yes"
     KMSApiEnabled            = "Yes"
+    S3ApiEnabled             = "Yes"
     SQSApiEnabled            = "Yes"
     SSMApiEnabled            = "Yes"
+    AllowRules               = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\".account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
   }
 }

--- a/sts-mock/src/token/tokenEncrypter/tokenEncrypter.ts
+++ b/sts-mock/src/token/tokenEncrypter/tokenEncrypter.ts
@@ -50,7 +50,6 @@ export class TokenEncrypter implements ITokenEncrypter {
   private async getJwks(): Promise<Result<object>> {
     let response;
     try {
-      console.log(this.jwksUri)
       response = await fetch(this.jwksUri, { method: "GET" });
       if (!response.ok) {
         return errorResult({
@@ -58,8 +57,7 @@ export class TokenEncrypter implements ITokenEncrypter {
           errorCategory: "SERVER_ERROR",
         });
       }
-    } catch (error) {
-      console.log(error)
+    } catch {
       return errorResult({
         errorMessage: "Unexpected network error fetching JWKS",
         errorCategory: "SERVER_ERROR",

--- a/sts-mock/src/token/tokenEncrypter/tokenEncrypter.ts
+++ b/sts-mock/src/token/tokenEncrypter/tokenEncrypter.ts
@@ -50,6 +50,7 @@ export class TokenEncrypter implements ITokenEncrypter {
   private async getJwks(): Promise<Result<object>> {
     let response;
     try {
+      console.log(this.jwksUri)
       response = await fetch(this.jwksUri, { method: "GET" });
       if (!response.ok) {
         return errorResult({
@@ -57,7 +58,8 @@ export class TokenEncrypter implements ITokenEncrypter {
           errorCategory: "SERVER_ERROR",
         });
       }
-    } catch {
+    } catch (error) {
+      console.log(error)
       return errorResult({
         errorMessage: "Unexpected network error fetching JWKS",
         errorCategory: "SERVER_ERROR",

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -213,7 +213,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: Execution role for the token function
-      RoleName: !Sub ${AWS::StackName}-token-2
+      RoleName: !Sub ${AWS::StackName}-token
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -226,7 +226,6 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       Policies:
         - PolicyName: S3ReadPolicy

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -226,7 +226,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: Execution role for the token function
-      RoleName: !Sub ${AWS::StackName}-token
+      RoleName: !Sub ${AWS::StackName}-token-2
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -145,7 +145,7 @@ Resources:
               Service: apigateway.amazonaws.com
         Version: 2012-10-17
       Policies:
-        - PolicyName: S3Policy
+        - PolicyName: JwksBucketPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -154,19 +154,6 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - !Sub ${JwksBucket.Arn}/.well-known/jwks.json
-
-  TokenFunctionSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: !Sub ${AWS::StackName}-token-sg
-      GroupDescription: Lambda Security group ruleset
-      SecurityGroupEgress:
-        - CidrIp: !ImportValue devplatform-vpc-VpcCidr
-          Description: TCP HTTPS outbound to vpc.
-          FromPort: 443
-          IpProtocol: tcp
-          ToPort: 443
-      VpcId: !ImportValue devplatform-vpc-VpcId
 
   TokenFunction:
     DependsOn:
@@ -205,7 +192,7 @@ Resources:
           - !ImportValue devplatform-vpc-ProtectedSubnetIdB
           - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
-          - !Ref TokenFunctionSecurityGroup
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   TokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -238,18 +225,11 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       Policies:
-        - PolicyName: LogsPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: arn:aws:logs:*:*:*
-        - PolicyName: S3Policy
+        - PolicyName: S3ReadPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -260,16 +240,6 @@ Resources:
                   - !Sub
                     - arn:aws:s3:::${TargetBucket}/*
                     - TargetBucket: !Ref JwksBucket
-        - PolicyName: ENIPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:DescribeNetworkInterfaces
-                  - ec2:CreateNetworkInterface
-                  - ec2:DeleteNetworkInterface
-                Resource: '*'
 
   JwksBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10254

Relates to PR https://github.com/govuk-one-login/mobile-id-check-async/pull/177

### What changed
**Infrastructure:**
- Allow communication with S3 and traffic outside VPC

**Token (sts-mock) Lambda - SAM template:**
- Reference `devplatform-vpc-AWSServicesEndpointSecurityGroupId` instead of creating a new one
- Remove `ENIPolicy` and `LogsPolicy` as these have been placed with AWSLambdaVPCAccessExecutionRole

**devplatform-vpc stack deployed to dev**:
![Screenshot 2024-09-26 at 09 39 49](https://github.com/user-attachments/assets/cd83ff85-8ae4-4bfd-81b6-165dd7da0f84)

![Screenshot 2024-09-26 at 09 37 46](https://github.com/user-attachments/assets/fc251be8-4c2a-47ba-bdaa-1d4a698d86b6)

**sts-mock stack deployed to dev:**

![Screenshot 2024-09-26 at 09 35 19](https://github.com/user-attachments/assets/31001964-f433-48cc-9cea-1fb3cd8421cf)

![Screenshot 2024-09-26 at 09 36 01](https://github.com/user-attachments/assets/d6b8e1ed-8450-47de-8073-ef9d10fe2a66)


### Why did it change
- VPC parameters had to be configured correctly in order for the Token function to work

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
