### PR TITLE
DCMAW-8389: fix header when calling private API

### DIFF
--- a/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
+++ b/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
@@ -175,7 +175,7 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer invalid.access.token",
+                [authorizationHeader]: "Bearer invalid.access.token",
               },
             },
           );
@@ -195,7 +195,7 @@ describe.each(APIS_TO_TEST)(
             "invalidRequestBody",
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessToken,
+                [authorizationHeader]: "Bearer " + accessToken,
               },
             },
           );
@@ -220,7 +220,8 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessTokenWithInvalidSignature,
+                [authorizationHeader]:
+                  "Bearer " + accessTokenWithInvalidSignature,
               },
             },
           );
@@ -238,7 +239,7 @@ describe.each(APIS_TO_TEST)(
           // Create session if it does not exist
           await apiInstance.post(`/async/credential`, credentialRequestBody, {
             headers: {
-              "X-Custom-Auth": "Bearer " + accessToken,
+              [authorizationHeader]: "Bearer " + accessToken,
             },
           });
 
@@ -247,7 +248,7 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessToken,
+                [authorizationHeader]: "Bearer " + accessToken,
               },
             },
           );
@@ -268,7 +269,7 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessToken,
+                [authorizationHeader]: "Bearer " + accessToken,
               },
             },
           );
@@ -279,7 +280,7 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessToken,
+                [authorizationHeader]: "Bearer " + accessToken,
               },
             },
           );
@@ -310,7 +311,7 @@ describe.each(APIS_TO_TEST)(
             credentialRequestBody,
             {
               headers: {
-                "X-Custom-Auth": "Bearer " + accessToken,
+                [authorizationHeader]: "Bearer " + accessToken,
               },
             },
           );


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8389

### What changed
- Fix API tests so that private API endpoints are invoked with `"Authorization"` instead of `"x-custom-auth"` in the header

![Screenshot 2024-10-07 at 17 06 23](https://github.com/user-attachments/assets/ccafd0c5-5865-4457-a58c-245cd1107ad8)


### Why did it change
<!-- Describe the reason these changes were made - the "why" -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
