### PR TITLE
fix: change DynamoDB table name back to what it was

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -680,7 +680,7 @@ Resources:
     # checkov:skip=CKV_AWS_28:Ensure Dynamodb point in time recovery (backup) is enabled
     # checkov:skip=CKV_AWS_119:No PII in table
     Properties:
-      TableName: !Sub ${AWS::StackName}-sessions-table-${Environment}-temp
+      TableName: !Sub ${AWS::StackName}-sessions-table-${Environment}
       AttributeDefinitions:
         - AttributeName: sessionId
           AttributeType: S


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed
- Remove `-temp` from DynamoDB table name

### Why did it change
- `-temp` was only added temporarily to allow changes to be made to the resource in a separate PR

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
