### PR TITLE
[DCMAW-10875] Set global MemorySize to 512 for async backend Lambdas

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -217,6 +217,7 @@ Conditions:
 Globals:
   Function:
     Timeout: 5
+    MemorySize: 512
     ReservedConcurrentExecutions: !FindInMap
       - Lambda
       - !Ref Environment

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -481,6 +481,11 @@ describe("Backend application infrastructure", () => {
           ],
         });
       });
+
+      test("Global memory size is set to 512MB", () => {
+        const globalMemorySize = template.toJSON().Globals.Function.MemorySize;
+        expect(globalMemorySize).toStrictEqual(512);
+      });
     });
 
     test("All lambdas have a FunctionName defined", () => {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10875

### What changed
* Sets global MemorySize to 512 for async backend Lambdas
* Adds infra test for the same

### Why did it change
* The programme standard is to default to 512, as a sweet spot of cost and performance.
* Out active session Lambda was experiencing frequent timeouts in all environments, disrupting testing - upping the memory was found to eliminate this issue.
<!-- Describe the reason these changes were made - the "why" -->

### Evidence
* Memory set to 512MB for all lambdas in deployed stack
![image](https://github.com/user-attachments/assets/51fdb833-829d-4f41-a058-fb02b7b95ca3)

* All API tests passing against deployed stack

![image](https://github.com/user-attachments/assets/d4ce8b8c-65e2-4368-a90b-5690df004861)
