### PR TITLE
DCMAW-10904: Switch sonarcloud-github-action for sonarqube-scan-action

### DIFF
--- a/.github/workflows/backend-api-pull-request.yml
+++ b/.github/workflows/backend-api-pull-request.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Validate SAM template
         run: sam validate --lint
 
-      - name: "Run SonarCloud Scan"
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # master
+      - name: Run SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backend-api-push-to-main.yml
+++ b/.github/workflows/backend-api-push-to-main.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Run Tests
         run: npm run test:unit
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 #master
+      - name: Run SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sts-mock-pull-request.yml
+++ b/.github/workflows/sts-mock-pull-request.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Validate SAM template
         run: sam validate --lint
 
-      - name: "Run SonarCloud Scan"
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # master
+      - name: Run SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sts-mock-push-to-main.yml
+++ b/.github/workflows/sts-mock-push-to-main.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Run Tests
         run: npm run test:unit
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 #master
+      - name: Run SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test-resources-pull-request.yml
+++ b/.github/workflows/test-resources-pull-request.yml
@@ -53,7 +53,7 @@ jobs:
         run: sam validate --lint
 
       - name: Run SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # master
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-resources-push-to-main.yml
+++ b/.github/workflows/test-resources-push-to-main.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Run Tests
         run: npm run test:unit
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 #master
+      - name: Run SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
​DCMAW-10904

### What changed
Switch from `sonarsource/sonarcloud-github-action` to `sonarsource/sonarqube-scan-action`.

### Why did it change
`sonarsource/sonarcloud-github-action` has been [deprecated](https://github.com/SonarSource/sonarcloud-github-action) and replaced by the pre-existing `sonarsource/sonarqube-scan-action`. This is a "drop-in replacement".

v4.2.1 is the latest version right now: https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.1

## Checklists
- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
