### PR TITLE
DCAMW-8229: Add Lambdas to VPC

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -372,13 +372,13 @@ Resources:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
           SESSION_DURATION_IN_SECONDS: 3600 #Used to set time to live when creating sessions. Set to 1 hour.
-      # VpcConfig:
-      #   SubnetIds:
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdA
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdB
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdC
-      #   SecurityGroupIds:
-      #     - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup
@@ -398,6 +398,7 @@ Resources:
   AsyncCredentialLambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub ${AWS::StackName}-credential-lambda
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -471,9 +472,16 @@ Resources:
                   - kms:Decrypt
                   - kms:GenerateDataKey
                 Resource: !GetAtt TxMAKMSEncryptionKey.Arn
-
-                # TxMA Audit service
-      RoleName: !Sub ${AWS::StackName}-credential-lambda
+        - PolicyName: ENIPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: '*'
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -127,9 +127,9 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSJWKSENDPOINT: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk/.well-known/jwks.json'
+      STSJWKSENDPOINT: 'https://sts-mock-ah.review-b-async.dev.account.gov.uk/.well-known/jwks.json'
     build:
-      STSJWKSENDPOINT: 'https://mob-sts-mock.review-b-async.build.account.gov.uk/.well-known/jwks.json'
+      STSJWKSENDPOINT: 'https://sts-mock-ah.review-b-async.build.account.gov.uk/.well-known/jwks.json'
     # staging:
     #   STSJWKSENDPOINT: '' TODO: Mock should only be used in dev and build. Update this value
     # integration:
@@ -1145,9 +1145,9 @@ Resources:
           JWKS_FILE_NAME: .well-known/jwks.json
       VpcConfig:
         SubnetIds:
-          - !ImportValue devplatform-vpc-PrivateSubnetIdA
-          - !ImportValue devplatform-vpc-PrivateSubnetIdB
-          - !ImportValue devplatform-vpc-PrivateSubnetIdC
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
           - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -259,13 +259,13 @@ Resources:
       Environment:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
-      VpcConfig:
-        SubnetIds:
-          - !ImportValue devplatform-vpc-PrivateSubnetIdA
-          - !ImportValue devplatform-vpc-PrivateSubnetIdB
-          - !ImportValue devplatform-vpc-PrivateSubnetIdC
-        SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+      # VpcConfig:
+      #   SubnetIds:
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdA
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdB
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdC
+      #   SecurityGroupIds:
+      #     - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -362,13 +362,13 @@ Resources:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
           SESSION_DURATION_IN_SECONDS: 3600 #Used to set time to live when creating sessions. Set to 1 hour.
-      VpcConfig:
-        SubnetIds:
-          - !ImportValue devplatform-vpc-PrivateSubnetIdA
-          - !ImportValue devplatform-vpc-PrivateSubnetIdB
-          - !ImportValue devplatform-vpc-PrivateSubnetIdC
-        SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+      # VpcConfig:
+      #   SubnetIds:
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdA
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdB
+      #     - !ImportValue devplatform-vpc-PrivateSubnetIdC
+      #   SecurityGroupIds:
+      #     - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup
@@ -829,6 +829,7 @@ Resources:
   AsyncActiveSessionLambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub ${AWS::StackName}-active-session-lambda
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -855,7 +856,16 @@ Resources:
                 Action:
                   - kms:Decrypt
                 Resource: !GetAtt KMSEncryptionKey.Arn
-      RoleName: !Sub ${AWS::StackName}-active-session-lambda
+        - PolicyName: ENIPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: '*'
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -1143,6 +1143,13 @@ Resources:
           ENCRYPTION_KEY_ID: !Ref KMSEncryptionKey
           JWKS_BUCKET_NAME: !Ref JsonWebKeysBucket
           JWKS_FILE_NAME: .well-known/jwks.json
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   JsonWebKeysFunctionLambdaRole:
     Type: AWS::IAM::Role
@@ -1185,6 +1192,16 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: arn:aws:logs:*:*:*
+        - PolicyName: ENIPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: '*'
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -265,7 +265,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+          - !Ref LambdaEgressSecurityGroup
 
   AsyncTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -378,7 +378,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+          - !Ref LambdaEgressSecurityGroup
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup
@@ -827,7 +827,7 @@ Resources:
           - !ImportValue devplatform-vpc-ProtectedSubnetIdB
           - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+          - !Ref LambdaEgressSecurityGroup
 
   AsyncActiveSessionFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1149,7 +1149,7 @@ Resources:
           - !ImportValue devplatform-vpc-ProtectedSubnetIdB
           - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
-          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+          - !Ref LambdaEgressSecurityGroup
 
   JsonWebKeysFunctionLambdaRole:
     Type: AWS::IAM::Role

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -127,9 +127,9 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSJWKSENDPOINT: 'https://sts-mock-ah.review-b-async.dev.account.gov.uk/.well-known/jwks.json'
+      STSJWKSENDPOINT: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk/.well-known/jwks.json'
     build:
-      STSJWKSENDPOINT: 'https://sts-mock-ah.review-b-async.build.account.gov.uk/.well-known/jwks.json'
+      STSJWKSENDPOINT: 'https://mob-sts-mock.review-b-async.build.account.gov.uk/.well-known/jwks.json'
     # staging:
     #   STSJWKSENDPOINT: '' TODO: Mock should only be used in dev and build. Update this value
     # integration:
@@ -576,7 +576,7 @@ Resources:
         HostedZoneId: !GetAtt ProxyApiDomainName.RegionalHostedZoneId
     Condition: ProxyApiDeployment
 
-  LambdaEgressSecurityGroup:
+  ProxyLambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: !Sub ${AWS::StackName}-proxy-sg
@@ -626,7 +626,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !Ref LambdaEgressSecurityGroup
+          - !Ref ProxyLambdaSecurityGroup
     Condition: ProxyApiDeployment
 
   ProxyLambdaLogGroup:
@@ -1145,9 +1145,9 @@ Resources:
           JWKS_FILE_NAME: .well-known/jwks.json
       VpcConfig:
         SubnetIds:
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
           - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -259,6 +259,13 @@ Resources:
       Environment:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -355,6 +362,13 @@ Resources:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
           SESSION_DURATION_IN_SECONDS: 3600 #Used to set time to live when creating sessions. Set to 1 hour.
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup
@@ -789,6 +803,13 @@ Resources:
           ENCRYPTION_KEY_ARN: !GetAtt KMSEncryptionKey.Arn
           STS_JWKS_ENDPOINT:
             !FindInMap [EnvironmentVariables, !Ref Environment, STSJWKSENDPOINT]
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
+          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncActiveSessionFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -259,13 +259,13 @@ Resources:
       Environment:
         Variables:
           CLIENT_REGISTRY_SECRET_NAME: !Sub ${Environment}/clientRegistry
-      # VpcConfig:
-      #   SubnetIds:
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdA
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdB
-      #     - !ImportValue devplatform-vpc-PrivateSubnetIdC
-      #   SecurityGroupIds:
-      #     - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
+      VpcConfig:
+        SubnetIds:
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
+        SecurityGroupIds:
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -285,6 +285,7 @@ Resources:
   AsyncTokenLambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub ${AWS::StackName}-token-lambda
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -334,7 +335,16 @@ Resources:
                   - kms:Decrypt
                   - kms:GenerateDataKey
                 Resource: !GetAtt TxMAKMSEncryptionKey.Arn
-      RoleName: !Sub ${AWS::StackName}-token-lambda
+        - PolicyName: ENIPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: '*'
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -1145,9 +1145,9 @@ Resources:
           JWKS_FILE_NAME: .well-known/jwks.json
       VpcConfig:
         SubnetIds:
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdA
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdB
-          - !ImportValue devplatform-vpc-ProtectedSubnetIdC
+          - !ImportValue devplatform-vpc-PrivateSubnetIdA
+          - !ImportValue devplatform-vpc-PrivateSubnetIdB
+          - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
           - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -576,7 +576,7 @@ Resources:
         HostedZoneId: !GetAtt ProxyApiDomainName.RegionalHostedZoneId
     Condition: ProxyApiDeployment
 
-  ProxyLambdaSecurityGroup:
+  LambdaEgressSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: !Sub ${AWS::StackName}-proxy-sg
@@ -626,7 +626,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !Ref ProxyLambdaSecurityGroup
+          - !Ref LambdaEgressSecurityGroup
     Condition: ProxyApiDeployment
 
   ProxyLambdaLogGroup:

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -265,7 +265,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !Ref LambdaEgressSecurityGroup
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -378,7 +378,7 @@ Resources:
           - !ImportValue devplatform-vpc-PrivateSubnetIdB
           - !ImportValue devplatform-vpc-PrivateSubnetIdC
         SecurityGroupIds:
-          - !Ref LambdaEgressSecurityGroup
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncCredentialLogGroup:
     Type: AWS::Logs::LogGroup
@@ -827,7 +827,7 @@ Resources:
           - !ImportValue devplatform-vpc-ProtectedSubnetIdB
           - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
-          - !Ref LambdaEgressSecurityGroup
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   AsyncActiveSessionFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1149,7 +1149,7 @@ Resources:
           - !ImportValue devplatform-vpc-ProtectedSubnetIdB
           - !ImportValue devplatform-vpc-ProtectedSubnetIdC
         SecurityGroupIds:
-          - !Ref LambdaEgressSecurityGroup
+          - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
 
   JsonWebKeysFunctionLambdaRole:
     Type: AWS::IAM::Role

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -335,7 +335,7 @@ Resources:
                   - kms:Decrypt
                   - kms:GenerateDataKey
                 Resource: !GetAtt TxMAKMSEncryptionKey.Arn
-        - PolicyName: ENIPolicy
+        - PolicyName: VpcPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -472,7 +472,7 @@ Resources:
                   - kms:Decrypt
                   - kms:GenerateDataKey
                 Resource: !GetAtt TxMAKMSEncryptionKey.Arn
-        - PolicyName: ENIPolicy
+        - PolicyName: VpcPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -658,7 +658,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !GetAtt ProxyLambdaLogGroup.Arn
-        - PolicyName: ENIPolicy
+        - PolicyName: VpcPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -874,7 +874,7 @@ Resources:
                 Action:
                   - kms:Decrypt
                 Resource: !GetAtt KMSEncryptionKey.Arn
-        - PolicyName: ENIPolicy
+        - PolicyName: VpcPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -1192,7 +1192,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: arn:aws:logs:*:*:*
-        - PolicyName: ENIPolicy
+        - PolicyName: VpcPolicy
           PolicyDocument:
             Version: "2012-10-17"
             Statement:

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -465,7 +465,7 @@ describe("Backend application infrastructure", () => {
       });
     });
 
-    test("Create session lambdas have the client registry environment variable", () => {
+    test("Token and Credential lambdas have the client registry environment variable", () => {
       const createSessionLambdaHandlers = [
         "asyncTokenHandler.lambdaHandler",
         "asyncCredentialHandler.lambdaHandler",
@@ -479,6 +479,64 @@ describe("Backend application infrastructure", () => {
                 "Fn::Sub": "${Environment}/clientRegistry",
               },
             },
+          },
+        });
+      });
+    });
+
+    test("All lambdas are attached to a VPC ", () => {
+      const lambdas = template.findResources("AWS::Serverless::Function");
+      const lambda_list = Object.keys(lambdas);
+      lambda_list.forEach((lambda) => {
+        expect(lambdas[lambda].Properties.VpcConfig).toBeTruthy();
+      });
+    });
+
+    test("Token, Credential and JWKS lambdas are attached to a VPC and subnets are private", () => {
+      const lambdaHandlers = [
+        "asyncTokenHandler.lambdaHandler",
+        "asyncCredentialHandler.lambdaHandler",
+        "jwksHandler.lambdaHandler",
+      ];
+      lambdaHandlers.forEach((lambdaHandler) => {
+        template.hasResourceProperties("AWS::Serverless::Function", {
+          Handler: lambdaHandler,
+          VpcConfig: {
+            SubnetIds: [
+              { "Fn::ImportValue": "devplatform-vpc-PrivateSubnetIdA" },
+              { "Fn::ImportValue": "devplatform-vpc-PrivateSubnetIdB" },
+              { "Fn::ImportValue": "devplatform-vpc-PrivateSubnetIdC" },
+            ],
+            SecurityGroupIds: [
+              {
+                "Fn::ImportValue":
+                  "devplatform-vpc-AWSServicesEndpointSecurityGroupId",
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    test("ActiveSession lambda is attached to a VPC and subnets are protected", () => {
+      const activeSessionLambdaHandlers = [
+        "asyncActiveSessionHandler.lambdaHandler",
+      ];
+      activeSessionLambdaHandlers.forEach((lambdaHandler) => {
+        template.hasResourceProperties("AWS::Serverless::Function", {
+          Handler: lambdaHandler,
+          VpcConfig: {
+            SubnetIds: [
+              { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdA" },
+              { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdB" },
+              { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdC" },
+            ],
+            SecurityGroupIds: [
+              {
+                "Fn::ImportValue":
+                  "devplatform-vpc-AWSServicesEndpointSecurityGroupId",
+              },
+            ],
           },
         });
       });

--- a/infra/terraform/base_stacks/vpc.tf
+++ b/infra/terraform/base_stacks/vpc.tf
@@ -16,6 +16,7 @@ resource "aws_cloudformation_stack" "vpc" {
     KMSApiEnabled            = "Yes"
     S3ApiEnabled             = "Yes"
     SQSApiEnabled            = "Yes"
+    SecretsManagerApiEnabled = "Yes"
     SSMApiEnabled            = "Yes"
     AllowRules               = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\".account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
   }

--- a/sts-mock/tests/infrastructure-tests/application.test.ts
+++ b/sts-mock/tests/infrastructure-tests/application.test.ts
@@ -177,6 +177,15 @@ describe("STS mock infrastructure", () => {
         expect(logGroups[logGroup].Properties.RetentionInDays).toEqual(30);
       });
     });
+
+    test("all lambdas are attached to a VPC and subnets are protected", () => {
+      const lambdas = template.findResources("AWS::Serverless::Function");
+      const lambdaList = Object.keys(lambdas);
+      lambdaList.forEach((lambda) => {
+        expect(lambdas[lambda].Properties.VpcConfig.SubnetIds).toEqual([{"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdA"}, {"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdB"}, {"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdC"}])
+        expect(lambdas[lambda].Properties.VpcConfig.SecurityGroupIds).toEqual([{"Fn::ImportValue": "devplatform-vpc-AWSServicesEndpointSecurityGroupId"}])
+      });
+    });
   });
 
   describe("S3", () => {

--- a/sts-mock/tests/infrastructure-tests/application.test.ts
+++ b/sts-mock/tests/infrastructure-tests/application.test.ts
@@ -182,8 +182,17 @@ describe("STS mock infrastructure", () => {
       const lambdas = template.findResources("AWS::Serverless::Function");
       const lambdaList = Object.keys(lambdas);
       lambdaList.forEach((lambda) => {
-        expect(lambdas[lambda].Properties.VpcConfig.SubnetIds).toEqual([{"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdA"}, {"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdB"}, {"Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdC"}])
-        expect(lambdas[lambda].Properties.VpcConfig.SecurityGroupIds).toEqual([{"Fn::ImportValue": "devplatform-vpc-AWSServicesEndpointSecurityGroupId"}])
+        expect(lambdas[lambda].Properties.VpcConfig.SubnetIds).toEqual([
+          { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdA" },
+          { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdB" },
+          { "Fn::ImportValue": "devplatform-vpc-ProtectedSubnetIdC" },
+        ]);
+        expect(lambdas[lambda].Properties.VpcConfig.SecurityGroupIds).toEqual([
+          {
+            "Fn::ImportValue":
+              "devplatform-vpc-AWSServicesEndpointSecurityGroupId",
+          },
+        ]);
       });
     });
   });


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed
- Add `VpcConfig` to Lambda functions and `VpcPolicy` to Lambda IAM Roles for:
  - AsyncToken
  - AsyncCredential
  - AsyncActiveSession
  - Jwks
- Add infra tests

Async backend and STS mock stacks were deployed to dev and tested:

Token & Credential
![Screenshot 2024-10-02 at 19 54 20](https://github.com/user-attachments/assets/de9c4885-1a3a-499f-8447-299357c94990)

STS Mock Token & Active Session
![Screenshot 2024-10-02 at 19 55 24](https://github.com/user-attachments/assets/01ed9bf4-7c35-42a8-84c8-fffb914ff531)



### Why did it change
- It is a security best practice to restrict access to functions

### Evidence

#### All tests passing using `run-tests-locally.sh` script against custom deployed   stack:

![Screenshot 2024-10-01 at 14 44 15](https://github.com/user-attachments/assets/0f541f5d-9827-4488-b70c-de3765a8e5f9)
![Screenshot 2024-10-01 at 14 44 32](https://github.com/user-attachments/assets/f0af0ac7-067c-462a-a841-250ccd388987)
![Screenshot 2024-10-01 at 14 44 51](https://github.com/user-attachments/assets/1479661b-360f-43b1-979e-766a10a5aa0d)


## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
