### PR TITLE
DCMAW-8389: use aws4Interceptor with proxy API only

### DIFF
--- a/backend-api/tests/api-tests/utils/apiInstance.ts
+++ b/backend-api/tests/api-tests/utils/apiInstance.ts
@@ -4,7 +4,7 @@ import "dotenv/config";
 import { aws4Interceptor } from "aws4-axios";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
-function getInstance(baseUrl: string, isProxy: boolean = false) {
+function getInstance(baseUrl: string, isProxyApi: boolean = false) {
   const apiInstance = axios.create({ baseURL: baseUrl });
   axiosRetry(apiInstance, {
     retries: 2,
@@ -12,7 +12,7 @@ function getInstance(baseUrl: string, isProxy: boolean = false) {
   });
   apiInstance.defaults.validateStatus = () => true;
 
-  if (isProxy) {
+  if (isProxyApi) {
     const interceptor = aws4Interceptor({
       options: {
         region: "eu-west-2",

--- a/backend-api/tests/api-tests/utils/apiInstance.ts
+++ b/backend-api/tests/api-tests/utils/apiInstance.ts
@@ -4,7 +4,7 @@ import "dotenv/config";
 import { aws4Interceptor } from "aws4-axios";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
-function getInstance(baseUrl: string, isProxyApi: boolean = false) {
+function getInstance(baseUrl: string, useAwsSigv4Signing: boolean = false) {
   const apiInstance = axios.create({ baseURL: baseUrl });
   axiosRetry(apiInstance, {
     retries: 2,
@@ -12,7 +12,7 @@ function getInstance(baseUrl: string, isProxyApi: boolean = false) {
   });
   apiInstance.defaults.validateStatus = () => true;
 
-  if (isProxyApi) {
+  if (useAwsSigv4Signing) {
     const interceptor = aws4Interceptor({
       options: {
         region: "eu-west-2",

--- a/backend-api/tests/api-tests/utils/apiInstance.ts
+++ b/backend-api/tests/api-tests/utils/apiInstance.ts
@@ -4,33 +4,30 @@ import "dotenv/config";
 import { aws4Interceptor } from "aws4-axios";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
-function getInstance(baseUrl: string) {
+function getInstance(baseUrl: string, isProxy: boolean = false) {
   const apiInstance = axios.create({ baseURL: baseUrl });
   axiosRetry(apiInstance, {
     retries: 2,
     retryDelay: (retryCount) => retryCount * 200,
   });
   apiInstance.defaults.validateStatus = () => true;
-  axiosRetry(apiInstance, {
-    retries: 2,
-    retryDelay: (retryCount) => retryCount * 200,
-  });
 
-  const interceptor = aws4Interceptor({
-    options: {
-      region: "eu-west-2",
-      service: "execute-api",
-    },
-    credentials: {
-      getCredentials: fromNodeProviderChain({
-        timeout: 1000,
-        maxRetries: 1,
-        profile: process.env.AWS_PROFILE,
-      }),
-    },
-  });
-
-  apiInstance.interceptors.request.use(interceptor);
+  if (isProxy) {
+    const interceptor = aws4Interceptor({
+      options: {
+        region: "eu-west-2",
+        service: "execute-api",
+      },
+      credentials: {
+        getCredentials: fromNodeProviderChain({
+          timeout: 1000,
+          maxRetries: 1,
+          profile: process.env.AWS_PROFILE,
+        }),
+      },
+    });
+    apiInstance.interceptors.request.use(interceptor);
+  }
 
   return apiInstance;
 }
@@ -46,7 +43,7 @@ function getProxyApiInstance() {
   const apiUrl = process.env.PROXY_API_URL;
   if (!apiUrl)
     throw new Error("PROXY_API_URL needs to be defined for API tests");
-  return getInstance(apiUrl);
+  return getInstance(apiUrl, true);
 }
 
 function getPrivateApiInstance() {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8389

### What changed
- Fix API tests so that `aws4Interceptor` is only used with the proxy API and not the others

![Screenshot 2024-10-07 at 16 35 47](https://github.com/user-attachments/assets/9578cf09-e3ea-4af8-8b4c-19fadba764a5)

### Why did it change
- `aws4Interceptor` not required for public and private APIs 

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
