### PR TITLE
DCMAW-10870: move esbuild back to dependencies

### DIFF
--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -19,6 +19,7 @@
         "@aws-sdk/util-dynamodb": "^3.713.0",
         "axios": "1.7.9",
         "ecdsa-sig-formatter": "1.0.11",
+        "esbuild": "^0.24.0",
         "jose": "^5.9.6"
       },
       "devDependencies": {
@@ -38,7 +39,6 @@
         "aws4-axios": "^3.3.11",
         "axios-retry": "^4.5.0",
         "dotenv": "16.4.7",
-        "esbuild": "^0.24.0",
         "eslint": "^9.17.0",
         "express": "^4.21.2",
         "jest": "29.7.0",
@@ -2065,7 +2065,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5487,7 +5486,6 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
       "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -38,7 +38,6 @@
     "aws4-axios": "^3.3.11",
     "axios-retry": "^4.5.0",
     "dotenv": "16.4.7",
-    "esbuild": "^0.24.0",
     "eslint": "^9.17.0",
     "express": "^4.21.2",
     "jest": "29.7.0",
@@ -63,6 +62,7 @@
     "@aws-sdk/util-dynamodb": "^3.713.0",
     "axios": "1.7.9",
     "ecdsa-sig-formatter": "1.0.11",
+    "esbuild": "^0.24.0",
     "jose": "^5.9.6"
   },
   "overrides": {

--- a/sts-mock/package-lock.json
+++ b/sts-mock/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.11.0",
         "@aws-sdk/client-s3": "^3.713.0",
+        "esbuild": "^0.24.0",
         "jose": "^5.9.6"
       },
       "devDependencies": {
@@ -24,7 +25,6 @@
         "axios": "^1.7.9",
         "axios-retry": "^4.5.0",
         "dotenv": "^16.4.7",
-        "esbuild": "^0.24.0",
         "eslint": "^9.17.0",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
@@ -1596,7 +1596,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4353,7 +4352,6 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
       "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"

--- a/sts-mock/package.json
+++ b/sts-mock/package.json
@@ -27,7 +27,6 @@
     "aws-cdk-lib": "^2.173.1",
     "aws-sdk-client-mock": "^4.1.0",
     "dotenv": "^16.4.7",
-    "esbuild": "^0.24.0",
     "eslint": "^9.17.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
@@ -42,6 +41,7 @@
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.11.0",
     "@aws-sdk/client-s3": "^3.713.0",
+    "esbuild": "^0.24.0",
     "jose": "^5.9.6"
   },
   "overrides": {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
DCMAW-10870

### What changed
Fix workflow failure caused by this PR: https://github.com/govuk-one-login/mobile-id-check-async/commit/65e185e6f5aa6ea4a71b3e9b3d2f748ff7b33d81

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
