### PR TITLE
[DCMAW-10280] Remove test stage from Staging pipeline

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -48,8 +48,8 @@ Mappings:
       ApiBurstLimit: 10
       ApiRateLimit: 10
     build:
-      ApiBurstLimit: 0
-      ApiRateLimit: 0
+      ApiBurstLimit: 10
+      ApiRateLimit: 10
     staging:
       ApiBurstLimit: 0
       ApiRateLimit: 0

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -204,7 +204,7 @@ describe("Backend application infrastructure", () => {
       test("Rate and burst limit mappings are set", () => {
         const expectedBurstLimits = {
           dev: 10,
-          build: 0,
+          build: 10,
           staging: 0,
           integration: 0,
           production: 0,
@@ -212,7 +212,7 @@ describe("Backend application infrastructure", () => {
 
         const expectedRateLimits = {
           dev: 10,
-          build: 0,
+          build: 10,
           staging: 0,
           integration: 0,
           production: 0,

--- a/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
+++ b/infra/terraform/secure_pipelines/mob_async_backend_pl.tf
@@ -71,8 +71,7 @@ locals {
 
       SigningProfileArn        = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileArn"])
       SigningProfileVersionArn = one(data.aws_cloudformation_stack.signer_build[*].outputs["SigningProfileVersionArn"])
-
-      TestImageRepositoryUri = one(data.aws_cloudformation_stack.mob_async_backend_tir_build[*].outputs["TestRunnerImageEcrRepositoryUri"])
+      
     }
 
     integration = {


### PR DESCRIPTION
​DCMAW-10280

### What changed
Remove the TestImageUriRepository value from the Staging pipeline parameters as we do not run the test container in the Staging pipeline.

Update sessions api rate limits to allow tests to run on sessions api

### Why did it change
We don't run tests in Staging.

Test stage removed from pipeline:

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/c9d113a6-d298-463d-94f7-8118459756d2">

