### PR TITLE
[DCMAW-10280] rename sessions table to see if it will fix deployments

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -680,7 +680,7 @@ Resources:
     # checkov:skip=CKV_AWS_28:Ensure Dynamodb point in time recovery (backup) is enabled
     # checkov:skip=CKV_AWS_119:No PII in table
     Properties:
-      TableName: !Sub ${AWS::StackName}-sessions-table-${Environment}
+      TableName: !Sub ${AWS::StackName}-to-revert-${Environment}
       AttributeDefinitions:
         - AttributeName: sessionId
           AttributeType: S


### PR DESCRIPTION
​DCMAW-10280

### What changed
As part of trying to fix deployments in Staging, renaming the Sessions Table temporarily to see if it will deploy in the Staging environment.

### Why did it change
Because Staging deployments are failing due to the sessions table.


