### PR TITLE
DCMAW-8229: Update logic in shared util in request service

### DIFF
--- a/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
+++ b/backend-api/src/functions/asyncActiveSession/requestService/requestService.ts
@@ -1,9 +1,9 @@
-import { getBearerTokenFromHeader } from "../../services/utils/requestService";
+import { getBearerToken } from "../../services/utils/getBearerToken";
 import { Result } from "../../utils/result";
 
 export class RequestService implements IRequestService {
   getAuthorizationHeader = (authorizationHeader: string | undefined) => {
-    return getBearerTokenFromHeader(authorizationHeader);
+    return getBearerToken(authorizationHeader);
   };
 }
 

--- a/backend-api/src/functions/asyncCredential/requestService/requestService.ts
+++ b/backend-api/src/functions/asyncCredential/requestService/requestService.ts
@@ -1,6 +1,6 @@
 import { errorResult, Result, successResult } from "../../utils/result";
 import { IRequestBody } from "../asyncCredentialHandler";
-import { getBearerTokenFromHeader } from "../../services/utils/requestService";
+import { getBearerToken } from "../../services/utils/getBearerToken";
 
 export interface IRequestService {
   getAuthorizationHeader: (
@@ -14,7 +14,7 @@ export interface IRequestService {
 
 export class RequestService implements IRequestService {
   getAuthorizationHeader = (authorizationHeader: string | undefined) => {
-    return getBearerTokenFromHeader(authorizationHeader);
+    return getBearerToken(authorizationHeader);
   };
 
   getRequestBody = (

--- a/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
@@ -10,7 +10,7 @@ describe("Token Service", () => {
         const tokenService = new TokenService();
         const invalidJson =
           "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJKV1QifQ.eyJpc3MiOiJtb2NrSXNzdWVyIiwiYXVkIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.fFnJIXCCkFY-LdzcUB7JmedN-97sE2J-J1FT74HJd7o";
-        const authorizationHeader = `Bearer ${invalidJson}`;
+        const authorizationHeader = `${invalidJson}`;
 
         const result = tokenService.getDecodedToken({
           authorizationHeader,
@@ -30,7 +30,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteExp();
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -50,7 +50,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setExp(Math.floor(Date.now() - 1000) / 1000);
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -72,7 +72,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setIat(Math.floor(Date.now() + 1000) / 1000);
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -94,7 +94,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setNbf(Date.now() + 1000);
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -116,7 +116,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteIss();
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -136,7 +136,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setIss("invalidIss");
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -159,7 +159,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteScope();
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -178,7 +178,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setScope("invalidScope");
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -200,7 +200,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteClientId();
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -222,7 +222,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteAud();
-          const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -243,7 +243,7 @@ describe("Token Service", () => {
         const tokenService = new TokenService();
         const jwtBuilder = new MockJWTBuilder();
         jwtBuilder.setExp(1721901143000);
-        const authorizationHeader = `Bearer ${jwtBuilder.getEncodedJwt()}`;
+        const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
 
         const result = tokenService.getDecodedToken({
           authorizationHeader,

--- a/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
@@ -10,7 +10,7 @@ describe("Token Service", () => {
         const tokenService = new TokenService();
         const invalidJson =
           "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJKV1QifQ.eyJpc3MiOiJtb2NrSXNzdWVyIiwiYXVkIjoibW9ja0lzc3VlciIsInNjb3BlIjoiZGNtYXcuc2Vzc2lvbi5hc3luY19jcmVhdGUiCJjbGllbnRfaWQiOiJtb2NrQ2xpZW50SWQifQ.fFnJIXCCkFY-LdzcUB7JmedN-97sE2J-J1FT74HJd7o";
-        const authorizationHeader = `${invalidJson}`;
+        const authorizationHeader = invalidJson;
 
         const result = tokenService.getDecodedToken({
           authorizationHeader,
@@ -30,7 +30,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteExp();
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -50,7 +50,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setExp(Math.floor(Date.now() - 1000) / 1000);
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -72,7 +72,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setIat(Math.floor(Date.now() + 1000) / 1000);
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -94,7 +94,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setNbf(Date.now() + 1000);
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -116,7 +116,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteIss();
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -136,7 +136,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setIss("invalidIss");
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -159,7 +159,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteScope();
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -178,7 +178,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.setScope("invalidScope");
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -200,7 +200,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteClientId();
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -222,7 +222,7 @@ describe("Token Service", () => {
           const tokenService = new TokenService();
           const jwtBuilder = new MockJWTBuilder();
           jwtBuilder.deleteAud();
-          const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+          const authorizationHeader = jwtBuilder.getEncodedJwt();
 
           const result = tokenService.getDecodedToken({
             authorizationHeader,
@@ -243,7 +243,7 @@ describe("Token Service", () => {
         const tokenService = new TokenService();
         const jwtBuilder = new MockJWTBuilder();
         jwtBuilder.setExp(1721901143000);
-        const authorizationHeader = `${jwtBuilder.getEncodedJwt()}`;
+        const authorizationHeader = jwtBuilder.getEncodedJwt();
 
         const result = tokenService.getDecodedToken({
           authorizationHeader,

--- a/backend-api/src/functions/asyncCredential/tokenService/tokenService.ts
+++ b/backend-api/src/functions/asyncCredential/tokenService/tokenService.ts
@@ -5,7 +5,7 @@ import { errorResult, Result, successResult } from "../../utils/result";
 
 export class TokenService implements IDecodeToken, IVerifyTokenSignature {
   getDecodedToken(config: IDecodeTokenConfig): Result<IDecodedToken> {
-    const encodedJwt = config.authorizationHeader.split(" ")[1];
+    const encodedJwt = config.authorizationHeader
 
     const decodedJwtResult = this.decodeToken(encodedJwt);
     if (decodedJwtResult.isError) {

--- a/backend-api/src/functions/asyncCredential/tokenService/tokenService.ts
+++ b/backend-api/src/functions/asyncCredential/tokenService/tokenService.ts
@@ -5,7 +5,7 @@ import { errorResult, Result, successResult } from "../../utils/result";
 
 export class TokenService implements IDecodeToken, IVerifyTokenSignature {
   getDecodedToken(config: IDecodeTokenConfig): Result<IDecodedToken> {
-    const encodedJwt = config.authorizationHeader
+    const encodedJwt = config.authorizationHeader;
 
     const decodedJwtResult = this.decodeToken(encodedJwt);
     if (decodedJwtResult.isError) {

--- a/backend-api/src/functions/services/utils/getBearerToken.ts
+++ b/backend-api/src/functions/services/utils/getBearerToken.ts
@@ -1,6 +1,6 @@
 import { errorResult, Result, successResult } from "../../utils/result";
 
-export const getBearerTokenFromHeader = (
+export const getBearerToken = (
   authorizationHeader: string | undefined,
 ): Result<string> => {
   if (authorizationHeader == null) {
@@ -25,14 +25,14 @@ export const getBearerTokenFromHeader = (
     });
   }
 
-  const jwe = authorizationHeader.split(" ")[1];
+  const token = authorizationHeader.split(" ")[1];
 
-  if (jwe.length == 0) {
+  if (token.length == 0) {
     return errorResult({
       errorMessage: "Invalid authentication header format - missing token",
       errorCategory: "CLIENT_ERROR",
     });
   }
 
-  return successResult(jwe);
+  return successResult(token);
 };


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed
- Updated request service util file and function name to be more specific to what it does
- Updates variable name inside util func, `jwe` now is `token`
- Updates imports
- Updates tokenService to not split header as this is already done in util func
- Updates tokenService tests as func is no longer expecting token starting with the word bearer

### Why did it change
In #183 we changed how a shared util works by returning the token already being split (i.e. not returning the token with the word Bearer at the start). The token service used by the Credential lambda was not expecting this and therefore started returning 500 responses.

This util function is used in the `asyncCredential` and `asyncActiveSession` lambdas.

### Evidence

Previously when calling credential endpoint we'd receive a 500. Ana found the following log:

![Screenshot 2024-09-30 at 15 34 52](https://github.com/user-attachments/assets/2ba9359d-b39b-437e-8f1e-1c7142f33218)

Deployed new stack and now we get a success response again:

![Screenshot 2024-09-30 at 15 35 27](https://github.com/user-attachments/assets/66d40b47-c302-4959-8b1f-163ff3aa52f0)

Also confirmed that activeSession endpoint is still working:

![Screenshot 2024-09-30 at 15 43 22](https://github.com/user-attachments/assets/67ced95b-3a11-4c4b-89d0-3de7c4c43d01)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
