### PR TITLE
DCMAW-8229: check KMS error type

### DIFF
--- a/backend-api/src/functions/adapters/kmsAdapter.ts
+++ b/backend-api/src/functions/adapters/kmsAdapter.ts
@@ -42,7 +42,7 @@ export class KMSAdapter implements IKmsAdapter {
         error instanceof InvalidCiphertextException ||
         error instanceof IncorrectKeyException
       ) {
-        throw new ClientError(error.message);
+        throw new ClientError(error.name);
       }
       throw error;
     }

--- a/backend-api/src/functions/adapters/tests/kmsAdapter.test.ts
+++ b/backend-api/src/functions/adapters/tests/kmsAdapter.test.ts
@@ -23,23 +23,8 @@ describe("KMS Adapter", () => {
     kmsAdapter = new KMSAdapter();
   });
 
-  describe("Given an error happens trying to decrypt the data", () => {
-    it("Throws the error thrown by the KMS client", async () => {
-      mockKmsClient.on(DecryptCommand).rejects(
-        new KeyUnavailableException({
-          $metadata: {},
-          message: "Some error message",
-        }),
-      );
-
-      await expect(() =>
-        kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
-      ).rejects.toThrowError(KeyUnavailableException);
-    });
-  });
-
   describe("Given a InvalidCiphertextException error happens trying to decrypt the data", () => {
-    it("Throws the error thrown by the KMS client", async () => {
+    it("Throws a ClientError", async () => {
       mockKmsClient.on(DecryptCommand).rejects(
         new InvalidCiphertextException({
           $metadata: {},
@@ -54,7 +39,7 @@ describe("KMS Adapter", () => {
   });
 
   describe("Given a IncorrectKeyException error happens trying to decrypt the data", () => {
-    it("Throws the error thrown by the KMS client", async () => {
+    it("Throws a ClientError", async () => {
       mockKmsClient.on(DecryptCommand).rejects(
         new IncorrectKeyException({
           $metadata: {},
@@ -65,6 +50,21 @@ describe("KMS Adapter", () => {
       await expect(() =>
         kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
       ).rejects.toThrowError(ClientError);
+    });
+  });
+
+  describe("Given any other error happens trying to decrypt the data", () => {
+    it("Throws the error thrown by the KMS client", async () => {
+      mockKmsClient.on(DecryptCommand).rejects(
+        new KeyUnavailableException({
+          $metadata: {},
+          message: "Some error message",
+        }),
+      );
+
+      await expect(() =>
+        kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
+      ).rejects.toThrowError(KeyUnavailableException);
     });
   });
 

--- a/backend-api/src/functions/adapters/tests/kmsAdapter.test.ts
+++ b/backend-api/src/functions/adapters/tests/kmsAdapter.test.ts
@@ -1,13 +1,15 @@
 import { AwsStub, mockClient } from "aws-sdk-client-mock";
 import {
   DecryptCommand,
+  IncorrectKeyException,
+  InvalidCiphertextException,
   KeyUnavailableException,
   KMSClient,
   KMSClientResolvedConfig,
   ServiceInputTypes,
   ServiceOutputTypes,
 } from "@aws-sdk/client-kms";
-import { IKmsAdapter, KMSAdapter } from "../kmsAdapter";
+import { ClientError, IKmsAdapter, KMSAdapter } from "../kmsAdapter";
 
 describe("KMS Adapter", () => {
   let mockKmsClient: AwsStub<
@@ -33,6 +35,36 @@ describe("KMS Adapter", () => {
       await expect(() =>
         kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
       ).rejects.toThrowError(KeyUnavailableException);
+    });
+  });
+
+  describe("Given a InvalidCiphertextException error happens trying to decrypt the data", () => {
+    it("Throws the error thrown by the KMS client", async () => {
+      mockKmsClient.on(DecryptCommand).rejects(
+        new InvalidCiphertextException({
+          $metadata: {},
+          message: "Some error message",
+        }),
+      );
+
+      await expect(() =>
+        kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
+      ).rejects.toThrowError(ClientError);
+    });
+  });
+
+  describe("Given a IncorrectKeyException error happens trying to decrypt the data", () => {
+    it("Throws the error thrown by the KMS client", async () => {
+      mockKmsClient.on(DecryptCommand).rejects(
+        new IncorrectKeyException({
+          $metadata: {},
+          message: "Some error message",
+        }),
+      );
+
+      await expect(() =>
+        kmsAdapter.decrypt(new Uint8Array(), "mockKeyId"),
+      ).rejects.toThrowError(ClientError);
     });
   });
 

--- a/backend-api/src/functions/adapters/tests/mocks.ts
+++ b/backend-api/src/functions/adapters/tests/mocks.ts
@@ -1,4 +1,4 @@
-import { IKmsAdapter } from "../kmsAdapter";
+import { ClientError, IKmsAdapter } from "../kmsAdapter";
 
 export class MockAsymmetricDecrypterSuccess implements IKmsAdapter {
   async decrypt(): Promise<Uint8Array> {
@@ -6,8 +6,16 @@ export class MockAsymmetricDecrypterSuccess implements IKmsAdapter {
   }
 }
 
-export class MockAsymmetricDecrypterFailure implements IKmsAdapter {
+export class MockAsymmetricDecrypterError implements IKmsAdapter {
   async decrypt(): Promise<Uint8Array> {
-    return Promise.reject("Some mock asymmetric decryption error");
+    return Promise.reject(new Error("Some mock asymmetric decryption error"));
+  }
+}
+
+export class MockAsymmetricDecrypterClientError implements IKmsAdapter {
+  async decrypt(): Promise<Uint8Array> {
+    return Promise.reject(
+      new ClientError("Some mock asymmetric decryption client error"),
+    );
   }
 }

--- a/backend-api/src/functions/asyncActiveSession/jwe/jweDecrypter.ts
+++ b/backend-api/src/functions/asyncActiveSession/jwe/jweDecrypter.ts
@@ -1,6 +1,10 @@
 import { SymmetricDecrypter, IDecryptSymmetric } from "./symmetricDecrypter";
 import { errorResult, Result, successResult } from "../../utils/result";
-import { IKmsAdapter, KMSAdapter } from "../../adapters/kmsAdapter";
+import {
+  ClientError,
+  IKmsAdapter,
+  KMSAdapter,
+} from "../../adapters/kmsAdapter";
 
 export interface IDecryptJwe {
   decrypt: (jwe: string) => Promise<Result<string>>;
@@ -55,6 +59,12 @@ export class JweDecrypter implements IDecryptJwe {
         this.encryptionKeyId,
       );
     } catch (error) {
+      if (error instanceof ClientError) {
+        return errorResult({
+          errorMessage: `Unable to decrypt encryption key - ${error}`,
+          errorCategory: "CLIENT_ERROR",
+        });
+      }
       return errorResult({
         errorMessage: `Unable to decrypt encryption key - ${error}`,
         errorCategory: "SERVER_ERROR",

--- a/backend-api/src/functions/asyncActiveSession/jwe/tests/jweDecrypter.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/jwe/tests/jweDecrypter.test.ts
@@ -4,7 +4,8 @@ import {
   MockSymmetricDecrypterSuccess,
 } from "./mocks";
 import {
-  MockAsymmetricDecrypterFailure,
+  MockAsymmetricDecrypterClientError,
+  MockAsymmetricDecrypterError,
   MockAsymmetricDecrypterSuccess,
 } from "../../../adapters/tests/mocks";
 
@@ -32,9 +33,10 @@ describe("Decrypt JWE", () => {
     });
   });
 
-  describe("Given an error happens trying to decrypt the CEK", () => {
-    it("Returns a SERVER_ERROR error result", async () => {
-      dependencies.asymmetricDecrypter = new MockAsymmetricDecrypterFailure();
+  describe("Given a ClientError exception is thrown when trying to decrypt the CEK", () => {
+    it("Returns a CLIENT_ERROR error result", async () => {
+      dependencies.asymmetricDecrypter =
+        new MockAsymmetricDecrypterClientError();
       const result = await new JweDecrypter("keyId", dependencies).decrypt(
         "protectedHeader.encryptedKey.iv.ciphertext.tag",
       );
@@ -42,7 +44,23 @@ describe("Decrypt JWE", () => {
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
         errorMessage:
-          "Unable to decrypt encryption key - Some mock asymmetric decryption error",
+          "Unable to decrypt encryption key - ClientError: Some mock asymmetric decryption client error",
+        errorCategory: "CLIENT_ERROR",
+      });
+    });
+  });
+
+  describe("Given any other exception is thrown when trying to decrypt the CEK", () => {
+    it("Returns a SERVER_ERROR error result", async () => {
+      dependencies.asymmetricDecrypter = new MockAsymmetricDecrypterError();
+      const result = await new JweDecrypter("keyId", dependencies).decrypt(
+        "protectedHeader.encryptedKey.iv.ciphertext.tag",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.value).toStrictEqual({
+        errorMessage:
+          "Unable to decrypt encryption key - Error: Some mock asymmetric decryption error",
         errorCategory: "SERVER_ERROR",
       });
     });

--- a/backend-api/src/functions/testUtils/mockJwtBuilder.ts
+++ b/backend-api/src/functions/testUtils/mockJwtBuilder.ts
@@ -14,11 +14,6 @@ export class MockJWTBuilder {
     signature: "Ik_kbkTVKzlXadti994bAtiHaFO1KsD4_yJGt4wpjr8",
   };
 
-  setKid = (kid: string): this => {
-    this.jwt.header.kid = kid;
-    return this;
-  };
-
   deleteKid = (): this => {
     delete this.jwt.header.kid;
     return this;
@@ -31,11 +26,6 @@ export class MockJWTBuilder {
 
   deleteAud = (): this => {
     delete this.jwt.payload.aud;
-    return this;
-  };
-
-  setClientId = (clientId: string): this => {
-    this.jwt.payload.client_id = clientId;
     return this;
   };
 
@@ -92,13 +82,10 @@ export class MockJWTBuilder {
   getSignedEncodedJwt = async (
     privateKey: IMockPrivateKey = MOCK_SIGNING_KEY,
   ) => {
-    this.jwt.header.typ = "JWT";
     const signingKey = await importJWK(privateKey);
-    const signedEncodedJwt = await new SignJWT(this.jwt.payload)
+    return await new SignJWT(this.jwt.payload)
       .setProtectedHeader(this.jwt.header)
       .sign(signingKey);
-
-    return signedEncodedJwt;
   };
 
   getEncodedJwt = () => {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8229

### What changed

**KMS Adapter**
Check the exception type thrown by the KMS Client. If of type `InvalidCiphertextException` or `IncorrectKeyException`, throw a custom exception `ClientError`, otherwise just re-throw the error caught.

![Screenshot 2024-10-18 at 10 02 15](https://github.com/user-attachments/assets/5c2abec4-ac8e-40b2-9340-c337e247923f)

![Screenshot 2024-10-18 at 10 01 51](https://github.com/user-attachments/assets/35b2d588-f297-4fc1-9cda-150603f66485)

**Mock JWT Builder**
* Delete unused methods


### Why did it change
If the client sends an invalid JWE (e.g. one where the CEK has been encrypted with the wrong key or the encryption is invalid), we currently return a server error (500) to the client, which is incorrect as these clearly error client errors (400).

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
