### PR TITLE
[DCMAW-8266] Create 4/5XX alarms for /async/credential

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -1807,6 +1807,262 @@ Resources:
           ReturnData: false
           Expression: (errorSum5XX/invocations) * 100
 
+  AsyncCredential4XXLowThresholdAlarm:
+    Condition: DeployAlarms
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "1% or more of requests are failing on the /async/credential endpoint with a 4XX error. See runbook: ${RunbookUrl}"
+        - RunbookUrl:
+            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-low-threshold-async-credential-4xx-api-gw"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      TreatMissingData: notBreaching
+      Threshold: 1
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF((invocations>=4) && (errorSum4XX>=2),errorPercentage4XX,0)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorSum4XX
+          Label: "Number of 4XX errors"
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4XXError
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage4XX
+          Label: "Number of 4XX errors returned as a percentage"
+          ReturnData: false
+          Expression: (errorSum4XX/invocations) * 100
+
+  AsyncCredential4XXHighThresholdAlarm:
+    Condition: DeployAlarms
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "80% or more of requests are failing on the /async/credential endpoint with a 4XX error. See runbook: ${RunbookUrl}"
+        - RunbookUrl:
+            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-high-threshold-async-credential-4xx-api-gw"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      TreatMissingData: notBreaching
+      Threshold: 80
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations>=10,errorPercentage4XX,0)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorSum4XX
+          Label: "Number of 4XX errors"
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 4XXError
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage4XX
+          Label: "Number of 4XX errors returned as a percentage"
+          ReturnData: false
+          Expression: (errorSum4XX/invocations) * 100
+
+  AsyncCredential5XXLowThresholdAlarm:
+    Condition: DeployAlarms
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "1% or more of requests are failing on the /async/credential endpoint with a 5XX error. See runbook: ${RunbookUrl}"
+        - RunbookUrl:
+            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-low-threshold-async-credential-5xx-api-gw"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      TreatMissingData: notBreaching
+      Threshold: 1
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF((invocations>=4) && (errorSum5XX>=2),errorPercentage5XX,0)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorSum5XX
+          Label: "Number of 5XX errors"
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage5XX
+          Label: "Number of 5XX errors returned as a percentage"
+          ReturnData: false
+          Expression: (errorSum5XX/invocations) * 100
+
+  AsyncCredential5XXHighThresholdAlarm:
+    Condition: DeployAlarms
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "80% or more of requests are failing on the /async/credential endpoint with a 5XX error. See runbook: ${RunbookUrl}"
+        - RunbookUrl:
+            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-high-threshold-async-credential-5xx-api-gw"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      TreatMissingData: notBreaching
+      Threshold: 80
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations>=10,errorPercentage5XX,0)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorSum5XX
+          Label: "Number of 5XX errors"
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: Method
+                  Value: POST
+                - Name: ApiName
+                  Value: !Sub ${AWS::StackName}-private-api
+                - Name: Stage
+                  Value: !Ref Environment
+                - Name: Resource
+                  Value: /async/credential
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage5XX
+          Label: "Number of 5XX errors returned as a percentage"
+          ReturnData: false
+          Expression: (errorSum5XX/invocations) * 100
+
 Outputs:
   SessionsApiUrl:
     Description: Sessions API Gateway base URL

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -141,7 +141,11 @@ describe("Backend application infrastructure", () => {
       // to be updated only when a runbook exists for an alarm
       const runbooksByAlarm: Record<string, boolean> = {
         "high-threshold-well-known-5xx-api-gw": false,
-        "low-threshold-well-known-5xx-api-gw": false,
+        "high-threshold-well-known-4xx-api-gw": false,
+        "high-threshold-async-token-5xx-api-gw": false,
+        "high-threshold-async-token-4xx-api-gw": false,
+        "high-threshold-async-credential-5xx-api-gw": false,
+        "high-threshold-async-credential-4xx-api-gw": false,
       };
 
       const alarms = template.findResources("AWS::CloudWatch::Alarm");
@@ -184,6 +188,10 @@ describe("Backend application infrastructure", () => {
         ["low-threshold-async-token-5xx-api-gw"],
         ["high-threshold-async-token-4xx-api-gw"],
         ["low-threshold-async-token-4xx-api-gw"],
+        ["high-threshold-async-credential-5xx-api-gw"],
+        ["low-threshold-async-credential-5xx-api-gw"],
+        ["high-threshold-async-credential-4xx-api-gw"],
+        ["low-threshold-async-credential-4xx-api-gw"],
       ])(
         "The %s alarm is configured to send an event to the warnings SNS topic on Alarm and OK actions",
         (alarmName: string) => {


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-8266

# What changed
* Creates high and low threshold 4/5XX alarms for /async/credential endpoint. These will ensure that we, and live support, are notified for persistent issues with this endpoint.
  * All four alarms are currently set to notify the warnings channel, with the high threshold alarms to be promoted to alerts on a future ticket.
* Updates infra tests accordingly

## Evidence

_The evidence provided here indicates that each alarm notifies slack correctly. To properly evidence that each alarm is configured with the correct conditions, please inspect the template.yaml, or view the alarms in the Cloudwatch console._

### Low Threshold 4XX
![image](https://github.com/user-attachments/assets/3c2a5fb9-48d4-4232-b2fc-b6975800b89f)

### High Threshold 4XX
![image](https://github.com/user-attachments/assets/edc289bd-d5e7-4ba9-805b-20b72c124748)

### Low Threshold 5XX
![image](https://github.com/user-attachments/assets/475665cc-4def-4835-af84-c24a03f79caf)

### High Threshold 5XX
![image](https://github.com/user-attachments/assets/6e7290f6-aac8-4175-8523-7a31e5233aaa)

## Documentation

I have updated our [warning](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings) and [critical](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarms+Runbook+Alerts+-+DRAFT) alarm runbooks.

