### PR TITLE
DCMAW-10822: Bumps path-to-regexp (indirect dep) to non vulnerable version

### DIFF
--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -102,6 +102,7 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -110,6 +111,7 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5942,9 +5944,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.11.tgz",
-      "integrity": "sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "express": {
-      "path-to-regexp": "^0.1.11"
+      "path-to-regexp": "^0.1.12"
     },
     "micromatch": "^4.0.8",
     "path-to-regexp": "^8.1.0"


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10822

### What changed
- Updates `package.json` `resolutions` entry for `express/path-to-regexp` to ensure that minimum version of this indirect dependancy will be `0.1.12`. 

### Why did it change
Versions < `0.1.12` have vulnerability, see [here](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-rhx6-c78j-4q9w)

### Evidence

Running `npm audit` shows 0 vulnerabilities

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
