### PR TITLE
[DCMAW-10280] Set apis to use new async SSM parameter

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -543,7 +543,7 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}'
+      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN}}'
       SecurityPolicy: TLS_1_2
     Condition: ProxyApiDeployment
 
@@ -761,7 +761,7 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}'
+      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN}}'
       SecurityPolicy: TLS_1_2
 
   SessionsApiBasePathMapping:

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -108,7 +108,7 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}'
+      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN}}'
       SecurityPolicy: TLS_1_2
 
   StsMockApiBasePathMapping:


### PR DESCRIPTION
​DCMAW-10280

### What changed
Move over the BE and sts-mock resources to the new async DNS certificates

### Why did it change
To add additional DNS names for our new API resources

[See first PR for update SSM parameter for new certificate being referenced here](https://github.com/govuk-one-login/mobile-id-check-async/pull/172)

Dev stacks attached to new certificate:

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/d0da3513-f2e0-4940-8d40-3047f0f24209">

BE on new certificate:

<img width="826" alt="image" src="https://github.com/user-attachments/assets/5ff71556-5cdc-46c7-997a-ddf0bc999b4a">

sts-mock on new certificate:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/80eade10-a31a-44fe-8b0c-f41b6ddb3f80">

