### PR TITLE
[DCMAW-10446] Vanity URL for PrivateApiGateway

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -35,18 +35,33 @@ Mappings:
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      VpceIPAddressA: 10.0.10.23
+      VpceIPAddressB: 10.0.13.96
+      VpceIPAddressC: 10.0.14.16
     build:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      VpceIPAddressA: 10.0.10.132
+      VpceIPAddressB: 10.0.13.150
+      VpceIPAddressC: 10.0.15.219
     staging:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      VpceIPAddressA: 10.0.10.12
+      VpceIPAddressB: 10.0.13.85
+      VpceIPAddressC: 10.0.15.161
     integration:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      VpceIPAddressA: 10.0.10.42
+      VpceIPAddressB: 10.0.13.207
+      VpceIPAddressC: 10.0.14.190
     production:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      VpceIPAddressA: 10.0.11.211
+      VpceIPAddressB: 10.0.13.200
+      VpceIPAddressC: 10.0.15.16
 
   SessionsApigw:
     dev:
@@ -289,6 +304,7 @@ Resources:
   PrivateApiLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
+      Name: !Sub private-api-${AWS::StackName}
       IpAddressType: ipv4
       Scheme: internal
       Subnets:
@@ -313,6 +329,7 @@ Resources:
   PrivateApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      Name: !Sub private-api-${AWS::StackName}
       HealthCheckEnabled: true
       HealthCheckIntervalSeconds: 10
       HealthCheckPort: 443
@@ -323,11 +340,20 @@ Resources:
       Port: 443
       Protocol: TLS
       Targets:
-        - Id: 10.0.10.23 # subnet-0d43f751301129abd (devplatform-vpc-PrivateSubnetA) eu-west-2c (euw2-az1)
+        - Id: !FindInMap
+            - PrivateApigw
+            - !Ref Environment
+            - VpceIPAddressA
           Port: 443
-        - Id: 10.0.13.96 # subnet-094e66815780c4556 (devplatform-vpc-PrivateSubnetB) eu-west-2a (euw2-az2)
+        - Id: !FindInMap
+            - PrivateApigw
+            - !Ref Environment
+            - VpceIPAddressB
           Port: 443
-        - Id: 10.0.14.16 # subnet-0d90ca1c3b3a83028 (devplatform-vpc-PrivateSubnetC) eu-west-2b (euw2-az3)
+        - Id: !FindInMap
+            - PrivateApigw
+            - !Ref Environment
+            - VpceIPAddressC
           Port: 443
       TargetType: ip
       VpcId: !ImportValue devplatform-vpc-VpcId
@@ -714,7 +740,6 @@ Resources:
     Properties:
       Environment:
         Variables:
-          # PRIVATE_API_URL: !Sub https://${PrivateApi.RestApiId}.execute-api.eu-west-2.amazonaws.com/${Environment}
           PRIVATE_API_URL: !Sub
             - https://private-${AWS::StackName}.${DNS_RECORD}
             - DNS_RECORD: !FindInMap

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -1,5 +1,4 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
 
 Description: async-backend SAM template for the ID Check v2 app
 
@@ -133,15 +132,15 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSBASEURL: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk'
+      STSBASEURL: https://mob-sts-mock.review-b-async.dev.account.gov.uk
     build:
-      STSBASEURL: 'https://mob-sts-mock.review-b-async.build.account.gov.uk'
+      STSBASEURL: https://mob-sts-mock.review-b-async.build.account.gov.uk
     staging:
-      STSBASEURL: '' #TODO: Update this value with 'real' STS URLs
+      STSBASEURL: "" #TODO: Update this value with 'real' STS URLs
     integration:
-      STSBASEURL: '' #TODO: Update this value with 'real' STS URLs
+      STSBASEURL: "" #TODO: Update this value with 'real' STS URLs
     production:
-      STSBASEURL: '' #TODO: Update this value with 'real' STS URLs
+      STSBASEURL: "" #TODO: Update this value with 'real' STS URLs
 
 Conditions:
   UseCodeSigning: !Not
@@ -178,6 +177,8 @@ Conditions:
       - !Ref DevOverrideStsBaseUrl
       - none
 
+Transform: AWS::Serverless-2016-10-31
+
 Globals:
   Function:
     Timeout: 5
@@ -199,8 +200,7 @@ Globals:
       Variables:
         SIGNING_KEY_ID: !GetAtt KMSSigningKey.Arn
         TXMA_SQS: !GetAtt TxMASQSQueue.QueueUrl
-        # ISSUER should be updated with DNS once available
-        ISSUER: mockIssuer
+        ISSUER: mockIssuer # ISSUER should be updated with DNS once available
         SESSION_TABLE_NAME: !Ref SessionsTable
 
 Resources:
@@ -242,6 +242,95 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: ./openApiSpecs/async-private-spec.yaml
+
+  PrivateApiDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      DomainName: !Sub
+        - private-${AWS::StackName}.${DNS_RECORD}
+        - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      RegionalCertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN}}' # Uses a wildcard (in dev only?)
+      SecurityPolicy: TLS_1_2
+
+  PrivateApiBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    DependsOn: PrivateApiDomainName
+    Properties:
+      DomainName: !Sub
+        - private-${AWS::StackName}.${DNS_RECORD}
+        - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+      RestApiId: !Ref PrivateApi
+      Stage: !Ref PrivateApi.Stage
+
+  PrivateApiRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Sub
+        - private-${AWS::StackName}.${DNS_RECORD}
+        - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+      Type: CNAME
+      HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
+      TTL: 60
+      ResourceRecords:
+        - !GetAtt PrivateApiLoadBalancer.DNSName # this will be the load balancer domain
+
+  PrivateApiLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      IpAddressType: ipv4
+      Scheme: internal
+      Subnets:
+        - !ImportValue devplatform-vpc-PrivateSubnetIdA
+        - !ImportValue devplatform-vpc-PrivateSubnetIdB
+        - !ImportValue devplatform-vpc-PrivateSubnetIdC
+      Type: network
+
+  PrivateApiListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Order: 1
+          TargetGroupArn: !Ref PrivateApiTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref PrivateApiLoadBalancer
+      Port: 443
+      Certificates:
+        - CertificateArn: !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN}}'
+      Protocol: TLS
+
+  PrivateApiTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: 443
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
+      Port: 443
+      Protocol: TLS
+      Targets:
+        - Id: 10.0.10.23 # subnet-0d43f751301129abd (devplatform-vpc-PrivateSubnetA) eu-west-2c (euw2-az1)
+          Port: 443
+        - Id: 10.0.13.96 # subnet-094e66815780c4556 (devplatform-vpc-PrivateSubnetB) eu-west-2a (euw2-az2)
+          Port: 443
+        - Id: 10.0.14.16 # subnet-0d90ca1c3b3a83028 (devplatform-vpc-PrivateSubnetC) eu-west-2b (euw2-az3)
+          Port: 443
+      TargetType: ip
+      VpcId: !ImportValue devplatform-vpc-VpcId
 
   AsyncCredentialPrivateApiAccessLogs:
     Type: AWS::Logs::LogGroup
@@ -426,7 +515,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource:
-                  - Fn::GetAtt: [ "SessionsTable", "Arn" ]
+                  - !GetAtt SessionsTable.Arn
                   - !Sub ${SessionsTable.Arn}/index/subjectIdentifier-timeToLive-index
                 Condition:
                   ForAllValues:StringEquals:
@@ -625,7 +714,13 @@ Resources:
     Properties:
       Environment:
         Variables:
-          PRIVATE_API_URL: !Sub https://${PrivateApi.RestApiId}.execute-api.eu-west-2.amazonaws.com/${Environment}
+          # PRIVATE_API_URL: !Sub https://${PrivateApi.RestApiId}.execute-api.eu-west-2.amazonaws.com/${Environment}
+          PRIVATE_API_URL: !Sub
+            - https://private-${AWS::StackName}.${DNS_RECORD}
+            - DNS_RECORD: !FindInMap
+                - DNS
+                - !Ref Environment
+                - BaseDns
       FunctionName: !Sub ${AWS::StackName}-proxy-lambda
       Runtime: nodejs20.x
       Handler: proxyHandler.lambdaHandler
@@ -833,7 +928,10 @@ Resources:
           STS_BASE_URL: !If
             - UseDevOverrideStsBaseUrl
             - !Ref DevOverrideStsBaseUrl
-            - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
+            - !FindInMap
+              - EnvironmentVariables
+              - !Ref Environment
+              - STSBASEURL
           AUDIENCE: !Sub https://${SessionsApiDomainName}
       VpcConfig:
         SubnetIds:
@@ -878,7 +976,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource:
-                  - Fn::GetAtt: [ "SessionsTable", "Arn" ]
+                  - !GetAtt SessionsTable.Arn
                   - !Sub ${SessionsTable.Arn}/index/subjectIdentifier-timeToLive-index
                 Condition:
                   ForAllValues:StringEquals:
@@ -1280,16 +1378,16 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
-  WellKnown5XXLowThresholdAlarm:    
+  WellKnown5XXLowThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
-      AlarmDescription: "1% or more of requests are failing on the /.well-known/jwks.json endpoint"
-      AlarmName: !Sub "${AWS::StackName}-LowThresholdWellKnown5XXApiGwAlarm"
+      AlarmDescription: 1% or more of requests are failing on the /.well-known/jwks.json endpoint
+      AlarmName: !Sub ${AWS::StackName}-LowThresholdWellKnown5XXApiGwAlarm
       AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
       OKActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 2
       EvaluationPeriods: 5
@@ -1318,7 +1416,7 @@ Resources:
             Period: 60
             Stat: Sum
         - Id: errorSum5XX
-          Label: "Number of 5XX errors"
+          Label: Number of 5XX errors
           ReturnData: false
           MetricStat:
             Metric:
@@ -1336,20 +1434,20 @@ Resources:
             Period: 60
             Stat: Sum
         - Id: errorPercentage5XX
-          Label: "Number of 5XX errors returned as a percentage"
+          Label: Number of 5XX errors returned as a percentage
           ReturnData: false
           Expression: (errorSum5XX/invocations) * 100
 
-  WellKnown5XXHighThresholdAlarm:    
+  WellKnown5XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
-      AlarmDescription: "80% or more of requests are failing on the /.well-known/jwks.json endpoint"
-      AlarmName: !Sub "${AWS::StackName}-HighThresholdWellKnown5XXApiGwAlarm"
+      AlarmDescription: 80% or more of requests are failing on the /.well-known/jwks.json endpoint
+      AlarmName: !Sub ${AWS::StackName}-HighThresholdWellKnown5XXApiGwAlarm
       AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
       OKActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 2
       EvaluationPeriods: 5
@@ -1378,7 +1476,7 @@ Resources:
             Period: 60
             Stat: Sum
         - Id: errorSum5XX
-          Label: "Number of 5XX errors"
+          Label: Number of 5XX errors
           ReturnData: false
           MetricStat:
             Metric:
@@ -1396,7 +1494,7 @@ Resources:
             Period: 60
             Stat: Sum
         - Id: errorPercentage5XX
-          Label: "Number of 5XX errors returned as a percentage"
+          Label: Number of 5XX errors returned as a percentage
           ReturnData: false
           Expression: (errorSum5XX/invocations) * 100
 
@@ -1406,9 +1504,9 @@ Outputs:
     Value: !Sub https://${SessionsApiDomainName}
 
   ProxyApiUrl:
-    Condition: ProxyApiDeployment
     Description: Proxy API Gateway Pretty DNS
     Value: !Sub https://${ProxyApiDomainName}
+    Condition: ProxyApiDeployment
 
   PrivateApiUrl:
     Description: Private API Gateway base URL
@@ -1417,6 +1515,9 @@ Outputs:
   StsMockApiUrl:
     Description: STS Mock API Gateway base URL
     Value: !If
-        - UseDevOverrideStsBaseUrl
-        - !Ref DevOverrideStsBaseUrl
-        - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
+      - UseDevOverrideStsBaseUrl
+      - !Ref DevOverrideStsBaseUrl
+      - !FindInMap
+        - EnvironmentVariables
+        - !Ref Environment
+        - STSBASEURL

--- a/helper-scripts/get_apigw_vpce_ips.sh
+++ b/helper-scripts/get_apigw_vpce_ips.sh
@@ -1,0 +1,42 @@
+#! /usr/bin/env bash
+
+# Used to retrieve the IP addresses of the network interfaces created for the exeute-api VPC Endpoint in the dev platform vpc
+# Requires the use of an aws profile for each environment, the profile name is of the form "async-${env}"
+
+envs=${1:-"dev build staging integration production"}
+
+results="$(printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "Environment" "Network InterfaceId" "Availability Zone" "IP Address" "Subnet Id" "Subnet Name" "VpcId" "VpcName")"
+results="$(printf "%s\n%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "${results}" "-----------" "-------------------" "-----------------" "----------" "---------" "-----------" "-----" "-------")"
+
+for env in $envs; do
+
+  export AWS_PROFILE="async-${env}"
+
+  echo "Environment: ${env}"
+
+  aws ec2 describe-vpcs >"vpcs.${env}.json"
+  aws ec2 describe-vpc-endpoints >"vpc-endpoints.${env}.json"
+  aws ec2 describe-network-interfaces >"network-interfaces.${env}.json"
+  aws ec2 describe-subnets >"subnets.${env}.json"
+
+  vpcName="devplatform-vpc-Vpc"
+  vpcId="$(jq --raw-output --arg vpcName "${vpcName}" '.Vpcs[] | select( ( .Tags[] | select(.Key == "Name") | .Value ) == $vpcName) | .VpcId ' vpcs.${env}.json)"
+  executeApiNetworkInterfaceIds=$(jq --raw-output '.VpcEndpoints[] | select(.ServiceName == "com.amazonaws.eu-west-2.execute-api" ) | .NetworkInterfaceIds[]' "vpc-endpoints.${env}.json")
+
+  for executeApiNetworkInterfaceId in $executeApiNetworkInterfaceIds; do
+    echo "Network Interface Id: ${executeApiNetworkInterfaceId}"
+
+    az=$(jq --raw-output --arg netwrokInterfaceId "${executeApiNetworkInterfaceId}" '.NetworkInterfaces[] | select(.NetworkInterfaceId == $netwrokInterfaceId) | .AvailabilityZone' "network-interfaces.${env}.json")
+    ip=$(jq --raw-output --arg netwrokInterfaceId "${executeApiNetworkInterfaceId}" '.NetworkInterfaces[] | select(.NetworkInterfaceId == $netwrokInterfaceId) | .PrivateIpAddress' "network-interfaces.${env}.json")
+    sn=$(jq --raw-output --arg netwrokInterfaceId "${executeApiNetworkInterfaceId}" '.NetworkInterfaces[] | select(.NetworkInterfaceId == $netwrokInterfaceId) | .SubnetId' "network-interfaces.${env}.json")
+
+    snName=$(jq --raw-output --arg sn "${sn}" '.Subnets[] | select(.SubnetId == $sn) | .Tags[] | select(.Key == "Name") | .Value' "subnets.${env}.json")
+
+    results="${results}\n$(printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "${env}" "${executeApiNetworkInterfaceId}" "${az}" "${ip}" "${sn}" "${snName}" "${vpcId}" "${vpcName}")"
+  done
+
+  echo
+
+done
+
+echo "${results}" | column -t -s $'\t'


### PR DESCRIPTION
Ticket: https://govukverify.atlassian.net/browse/DCMAW-10446

Implements a workaround for custom domain names for a private api gateway. By using a load balancer pointed at the VPCEndpoint we're able to create a record which directs traffic to the load balancer. 

The popular tutorials suggest creating a private hosted zone to hold the DNS record. This first attempt is using the established Public Hosted zone for the CNAME record to the load balancer DNS.

Tests: 

Initial tests show the proxy lambda, which is using the vanity url, is successfully working. 
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/2468afee-cbc8-4a61-b74f-50686befa493">
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/a71a4af4-5c3c-4eb6-b768-8fcf0d516993">

And the load balancer is in use. 

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/e848a5d5-fca2-45b6-8dc5-69dbfd43cd8c">
