### PR TITLE
[DCMAW-10586] pin all workflows to ubuntu 22.04

### DIFF
--- a/.github/workflows/backend-api-pull-request.yml
+++ b/.github/workflows/backend-api-pull-request.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   ci-checks:
     name: Run CI checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   sonar-scan:
     name: Sonar main branch scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -54,7 +54,7 @@ jobs:
   build-and-push-to-dev:
     name: 'Push test image and SAM artifact to dev'
     needs: sonar-scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BACKEND_API_DEV_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_DEV_TEST_IMAGE_REPOSITORY }}
       DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
@@ -136,7 +136,7 @@ jobs:
   build-and-push-to-build:
     name: Push test image and SAM artifact to build
     needs: sonar-scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BACKEND_API_BUILD_TEST_IMAGE_REPOSITORY: ${{ secrets.BACKEND_API_BUILD_TEST_IMAGE_REPOSITORY }}
       BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/sts-mock-pull-request.yml
+++ b/.github/workflows/sts-mock-pull-request.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ci-checks:
     name: Run CI checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   sonar-scan:
     name: Run tests and Sonar scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -54,7 +54,7 @@ jobs:
   # build-and-push-test-image-to-dev:
   #   name: Build and push test image to Dev
   #   needs: sts-mock-tests-and-sonar-scan
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   env:
   #     STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_DEV_TEST_IMAGE_REPOSITORY_URI }}      
   #     DEV_CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
@@ -99,7 +99,7 @@ jobs:
 
   build-and-upload-sam-artifact-to-dev:
     name: Validate & upload S3 artifact to dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: sonar-scan
     defaults:
       run:
@@ -150,7 +150,7 @@ jobs:
   # build-and-push-test-image-to-build:
   #   name: Build and push test image to Build
   #   needs: sts-mock-tests-and-sonar-scan  
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   env:
   #     STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI: ${{ secrets.STS_MOCK_BUILD_TEST_IMAGE_REPOSITORY_URI }}      
   #     BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
@@ -195,7 +195,7 @@ jobs:
 
   build-and-upload-sam-artifact-to-build:
     name: Validate & upload S3 artifact to Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: sonar-scan 
     defaults:
       run:


### PR DESCRIPTION
​DCMAW-10586

### What changed
Pin workflows to `ubuntu-22.04` as our workflows are not entirely compatible with upcoming `ubuntu-latest` changes.

