### PR TITLE
DCMAW-8229: Extract token verification logic

### DIFF
--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
@@ -8,7 +8,7 @@ import { Logger } from "../services/logging/logger";
 import { MockJWTBuilder } from "../testUtils/mockJwtBuilder";
 import { errorResult, Result, successResult } from "../utils/result";
 import { ITokenService } from "./tokenService/tokenService";
-import { MockPubicKeyGetterGetPublicKeySuccess } from "./tokenService/tests/mocks";
+import { MockPubicKeyGetterGetPublicKeySuccess,   MockTokenVerifierVerifySuccess } from "./tokenService/tests/mocks";
 import {
   MockSessionServiceGetErrorResult,
   MockSessionServiceGetSuccessResult,
@@ -32,6 +32,7 @@ describe("Async Active Session", () => {
       logger: () => new Logger(mockLoggingAdapter, registeredLogs),
       tokenServiceDependencies: {
         publicKeyGetter: () => new MockPubicKeyGetterGetPublicKeySuccess(),
+        tokenVerifier: () => new MockTokenVerifierVerifySuccess()
       },
       tokenService: () => new MockTokenServiceSuccess(),
       sessionService: () => new MockSessionServiceGetSuccessResult(),

--- a/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/asyncActiveSessionHandler.test.ts
@@ -8,7 +8,10 @@ import { Logger } from "../services/logging/logger";
 import { MockJWTBuilder } from "../testUtils/mockJwtBuilder";
 import { errorResult, Result, successResult } from "../utils/result";
 import { ITokenService } from "./tokenService/tokenService";
-import { MockPubicKeyGetterGetPublicKeySuccess,   MockTokenVerifierVerifySuccess } from "./tokenService/tests/mocks";
+import {
+  MockPubicKeyGetterGetPublicKeySuccess,
+  MockTokenVerifierVerifySuccess,
+} from "./tokenService/tests/mocks";
 import {
   MockSessionServiceGetErrorResult,
   MockSessionServiceGetSuccessResult,
@@ -32,7 +35,7 @@ describe("Async Active Session", () => {
       logger: () => new Logger(mockLoggingAdapter, registeredLogs),
       tokenServiceDependencies: {
         publicKeyGetter: () => new MockPubicKeyGetterGetPublicKeySuccess(),
-        tokenVerifier: () => new MockTokenVerifierVerifySuccess()
+        tokenVerifier: () => new MockTokenVerifierVerifySuccess(),
       },
       tokenService: () => new MockTokenServiceSuccess(),
       sessionService: () => new MockSessionServiceGetSuccessResult(),

--- a/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
+++ b/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
@@ -11,9 +11,11 @@ import {
   ITokenServiceDependencies,
   TokenService,
 } from "./tokenService/tokenService";
+import { TokenVerifier } from "./tokenService/tokenVerifier";
 
 const tokenServiceDependencies: ITokenServiceDependencies = {
   publicKeyGetter: () => new PublicKeyGetter(),
+  tokenVerifier: () => new TokenVerifier()
 };
 
 export interface IAsyncActiveSessionDependencies {

--- a/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
+++ b/backend-api/src/functions/asyncActiveSession/handlerDependencies.ts
@@ -15,7 +15,7 @@ import { TokenVerifier } from "./tokenService/tokenVerifier";
 
 const tokenServiceDependencies: ITokenServiceDependencies = {
   publicKeyGetter: () => new PublicKeyGetter(),
-  tokenVerifier: () => new TokenVerifier()
+  tokenVerifier: () => new TokenVerifier(),
 };
 
 export interface IAsyncActiveSessionDependencies {

--- a/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
@@ -63,7 +63,7 @@ export interface IJwks {
   keys: IJwk[];
 }
 
-interface IJwk extends JsonWebKey {
+export interface IJwk extends JsonWebKey {
   alg: "ES256";
   kid: string;
   kty: "EC";

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
@@ -1,4 +1,4 @@
-import { KeyLike, JWTVerifyResult } from "jose";
+import { JWTVerifyResult } from "jose";
 import { errorResult, Result, successResult } from "../../../utils/result";
 import { IPublicKeyGetter } from "../publicKeyGetter";
 import { ITokenVerifier } from "../tokenVerifier";
@@ -21,25 +21,27 @@ export class MockPubicKeyGetterGetPublicKeySuccess implements IPublicKeyGetter {
 }
 
 export class MockTokenVerifierVerifyError implements ITokenVerifier {
-  verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
-    return Promise.reject("Error verifying token signature")
+  verify(): Promise<Result<JWTVerifyResult>> {
+    return Promise.reject("Error verifying token signature");
   }
 }
 
 export class MockTokenVerifierVerifySuccess implements ITokenVerifier {
-  verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
-    return Promise.resolve(successResult({
-      "protectedHeader": {
-        "alg": "ES256",
-        "typ": "JWT",
-      },
-      "payload": {
-        "aud": "mockIssuer",
-        "client_id": "mockClientId",
-        "exp": 1728994993626,
-        "iss": "mockIssuer",
-        "scope": "dcmaw.session.async_create",
-      }
-    }))
+  verify(): Promise<Result<JWTVerifyResult>> {
+    return Promise.resolve(
+      successResult({
+        protectedHeader: {
+          alg: "ES256",
+          typ: "JWT",
+        },
+        payload: {
+          aud: "mockIssuer",
+          client_id: "mockClientId",
+          exp: 1728994993626,
+          iss: "mockIssuer",
+          scope: "dcmaw.session.async_create",
+        },
+      }),
+    );
   }
 }

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
@@ -1,5 +1,7 @@
-import { errorResult, successResult } from "../../../utils/result";
+import { KeyLike, JWTVerifyResult } from "jose";
+import { errorResult, Result, successResult } from "../../../utils/result";
 import { IPublicKeyGetter } from "../publicKeyGetter";
+import { ITokenVerifier } from "../tokenVerifier";
 
 export class MockPubicKeyGetterGetPublicKeyError implements IPublicKeyGetter {
   getPublicKey() {
@@ -15,5 +17,29 @@ export class MockPubicKeyGetterGetPublicKeyError implements IPublicKeyGetter {
 export class MockPubicKeyGetterGetPublicKeySuccess implements IPublicKeyGetter {
   getPublicKey() {
     return Promise.resolve(successResult(new Uint8Array()));
+  }
+}
+
+export class MockTokenVerifierVerifyError implements ITokenVerifier {
+  verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
+    return Promise.reject("Error verifying token signature")
+  }
+}
+
+export class MockTokenVerifierVerifySuccess implements ITokenVerifier {
+  verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
+    return Promise.resolve(successResult({
+      "protectedHeader": {
+        "alg": "ES256",
+        "typ": "JWT",
+      },
+      "payload": {
+        "aud": "mockIssuer",
+        "client_id": "mockClientId",
+        "exp": 1728994993626,
+        "iss": "mockIssuer",
+        "scope": "dcmaw.session.async_create",
+      }
+    }))
   }
 }

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
@@ -22,10 +22,12 @@ export class MockPubicKeyGetterGetPublicKeySuccess implements IPublicKeyGetter {
 
 export class MockTokenVerifierVerifyError implements ITokenVerifier {
   verify(): Promise<Result<JWTVerifyResult>> {
-    return Promise.resolve(errorResult({
-      errorMessage: "Error verifying token signature",
-      errorCategory: "CLIENT_ERROR"
-    }));
+    return Promise.resolve(
+      errorResult({
+        errorMessage: "Error verifying token signature",
+        errorCategory: "CLIENT_ERROR",
+      }),
+    );
   }
 }
 

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/mocks.ts
@@ -22,7 +22,10 @@ export class MockPubicKeyGetterGetPublicKeySuccess implements IPublicKeyGetter {
 
 export class MockTokenVerifierVerifyError implements ITokenVerifier {
   verify(): Promise<Result<JWTVerifyResult>> {
-    return Promise.reject("Error verifying token signature");
+    return Promise.resolve(errorResult({
+      errorMessage: "Error verifying token signature",
+      errorCategory: "CLIENT_ERROR"
+    }));
   }
 }
 

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
@@ -355,7 +355,7 @@ describe("Token Service", () => {
     });
 
     describe("Token signature verification", () => {
-      describe("Given there is an error getting public key from JWKS (e.g. kid from JWT header is not found in JWKS)", () => {
+      describe("Given there is an error getting public key from JWKS (e.g. when kid from JWT header is not found in JWKS)", () => {
         it("Returns error result", async () => {
           dependencies.publicKeyGetter = () =>
             new MockPubicKeyGetterGetPublicKeyError();

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
@@ -23,7 +23,7 @@ describe("Token Service", () => {
   beforeEach(() => {
     dependencies = {
       publicKeyGetter: () => new MockPubicKeyGetterGetPublicKeySuccess(),
-      tokenVerifier: () => new MockTokenVerifierVerifySuccess()
+      tokenVerifier: () => new MockTokenVerifierVerifySuccess(),
     };
     tokenService = new TokenService(dependencies);
     mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
@@ -400,7 +400,7 @@ describe("Token Service", () => {
 
       describe("Given there is an error verifying token signature", () => {
         it("Returns error result", async () => {
-          dependencies.tokenVerifier = () => new MockTokenVerifierVerifyError()
+          dependencies.tokenVerifier = () => new MockTokenVerifierVerifyError();
           tokenService = new TokenService(dependencies);
           jest.spyOn(global, "fetch").mockImplementation(() =>
             Promise.resolve({

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
@@ -12,6 +12,7 @@ import { mockClient } from "aws-sdk-client-mock";
 import {
   MockPubicKeyGetterGetPublicKeyError,
   MockPubicKeyGetterGetPublicKeySuccess,
+  MockTokenVerifierVerifySuccess,
 } from "./mocks";
 
 describe("Token Service", () => {
@@ -22,6 +23,7 @@ describe("Token Service", () => {
   beforeEach(() => {
     dependencies = {
       publicKeyGetter: () => new MockPubicKeyGetterGetPublicKeySuccess(),
+      tokenVerifier: () => new MockTokenVerifierVerifySuccess()
     };
     tokenService = new TokenService(dependencies);
     mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenService.test.ts
@@ -355,7 +355,7 @@ describe("Token Service", () => {
     });
 
     describe("Token signature verification", () => {
-      describe("Given kid from JWT header is not found in JWKS", () => {
+      describe("Given there is an error getting public key from JWKS (e.g. kid from JWT header is not found in JWKS)", () => {
         it("Returns error result", async () => {
           dependencies.publicKeyGetter = () =>
             new MockPubicKeyGetterGetPublicKeyError();
@@ -374,7 +374,6 @@ describe("Token Service", () => {
                       {
                         crv: "mockCrv",
                         d: "mockD",
-                        kid: "mockKid",
                         kty: "mockKty",
                         x: "mockX",
                         y: "mockY",

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
@@ -1,84 +1,92 @@
-import { KeyLike } from "jose"
-import { MockJWTBuilder } from "../../../testUtils/mockJwtBuilder"
-import { ITokenVerifier, TokenVerifier } from "../tokenVerifier"
+import { KeyLike } from "jose";
+import { MockJWTBuilder } from "../../../testUtils/mockJwtBuilder";
+import { ITokenVerifier, TokenVerifier } from "../tokenVerifier";
 
 const MOCK_PUBLIC_KEY = {
-  "alg":"ES256",
-  "crv":"P-256",
-  "kid":"sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
-  "kty":"EC",
-  "use":"sig",
-  "x":"YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
-  "y":"47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
-}
+  alg: "ES256",
+  crv: "P-256",
+  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  kty: "EC",
+  use: "sig",
+  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+};
 
 const MOCK_INCORRECT_PULIC_KEY = {
-  "alg": "ES256",
-  "crv": "P-256",
-  "kid": "mockKid",
-  "kty": "EC",
-  "use": "sig",
-  "x": "NYmnFqCEFMVXQsmnSngTkiJK-Q9ixSBxLAXx6ZsBGlc",
-  "y": "9fpDnWl3rBP-T6z6e60Bmgym3ymjRK_VSdJ7wU_Nwvg",
-}
+  alg: "ES256",
+  crv: "P-256",
+  kid: "mockKid",
+  kty: "EC",
+  use: "sig",
+  x: "NYmnFqCEFMVXQsmnSngTkiJK-Q9ixSBxLAXx6ZsBGlc",
+  y: "9fpDnWl3rBP-T6z6e60Bmgym3ymjRK_VSdJ7wU_Nwvg",
+};
 
 const MOCK_PRIVATE_KEY = {
-  "crv":"P-256",
-  "d":"IMeUPld6UA1WUKJF34HDwZGT2tArxZslpl_dVYzOLKU",
-  "kid":"sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
-  "kty":"EC",
-  "x":"YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
-  "y":"47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
-}
+  crv: "P-256",
+  d: "IMeUPld6UA1WUKJF34HDwZGT2tArxZslpl_dVYzOLKU",
+  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  kty: "EC",
+  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+};
 
 describe("Token Verifier", () => {
-  let tokenVerifier: ITokenVerifier
-  let mockPublicKey: KeyLike | Uint8Array
-  let mockJwt: string
+  let tokenVerifier: ITokenVerifier;
+  let mockPublicKey: KeyLike | Uint8Array;
+  let mockJwt: string;
 
   beforeEach(async () => {
-    tokenVerifier = new TokenVerifier()
-    mockJwt = new MockJWTBuilder().getEncodedJwt()
-    mockPublicKey = await MockJWTBuilder.getPublicKey(MOCK_PUBLIC_KEY)
-  })
+    tokenVerifier = new TokenVerifier();
+    mockJwt = new MockJWTBuilder().getEncodedJwt();
+    mockPublicKey = await MockJWTBuilder.getPublicKey(MOCK_PUBLIC_KEY);
+  });
 
   describe("Verify", () => {
     describe("Given there is an error verifying token signature", () => {
       it("Returns error result", async () => {
-        const mockJwt = await new MockJWTBuilder().getEncodedJwt()
-        const mockIncorrectPublicKey = await MockJWTBuilder.getPublicKey(MOCK_INCORRECT_PULIC_KEY)
+        const mockJwt = await new MockJWTBuilder().getEncodedJwt();
+        const mockIncorrectPublicKey = await MockJWTBuilder.getPublicKey(
+          MOCK_INCORRECT_PULIC_KEY,
+        );
 
-        const result = await tokenVerifier.verify(mockJwt, mockIncorrectPublicKey)
+        const result = await tokenVerifier.verify(
+          mockJwt,
+          mockIncorrectPublicKey,
+        );
 
-        expect(result.isError).toBe(true)
+        expect(result.isError).toBe(true);
         expect(result.value).toStrictEqual({
-          errorMessage: "Error verifying token signature: JWSSignatureVerificationFailed: signature verification failed",
+          errorMessage:
+            "Error verifying token signature: JWSSignatureVerificationFailed: signature verification failed",
           errorCategory: "SERVER_ERROR",
-        })
-      })
-    })
+        });
+      });
+    });
 
     describe("Given token signature verification is successful", () => {
       it("Returns success result", async () => {
-        mockJwt = await new MockJWTBuilder().setExp(1728994993626).getSignedEncodedJwt(MOCK_PRIVATE_KEY)
+        mockJwt = await new MockJWTBuilder()
+          .setExp(1728994993626)
+          .getSignedEncodedJwt(MOCK_PRIVATE_KEY);
 
-        const result = await tokenVerifier.verify(mockJwt, mockPublicKey)
+        const result = await tokenVerifier.verify(mockJwt, mockPublicKey);
 
-        expect(result.isError).toBe(false)
+        expect(result.isError).toBe(false);
         expect(result.value).toStrictEqual({
-          "protectedHeader": {
-            "alg": "ES256",
-            "typ": "JWT",
+          protectedHeader: {
+            alg: "ES256",
+            typ: "JWT",
           },
-          "payload": {
-            "aud": "mockIssuer",
-            "client_id": "mockClientId",
-            "exp": 1728994993626,
-            "iss": "mockIssuer",
-            "scope": "dcmaw.session.async_create",
+          payload: {
+            aud: "mockIssuer",
+            client_id: "mockClientId",
+            exp: 1728994993626,
+            iss: "mockIssuer",
+            scope: "dcmaw.session.async_create",
           },
-        })
-      })
-    })
-  })
-})
+        });
+      });
+    });
+  });
+});

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
@@ -1,0 +1,84 @@
+import { KeyLike } from "jose"
+import { MockJWTBuilder } from "../../../testUtils/mockJwtBuilder"
+import { ITokenVerifier, TokenVerifier } from "../tokenVerifier"
+
+const MOCK_PUBLIC_KEY = {
+  "alg":"ES256",
+  "crv":"P-256",
+  "kid":"sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  "kty":"EC",
+  "use":"sig",
+  "x":"YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  "y":"47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+}
+
+const MOCK_INCORRECT_PULIC_KEY = {
+  "alg": "ES256",
+  "crv": "P-256",
+  "kid": "mockKid",
+  "kty": "EC",
+  "use": "sig",
+  "x": "NYmnFqCEFMVXQsmnSngTkiJK-Q9ixSBxLAXx6ZsBGlc",
+  "y": "9fpDnWl3rBP-T6z6e60Bmgym3ymjRK_VSdJ7wU_Nwvg",
+}
+
+const MOCK_PRIVATE_KEY = {
+  "crv":"P-256",
+  "d":"IMeUPld6UA1WUKJF34HDwZGT2tArxZslpl_dVYzOLKU",
+  "kid":"sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  "kty":"EC",
+  "x":"YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  "y":"47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+}
+
+describe("Token Verifier", () => {
+  let tokenVerifier: ITokenVerifier
+  let mockPublicKey: KeyLike | Uint8Array
+  let mockJwt: string
+
+  beforeEach(async () => {
+    tokenVerifier = new TokenVerifier()
+    mockJwt = new MockJWTBuilder().getEncodedJwt()
+    mockPublicKey = await MockJWTBuilder.getPublicKey(MOCK_PUBLIC_KEY)
+  })
+
+  describe("Verify", () => {
+    describe("Given there is an error verifying token signature", () => {
+      it("Returns error result", async () => {
+        const mockJwt = await new MockJWTBuilder().getEncodedJwt()
+        const mockIncorrectPublicKey = await MockJWTBuilder.getPublicKey(MOCK_INCORRECT_PULIC_KEY)
+
+        const result = await tokenVerifier.verify(mockJwt, mockIncorrectPublicKey)
+
+        expect(result.isError).toBe(true)
+        expect(result.value).toStrictEqual({
+          errorMessage: "Error verifying token signature: JWSSignatureVerificationFailed: signature verification failed",
+          errorCategory: "SERVER_ERROR",
+        })
+      })
+    })
+
+    describe("Given token signature verification is successful", () => {
+      it("Returns success result", async () => {
+        mockJwt = await new MockJWTBuilder().setExp(1728994993626).getSignedEncodedJwt(MOCK_PRIVATE_KEY)
+
+        const result = await tokenVerifier.verify(mockJwt, mockPublicKey)
+
+        expect(result.isError).toBe(false)
+        expect(result.value).toStrictEqual({
+          "protectedHeader": {
+            "alg": "ES256",
+            "typ": "JWT",
+          },
+          "payload": {
+            "aud": "mockIssuer",
+            "client_id": "mockClientId",
+            "exp": 1728994993626,
+            "iss": "mockIssuer",
+            "scope": "dcmaw.session.async_create",
+          },
+        })
+      })
+    })
+  })
+})

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
@@ -2,35 +2,6 @@ import { KeyLike } from "jose";
 import { MockJWTBuilder } from "../../../testUtils/mockJwtBuilder";
 import { ITokenVerifier, TokenVerifier } from "../tokenVerifier";
 
-const MOCK_PUBLIC_KEY = {
-  alg: "ES256",
-  crv: "P-256",
-  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
-  kty: "EC",
-  use: "sig",
-  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
-  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
-};
-
-const MOCK_INCORRECT_PULIC_KEY = {
-  alg: "ES256",
-  crv: "P-256",
-  kid: "mockKid",
-  kty: "EC",
-  use: "sig",
-  x: "NYmnFqCEFMVXQsmnSngTkiJK-Q9ixSBxLAXx6ZsBGlc",
-  y: "9fpDnWl3rBP-T6z6e60Bmgym3ymjRK_VSdJ7wU_Nwvg",
-};
-
-const MOCK_PRIVATE_KEY = {
-  crv: "P-256",
-  d: "IMeUPld6UA1WUKJF34HDwZGT2tArxZslpl_dVYzOLKU",
-  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
-  kty: "EC",
-  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
-  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
-};
-
 describe("Token Verifier", () => {
   let tokenVerifier: ITokenVerifier;
   let mockPublicKey: KeyLike | Uint8Array;
@@ -90,3 +61,32 @@ describe("Token Verifier", () => {
     });
   });
 });
+
+const MOCK_PUBLIC_KEY = {
+  alg: "ES256",
+  crv: "P-256",
+  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  kty: "EC",
+  use: "sig",
+  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+};
+
+const MOCK_INCORRECT_PULIC_KEY = {
+  alg: "ES256",
+  crv: "P-256",
+  kid: "mockKid",
+  kty: "EC",
+  use: "sig",
+  x: "NYmnFqCEFMVXQsmnSngTkiJK-Q9ixSBxLAXx6ZsBGlc",
+  y: "9fpDnWl3rBP-T6z6e60Bmgym3ymjRK_VSdJ7wU_Nwvg",
+};
+
+const MOCK_PRIVATE_KEY = {
+  crv: "P-256",
+  d: "IMeUPld6UA1WUKJF34HDwZGT2tArxZslpl_dVYzOLKU",
+  kid: "sThKMT3oxcTXG-sgMw2EVPTE9Y8W43wLXfqu7zT46-w",
+  kty: "EC",
+  x: "YMoiJArVzO9RIVR7J9mUlGixqWyXCAYrZLtdc8EhuO8",
+  y: "47JYyUr0qlg3VksGlHCAdpwR_w1dixXfcTi7hBEfrRo",
+};

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
@@ -29,8 +29,8 @@ describe("Token Verifier", () => {
         expect(result.isError).toBe(true);
         expect(result.value).toStrictEqual({
           errorMessage:
-            "Error verifying token signature: JWSSignatureVerificationFailed: signature verification failed",
-          errorCategory: "SERVER_ERROR",
+            "Error verifying token signature",
+          errorCategory: "CLIENT_ERROR",
         });
       });
     });

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/tokenVerifier.test.ts
@@ -28,8 +28,7 @@ describe("Token Verifier", () => {
 
         expect(result.isError).toBe(true);
         expect(result.value).toStrictEqual({
-          errorMessage:
-            "Error verifying token signature",
+          errorMessage: "Error verifying token signature",
           errorCategory: "CLIENT_ERROR",
         });
       });

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
@@ -8,6 +8,7 @@ import { KMSAdapter } from "../../adapters/kmsAdapter";
 import crypto from "crypto";
 import { jwtVerify, JWTVerifyResult, KeyLike } from "jose";
 import { IJwks, IPublicKeyGetter } from "./publicKeyGetter";
+import { ITokenVerifier } from "./tokenVerifier";
 
 export class TokenService implements ITokenService {
   private readonly dependencies: ITokenServiceDependencies;
@@ -74,7 +75,8 @@ export class TokenService implements ITokenService {
 
     const publicKey = getPublicKeyFromJwksResult.value;
 
-    const verifyTokenSignatureResult = await this.verifyTokenSignature(
+    const tokenVerifier = this.dependencies.tokenVerifier()
+    const verifyTokenSignatureResult = await tokenVerifier.verify(
       jwt,
       publicKey,
     );
@@ -213,23 +215,6 @@ export class TokenService implements ITokenService {
     const decoder = new TextDecoder();
     return successResult(decoder.decode(decryptedBuffer));
   }
-
-  private async verifyTokenSignature(
-    jwt: string,
-    publicKey: Uint8Array | KeyLike,
-  ): Promise<Result<JWTVerifyResult>> {
-    let result: JWTVerifyResult;
-    try {
-      result = await jwtVerify(jwt, publicKey);
-    } catch (error) {
-      return errorResult({
-        errorMessage: `Failed verifying service token signature. ${error}`,
-        errorCategory: "SERVER_ERROR",
-      });
-    }
-
-    return successResult(result);
-  }
 }
 
 export interface ITokenService {
@@ -243,4 +228,5 @@ export interface ITokenService {
 
 export interface ITokenServiceDependencies {
   publicKeyGetter: () => IPublicKeyGetter;
+  tokenVerifier: () => ITokenVerifier;
 }

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
@@ -1,12 +1,11 @@
+import crypto from "crypto";
+import { KMSAdapter } from "../../adapters/kmsAdapter";
 import {
   RetryConfig,
   sendHttpRequest,
   SuccessfulHttpResponse,
 } from "../../services/http/sendHttpRequest";
 import { errorResult, Result, successResult } from "../../utils/result";
-import { KMSAdapter } from "../../adapters/kmsAdapter";
-import crypto from "crypto";
-import { jwtVerify, JWTVerifyResult, KeyLike } from "jose";
 import { IJwks, IPublicKeyGetter } from "./publicKeyGetter";
 import { ITokenVerifier } from "./tokenVerifier";
 
@@ -75,7 +74,7 @@ export class TokenService implements ITokenService {
 
     const publicKey = getPublicKeyFromJwksResult.value;
 
-    const tokenVerifier = this.dependencies.tokenVerifier()
+    const tokenVerifier = this.dependencies.tokenVerifier();
     const verifyTokenSignatureResult = await tokenVerifier.verify(
       jwt,
       publicKey,

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenService.ts
@@ -1,5 +1,3 @@
-import crypto from "crypto";
-import { KMSAdapter } from "../../adapters/kmsAdapter";
 import {
   RetryConfig,
   sendHttpRequest,

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
@@ -1,10 +1,11 @@
 import { jwtVerify, JWTVerifyResult, KeyLike } from "jose";
 import { errorResult, Result, successResult } from "../../utils/result";
 
-
-
 export class TokenVerifier implements ITokenVerifier {
-  async verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
+  async verify(
+    jwt: string,
+    key: KeyLike | Uint8Array,
+  ): Promise<Result<JWTVerifyResult>> {
     let result: JWTVerifyResult;
     try {
       result = await jwtVerify(jwt, key);
@@ -20,5 +21,8 @@ export class TokenVerifier implements ITokenVerifier {
 }
 
 export interface ITokenVerifier {
-  verify: (jwt: string, key: KeyLike | Uint8Array) => Promise<Result<JWTVerifyResult>>
+  verify: (
+    jwt: string,
+    key: KeyLike | Uint8Array,
+  ) => Promise<Result<JWTVerifyResult>>;
 }

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
@@ -9,10 +9,10 @@ export class TokenVerifier implements ITokenVerifier {
     let result: JWTVerifyResult;
     try {
       result = await jwtVerify(jwt, key);
-    } catch (error) {
+    } catch {
       return errorResult({
-        errorMessage: `Error verifying token signature: ${error}`,
-        errorCategory: "SERVER_ERROR",
+        errorMessage: `Error verifying token signature`,
+        errorCategory: "CLIENT_ERROR",
       });
     }
 

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tokenVerifier.ts
@@ -1,0 +1,24 @@
+import { jwtVerify, JWTVerifyResult, KeyLike } from "jose";
+import { errorResult, Result, successResult } from "../../utils/result";
+
+
+
+export class TokenVerifier implements ITokenVerifier {
+  async verify(jwt: string, key: KeyLike | Uint8Array): Promise<Result<JWTVerifyResult>> {
+    let result: JWTVerifyResult;
+    try {
+      result = await jwtVerify(jwt, key);
+    } catch (error) {
+      return errorResult({
+        errorMessage: `Error verifying token signature: ${error}`,
+        errorCategory: "SERVER_ERROR",
+      });
+    }
+
+    return successResult(result);
+  }
+}
+
+export interface ITokenVerifier {
+  verify: (jwt: string, key: KeyLike | Uint8Array) => Promise<Result<JWTVerifyResult>>
+}

--- a/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
+++ b/backend-api/src/functions/asyncCredential/tokenService/tests/tokenService.test.ts
@@ -253,7 +253,7 @@ describe("Token Service", () => {
         expect(result.isError).toEqual(false);
         expect(result.value).toEqual({
           encodedJwt:
-            "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJKV1QifQ.eyJleHAiOjE3MjE5MDExNDMwMDAsImlzcyI6Im1vY2tJc3N1ZXIiLCJhdWQiOiJtb2NrSXNzdWVyIiwic2NvcGUiOiJkY21hdy5zZXNzaW9uLmFzeW5jX2NyZWF0ZSIsImNsaWVudF9pZCI6Im1vY2tDbGllbnRJZCJ9.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8",
+            "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjE5MDExNDMwMDAsImlzcyI6Im1vY2tJc3N1ZXIiLCJhdWQiOiJtb2NrSXNzdWVyIiwic2NvcGUiOiJkY21hdy5zZXNzaW9uLmFzeW5jX2NyZWF0ZSIsImNsaWVudF9pZCI6Im1vY2tDbGllbnRJZCJ9.Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8",
           jwtPayload: {
             aud: "mockIssuer",
             client_id: "mockClientId",

--- a/backend-api/src/functions/testUtils/mockJwtBuilder.ts
+++ b/backend-api/src/functions/testUtils/mockJwtBuilder.ts
@@ -84,19 +84,19 @@ export class MockJWTBuilder {
     return this;
   };
 
-  static getPublicKey = async (publicKey: any) => {
-    return await importJWK(publicKey)
-  }
+  static getPublicKey = async (publicKey: IMockPublicKey) => {
+    return await importJWK(publicKey);
+  };
 
-  getSignedEncodedJwt = async (privateKey: any) => {
-    this.jwt.header.typ = "JWT"
-    const signingKey = await importJWK(privateKey)
+  getSignedEncodedJwt = async (privateKey: IMockPrivateKey) => {
+    this.jwt.header.typ = "JWT";
+    const signingKey = await importJWK(privateKey);
     const signedEncodedJwt = await new SignJWT(this.jwt.payload)
       .setProtectedHeader(this.jwt.header)
-      .sign(signingKey)
+      .sign(signingKey);
 
-    return signedEncodedJwt
-  }
+    return signedEncodedJwt;
+  };
 
   getEncodedJwt = () => {
     const header = jose.util.base64url.encode(
@@ -127,4 +127,23 @@ interface IMockJwt {
     aud?: string;
   };
   signature: string;
+}
+
+interface IMockPublicKey {
+  alg: string;
+  crv: string;
+  kid: string;
+  kty: string;
+  use: string;
+  x: string;
+  y: string;
+}
+
+interface IMockPrivateKey {
+  crv: string;
+  d: string;
+  kid: string;
+  kty: string;
+  x: string;
+  y: string;
 }

--- a/backend-api/src/functions/testUtils/mockJwtBuilder.ts
+++ b/backend-api/src/functions/testUtils/mockJwtBuilder.ts
@@ -1,3 +1,4 @@
+import { importJWK, SignJWT } from "jose";
 import jose from "node-jose";
 
 export class MockJWTBuilder {
@@ -82,6 +83,20 @@ export class MockJWTBuilder {
     delete this.jwt.payload.scope;
     return this;
   };
+
+  static getPublicKey = async (publicKey: any) => {
+    return await importJWK(publicKey)
+  }
+
+  getSignedEncodedJwt = async (privateKey: any) => {
+    this.jwt.header.typ = "JWT"
+    const signingKey = await importJWK(privateKey)
+    const signedEncodedJwt = await new SignJWT(this.jwt.payload)
+      .setProtectedHeader(this.jwt.header)
+      .sign(signingKey)
+
+    return signedEncodedJwt
+  }
 
   getEncodedJwt = () => {
     const header = jose.util.base64url.encode(

--- a/backend-api/src/functions/testUtils/mockJwtBuilder.ts
+++ b/backend-api/src/functions/testUtils/mockJwtBuilder.ts
@@ -2,7 +2,7 @@ import jose from "node-jose";
 
 export class MockJWTBuilder {
   private jwt: IMockJwt = {
-    header: { alg: "HS256", type: "JWT" },
+    header: { alg: "ES256", typ: "JWT" },
     payload: {
       exp: Date.now() + 1000,
       iss: "mockIssuer",
@@ -99,7 +99,7 @@ export class MockJWTBuilder {
 interface IMockJwt {
   header: {
     alg: string;
-    type: string;
+    typ: string;
     kid?: string;
   };
   payload: {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed
- Extracted token verification logic into TokenVerifier class
- Updated handler and TokenService dependencies to include TokenVerifier
- Updated MockJWTBuilder
  - Added new function for building a singed JWT to enable testing of TokenVerifier
  - Amend JWT header property to be `typ` instead of `type`
- Updates asyncCredential lambda test to use new encoded header value to reflect change to header property key name

### Why did it change
To create better separation of concerns within token signature verification and to simplify adding and updating tests.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
