### PR TITLE
DCMAW-8389: clean up changes introduced in previous PRs

### DIFF
--- a/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
+++ b/backend-api/src/functions/asyncCredential/asyncCredentialHandler.ts
@@ -25,8 +25,6 @@ export async function lambdaHandlerConstructor(
 
   const requestService = new RequestService();
 
-  console.log(JSON.stringify(event.headers));
-
   const authorizationHeaderResult = requestService.getAuthorizationHeader(
     event.headers["Authorization"] ?? event.headers["authorization"],
   );

--- a/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
+++ b/backend-api/src/functions/asyncToken/asyncTokenHandler.ts
@@ -39,8 +39,6 @@ export async function lambdaHandlerConstructor(
     return badRequestResponse("Invalid grant type or grant type not specified");
   }
 
-  console.log(JSON.stringify(event.headers));
-
   const eventHeadersResult = requestService.getClientCredentials(event.headers);
   if (eventHeadersResult.isError) {
     logger.log("INVALID_REQUEST", {

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -32,8 +32,7 @@ export class EventService implements IEventService {
           MessageBody: JSON.stringify(txmaEvent),
         }),
       );
-    } catch (error) {
-      console.log(error);
+    } catch {
       return errorResult({
         errorMessage: "Failed to write to SQS",
         errorCategory: "SERVER_ERROR",

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -32,7 +32,8 @@ export class EventService implements IEventService {
           MessageBody: JSON.stringify(txmaEvent),
         }),
       );
-    } catch {
+    } catch (error) {
+      console.log(error);
       return errorResult({
         errorMessage: "Failed to write to SQS",
         errorCategory: "SERVER_ERROR",

--- a/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
+++ b/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
@@ -121,8 +121,7 @@ describe.each(APIS_TO_TEST)(
           },
         );
 
-        console.log("124 Response:", JSON.stringify(response));
-        console.log("125 Response Data:", JSON.stringify(response.data));
+        console.log("124 Response Data:", JSON.stringify(response.data));
 
         const accessTokenParts = response.data.access_token.split(".");
         const header = JSON.parse(fromBase64(accessTokenParts[0])) as object;
@@ -378,7 +377,7 @@ async function getAccessToken(
     },
   );
 
-  console.log("374 Response:", JSON.stringify(response));
+  console.log("380 Response:", JSON.stringify(response.data));
 
   return response.data.access_token as string;
 }

--- a/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
+++ b/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
@@ -26,9 +26,6 @@ describe.each(APIS_TO_TEST)(
     apiInstance: AxiosInstance,
     authorizationHeader: string,
   ) => {
-    console.log(
-      `apiInstanceName ${apiInstanceName} & authorizationHeader ${authorizationHeader}`,
-    );
     let clientIdAndSecret: string;
 
     beforeAll(async () => {
@@ -120,8 +117,6 @@ describe.each(APIS_TO_TEST)(
             },
           },
         );
-
-        console.log("124 Response Data:", JSON.stringify(response.data));
 
         const accessTokenParts = response.data.access_token.split(".");
         const header = JSON.parse(fromBase64(accessTokenParts[0])) as object;
@@ -376,8 +371,6 @@ async function getAccessToken(
       },
     },
   );
-
-  console.log("380 Response:", JSON.stringify(response.data));
 
   return response.data.access_token as string;
 }

--- a/infra/terraform/base_stacks/vpc.tf
+++ b/infra/terraform/base_stacks/vpc.tf
@@ -9,17 +9,16 @@ resource "aws_cloudformation_stack" "vpc" {
   capabilities = ["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM"]
 
   parameters = {
-    SSMParametersStoreEnabled = "Yes"
-    // TODO: Enable AWS Service APIs as required
-    CloudFormationEndpointEnabled = "Yes"
-    DynamoDBApiEnabled       = "Yes"
-    ExecuteApiGatewayEnabled = "Yes"
-    KMSApiEnabled            = "Yes"
-    LogsApiEnabled           = "Yes"
-    S3ApiEnabled             = "Yes"
-    SQSApiEnabled            = "Yes"
-    SecretsManagerApiEnabled = "Yes"
-    SSMApiEnabled            = "Yes"
-    AllowRules               = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\".account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
+    AllowRules                      = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\".account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
+    CloudFormationEndpointEnabled   = "Yes"
+    DynamoDBApiEnabled              = "Yes"
+    ExecuteApiGatewayEnabled        = "Yes"
+    KMSApiEnabled                   = "Yes"
+    LogsApiEnabled                  = "Yes"
+    S3ApiEnabled                    = "Yes"
+    SecretsManagerApiEnabled        = "Yes"
+    SQSApiEnabled                   = "Yes"
+    SSMApiEnabled                   = "Yes"
+    SSMParametersStoreEnabled       = "Yes"
   }
 }

--- a/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
+++ b/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
@@ -32,43 +32,42 @@ locals {
   // https://developer.hashicorp.com/terraform/language/functions/one
   mob_async_backend_pl = {
     dev = {
-      OneLoginRepositoryName = "mobile-id-check-async"
-
-      IncludePromotion = "No"
-      AllowedServiceOne = "EC2"
-      ProgrammaticPermissionsBoundary = "True"
-
-      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
-      RequireTestContainerSignatureValidation = "Yes"
-      RunTestContainerInVPC    = "True"
-      SigningProfileArn        = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
-      SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
-
-      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_async_backend_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      AllowedServiceOne                         = "EC2"
+      AllowedServiceTwo                         = "SQS"
+      AllowedServiceThree                       = "DynamoDB"
+      ContainerSignerKmsKeyArn                  = one(data.aws_cloudformation_stack.container_signer_dev[*].outputs["ContainerSignerKmsKeyArn"])
+      IncludePromotion                          = "No"
+      OneLoginRepositoryName                    = "mobile-id-check-async"
+      ProgrammaticPermissionsBoundary           = "True"
+      RequireTestContainerSignatureValidation   = "Yes"
+      RunTestContainerInVPC                     = "True"
+      SigningProfileArn                         = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileArn"])
+      SigningProfileVersionArn                  = one(data.aws_cloudformation_stack.signer_dev[*].outputs["SigningProfileVersionArn"])
+      TestImageRepositoryUri                    = one(aws_cloudformation_stack.mob_async_backend_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     build = {
-      OneLoginRepositoryName = "mobile-id-check-async"
-
-      IncludePromotion = "Yes"
-      AllowedAccounts  = local.account_vars.staging.account_id
-
-      ContainerSignerKmsKeyArn = one(data.aws_cloudformation_stack.container_signer_build[*].outputs["ContainerSignerKmsKeyArn"])
-      RequireTestContainerSignatureValidation = "Yes"
-
-      SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
-      SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
-
-      TestImageRepositoryUri = one(aws_cloudformation_stack.mob_async_backend_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      AllowedAccounts                           = local.account_vars.staging.account_id
+      AllowedServiceOne                         = "EC2"
+      AllowedServiceTwo                         = "SQS"
+      AllowedServiceThree                       = "DynamoDB"
+      ContainerSignerKmsKeyArn                  = one(data.aws_cloudformation_stack.container_signer_build[*].outputs["ContainerSignerKmsKeyArn"])
+      IncludePromotion                          = "Yes"
+      OneLoginRepositoryName                    = "mobile-id-check-async"
+      ProgrammaticPermissionsBoundary           = "True"
+      RequireTestContainerSignatureValidation   = "Yes"
+      RunTestContainerInVPC                     = "True"
+      SigningProfileArn                         = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
+      SigningProfileVersionArn                  = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
+      TestImageRepositoryUri                    = one(aws_cloudformation_stack.mob_async_backend_tir[*].outputs["TestRunnerImageEcrRepositoryUri"])
     }
 
     staging = {
       ArtifactSourceBucketArn                 = one(data.aws_cloudformation_stack.mob_async_backend_pl_build[*].outputs["ArtifactPromotionBucketArn"])
       ArtifactSourceBucketEventTriggerRoleArn = one(data.aws_cloudformation_stack.mob_async_backend_pl_build[*].outputs["ArtifactPromotionBucketEventTriggerRoleArn"])
+      AllowedAccounts  = null # join(",", [local.account_vars.integration.account_id, local.account_vars.production.account_id])  # Stopping promotion at staging
 
-      # Stopping promotion at staging
-      IncludePromotion = "No" # "Yes"
-      AllowedAccounts  = null # join(",", [local.account_vars.integration.account_id, local.account_vars.production.account_id])
+      IncludePromotion = "No" # "Yes"  # Stopping promotion at staging
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8389

Relates to PRs https://github.com/govuk-one-login/mobile-id-check-async/pull/201, https://github.com/govuk-one-login/mobile-id-check-async/pull/203 & https://github.com/govuk-one-login/mobile-id-check-async/pull/202

### What changed
- Remove temporary log messages 
- Put  `mob_async_backend_pl.tf` and `vpc.tf` in alphabetical order
- The following infra changes introduced in the previous PRs liked above:

**mob_async_backend_pl.tf**
```
AllowedServiceOne = "EC2"
AllowedServiceTwo = "SQS"
AllowedServiceThree = "DynamoDB"
RunTestContainerInVPC = "True"
ProgrammaticPermissionsBoundary = "True"
```

**vpc.tf**
```
CloudFormationEndpointEnabled = "Yes"
LogsApiEnabled = "Yes"
```

### Why did it change
- To allow API test to run in the VPC

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
