### PR TITLE
fix: simplify STS mock API name

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -67,7 +67,7 @@ Resources:
   StsMockApi:
     Type: AWS::Serverless::Api
     Properties:
-      Name: !Sub ${AWS::StackName}-sts-mock-api
+      Name: !Sub ${AWS::StackName}-api
       Description: Public API gateway for STS Mock
       EndpointConfiguration: REGIONAL
       StageName: 
@@ -93,7 +93,7 @@ Resources:
   StsMockApiAccessLogs:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-sts-mock-api-access-logs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-api-access-logs
       RetentionInDays: 30
 
   StsMockApiDomainName:

--- a/sts-mock/tests/infrastructure-tests/application.test.ts
+++ b/sts-mock/tests/infrastructure-tests/application.test.ts
@@ -18,7 +18,7 @@ describe("STS mock infrastructure", () => {
   describe("API Gateway", () => {
     test("the endpoints are REGIONAL", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
-        Name: { "Fn::Sub": "${AWS::StackName}-sts-mock-api" },
+        Name: { "Fn::Sub": "${AWS::StackName}-api" },
         EndpointConfiguration: "REGIONAL",
       });
     });
@@ -31,7 +31,7 @@ describe("STS mock infrastructure", () => {
 
     test("it uses the STS mock OpenAPI Spec", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
-        Name: { "Fn::Sub": "${AWS::StackName}-sts-mock-api" },
+        Name: { "Fn::Sub": "${AWS::StackName}-api" },
         DefinitionBody: {
           "Fn::Transform": {
             Name: "AWS::Include",
@@ -45,7 +45,7 @@ describe("STS mock infrastructure", () => {
       test("metrics are enabled", () => {
         const methodSettings = new Capture();
         template.hasResourceProperties("AWS::Serverless::Api", {
-          Name: { "Fn::Sub": "${AWS::StackName}-sts-mock-api" },
+          Name: { "Fn::Sub": "${AWS::StackName}-api" },
           MethodSettings: methodSettings,
         });
         expect(methodSettings.asArray()[0].MetricsEnabled).toBe(true);
@@ -74,7 +74,7 @@ describe("STS mock infrastructure", () => {
       test("rate limit and burst mappings are applied to the API gateway", () => {
         const methodSettings = new Capture();
         template.hasResourceProperties("AWS::Serverless::Api", {
-          Name: { "Fn::Sub": "${AWS::StackName}-sts-mock-api" },
+          Name: { "Fn::Sub": "${AWS::StackName}-api" },
           MethodSettings: methodSettings,
         });
         expect(methodSettings.asArray()[0].ThrottlingBurstLimit).toStrictEqual({
@@ -96,7 +96,7 @@ describe("STS mock infrastructure", () => {
 
     test("access log group is attached to the API gateway", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
-        Name: { "Fn::Sub": "${AWS::StackName}-sts-mock-api" },
+        Name: { "Fn::Sub": "${AWS::StackName}-api" },
         AccessLogSetting: {
           DestinationArn: {
             "Fn::Sub":
@@ -110,8 +110,7 @@ describe("STS mock infrastructure", () => {
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         RetentionInDays: 30,
         LogGroupName: {
-          "Fn::Sub":
-            "/aws/apigateway/${AWS::StackName}-sts-mock-api-access-logs",
+          "Fn::Sub": "/aws/apigateway/${AWS::StackName}-api-access-logs",
         },
       });
     });


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
Relates to [DCMAW-10254](https://govukverify.atlassian.net/browse/DCMAW-10254
)
### What changed
Remove `sts-mock` from the STS mock API name as it's already part of the stack name.

Stack deployed and tested in `dev`:

![Screenshot 2024-09-27 at 09 40 28](https://github.com/user-attachments/assets/3978db68-693a-4b11-913b-7189ed224406)


`/token`
![Screenshot 2024-09-27 at 09 38 41](https://github.com/user-attachments/assets/3f0d914a-b97f-4e50-a5d1-694ade3618e0)

`/.well-known/jwks.json`
![Screenshot 2024-09-27 at 09 48 40](https://github.com/user-attachments/assets/d118a66b-d099-4447-a503-ec73cddc7dd5)



### Why did it change
To stop `sts-mock` from being stated twice:
![Screenshot 2024-09-26 at 14 30 05](https://github.com/user-attachments/assets/28061685-1ce3-4383-832c-4d11c6804d94)



## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DCMAW-10254]: https://govukverify.atlassian.net/browse/DCMAW-10254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ