### PR TITLE
DCMAW-10416: Fixes ASYNC_BACKEND_BASE_URL envVar if no override

### DIFF
--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -199,7 +199,7 @@ Resources:
           ASYNC_BACKEND_BASE_URL: !If
             - UseDevOverrideAsyncBackendBaseUrl
             - !Ref DevOverrideAsyncBackendBaseUrl
-            - !Sub https://mob-async-backend.review-b-async.${Environment}.account.gov.uk
+            - !Sub https://sessions-mob-async-backend.review-b-async.${Environment}.account.gov.uk
           KEY_STORAGE_BUCKET_NAME: !Ref JwksBucket
       VpcConfig:
         SubnetIds:


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10416

### What changed
`ASYNC_BACKEND_BASE_URL` envVar value if no override

### Why did it change

Pipeline failure. Analysis can be found [here](https://gds.slack.com/archives/C04RSBGJH6D/p1729590644183349)

In previous PR this was [incorrectly set](https://github.com/govuk-one-login/mobile-id-check-async/pull/233/files#diff-8c3781550792bb6cc5b2caec488972810b818b0999b7454ad6d79658d4c6c2dcR202), you can see that `sessions-` has been accidentally removed.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
