### PR TITLE
[DCMAW-10899] Async CloudFront | Route backend traffic through the cloudfront distribution

### DIFF
--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -811,7 +811,7 @@ Resources:
           Parameters:
             Location: ./openApiSpecs/async-public-spec.yaml
       Tags:
-        FMSRegionalPolicy: false
+        FMSRegionalPolicy: false # Disables FMS for this API Gateway in favor of the cf-dist WAF. FMS Docs: https://govukverify.atlassian.net/wiki/x/eoBNEQE
 
   SessionsApiAccessLogs:
     Type: AWS::Logs::LogGroup

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -875,9 +875,6 @@ Resources:
         DNSName:
           Fn::ImportValue: !Sub "${AWS::StackName}-cf-dist-DistributionDomain"
         HostedZoneId: Z2FDTNDATAQYW2
-        # AliasTarget:
-        #   DNSName: !GetAtt SessionsApiDomainName.RegionalDomainName
-        #   HostedZoneId: !GetAtt SessionsApiDomainName.RegionalHostedZoneId
 
   SessionsApiWebAclAssociation:
     Type: AWS::WAFv2::WebACLAssociation

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -810,6 +810,8 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: ./openApiSpecs/async-public-spec.yaml
+      Tags:
+        FMSRegionalPolicy: false
 
   SessionsApiAccessLogs:
     Type: AWS::Logs::LogGroup

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -212,7 +212,7 @@ Conditions:
       - !Equals
         - !Ref Environment
         - dev
-    - !Equals [ !Ref DeployAlarmsInDev, true ]
+    - !Equals [!Ref DeployAlarmsInDev, true]
 
 Globals:
   Function:
@@ -242,24 +242,24 @@ Globals:
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_CONNECTION_BASE_URL: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_CLUSTER_ID: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_TENANT: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
-    Layers: 
+    Layers:
       - !Sub
         - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
 
 Resources:
 
@@ -484,7 +484,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource:
-                  - Fn::GetAtt: [ "SessionsTable", "Arn" ]
+                  - Fn::GetAtt: ["SessionsTable", "Arn"]
                   - !Sub ${SessionsTable.Arn}/index/subjectIdentifier-timeToLive-index
                 Condition:
                   ForAllValues:StringEquals:
@@ -845,6 +845,21 @@ Resources:
       RestApiId: !Ref SessionsApi
       Stage: !Ref SessionsApi.Stage
 
+  SessionsApiOriginRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Sub
+        - "origin.sessions-${AWS::StackName}.${DNS_RECORD}"
+        - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+      Type: A
+      HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
+      AliasTarget:
+        DNSName: !GetAtt SessionsApiDomainName.RegionalDomainName
+        HostedZoneId: !GetAtt SessionsApiDomainName.RegionalHostedZoneId
+
   SessionsApiRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -857,8 +872,21 @@ Resources:
       Type: A
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
       AliasTarget:
-        DNSName: !GetAtt SessionsApiDomainName.RegionalDomainName
-        HostedZoneId: !GetAtt SessionsApiDomainName.RegionalHostedZoneId
+        DNSName:
+          Fn::ImportValue: !Sub "${AWS::StackName}-cf-dist-DistributionDomain"
+        HostedZoneId: Z2FDTNDATAQYW2
+        # AliasTarget:
+        #   DNSName: !GetAtt SessionsApiDomainName.RegionalDomainName
+        #   HostedZoneId: !GetAtt SessionsApiDomainName.RegionalHostedZoneId
+
+  SessionsApiWebAclAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Sub
+        - "arn:aws:apigateway:${AWS::Region}::/restapis/${SessionsApi}/stages/${ApiStage}"
+        - ApiStage: !Ref SessionsApi.Stage
+      WebACLArn:
+        Fn::ImportValue: !Sub "${AWS::StackName}-cf-dist-CloakingOriginWebACLArn"
 
   AsyncActiveSessionFunction:
     Type: AWS::Serverless::Function
@@ -936,7 +964,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource:
-                  - Fn::GetAtt: [ "SessionsTable", "Arn" ]
+                  - Fn::GetAtt: ["SessionsTable", "Arn"]
                   - !Sub ${SessionsTable.Arn}/index/subjectIdentifier-timeToLive-index
                 Condition:
                   ForAllValues:StringEquals:
@@ -1430,8 +1458,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "1% or more of requests are failing on the /.well-known/jwks.json endpoint. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-low-threshold-well-known-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1494,8 +1521,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "80% or more of requests are failing on the /.well-known/jwks.json endpoint. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-high-threshold-well-known-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1558,8 +1584,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "1% or more of requests are failing on the /async/token endpoint with a 4XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-low-threshold-async-token-4xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1622,8 +1647,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "80% or more of requests are failing on the /async/token endpoint with a 4XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-high-threshold-async-token-4xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1686,8 +1710,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "1% or more of requests are failing on the /async/token endpoint with a 5XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-low-threshold-async-token-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1750,8 +1773,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "80% or more of requests are failing on the /async/token endpoint with a 5XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-high-threshold-async-token-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1814,8 +1836,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "1% or more of requests are failing on the /async/credential endpoint with a 4XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-low-threshold-async-credential-4xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1878,8 +1899,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "80% or more of requests are failing on the /async/credential endpoint with a 4XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-high-threshold-async-credential-4xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -1942,8 +1962,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "1% or more of requests are failing on the /async/credential endpoint with a 5XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-low-threshold-async-credential-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -2006,8 +2025,7 @@ Resources:
       ActionsEnabled: true
       AlarmDescription: !Sub
         - "80% or more of requests are failing on the /async/credential endpoint with a 5XX error. See runbook: ${RunbookUrl}"
-        - RunbookUrl:
-            !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
+        - RunbookUrl: !FindInMap [StaticVariables, urls, CriticalAlarmsRunbook]
       AlarmName: !Sub "${AWS::StackName}-high-threshold-async-credential-5xx-api-gw"
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
@@ -2080,9 +2098,9 @@ Outputs:
   StsMockApiUrl:
     Description: STS Mock API Gateway base URL
     Value: !If
-        - UseDevOverrideStsBaseUrl
-        - !Ref DevOverrideStsBaseUrl
-        - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
+      - UseDevOverrideStsBaseUrl
+      - !Ref DevOverrideStsBaseUrl
+      - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
 
   TxmaSqsQueueArn:
     Condition: IsDevOrBuild

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -236,6 +236,13 @@ describe("Backend application infrastructure", () => {
       });
     });
 
+    test("It disables the FMS WAF", () => {
+      template.hasResourceProperties("AWS::Serverless::Api", {
+        Name: { "Fn::Sub": "${AWS::StackName}-sessions-api" },
+        Tags: { "FMSRegionalPolicy": false }
+      });
+    });
+
     describe("APIgw method settings", () => {
       test("Metrics are enabled", () => {
         const methodSettings = new Capture();

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -239,7 +239,7 @@ describe("Backend application infrastructure", () => {
     test("It disables the FMS WAF", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
         Name: { "Fn::Sub": "${AWS::StackName}-sessions-api" },
-        Tags: { "FMSRegionalPolicy": false }
+        Tags: { FMSRegionalPolicy: false },
       });
     });
 


### PR DESCRIPTION
Reroutes the traffic for the Session API through the cloudfront distribution stack. The CF DIstribution template is provided by Dev Platform and is now a requirement for the backend api stack in all instances. 

Changes: 

- `${VANITY_URL}` (i.e. `sessions-mob-async-backend.review-b-backend.dev.account.gov.uk`) now points to the cloudfront distribution domain
- Creates the `origin.${VANITY_URL}` route53 record which targets the sessions api gateway domain name. 
- Attaches the origin protection waf to ensure all traffic is passing through the cloudfront distribution. 
- Preemptively adds the tag `FMSRegionalPolicy: false` to exclude the api gateway stage from the automated WAF association and preserve the origin protection WAF.

Test: 

- Deployed a backend stack `douglast-async-backend` which passes test successfully. 
- Deployed a `douglast-async-backend-cf-dist` stack. 

- Created a change set for `douglast-async-backend` with the template changes in this PR:
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/17ff7bbb-15f8-4b52-af98-907d7ec5bb37" />

- Executed the change set 
- Reran tests `sh ./run-tests-locally.sh douglast-async-backend`
<img width="346" alt="image" src="https://github.com/user-attachments/assets/1d219b8c-2d4d-48aa-b084-7ccdc634f8f3" />
<img width="708" alt="image" src="https://github.com/user-attachments/assets/93709429-719c-4453-af43-2df3abfd7cee" />

- Checked metrics and CloudFront is seeing the same amount of requests as the API Gateway: 
<img width="446" alt="image" src="https://github.com/user-attachments/assets/7dd3ac1e-3039-45f9-bca7-32e9139edada" />

- curl commands: I used the following script to prove that access is blocked through the `origin.${VANITY_URL}` without the origin cloaking header:

```
vanity_url=sessions-douglast-async-backend.review-b-async.dev.account.gov.uk
origin_url="origin.${vanity_url}"

vanity_ip=$(dig +short "${vanity_url}" | head --lines 1)
origin_ip=$(dig +short "${origin_url}" | head --lines 1)

echo "Confirm origin ip and vanity ip are different:"
echo "Vanity IP: ${vanity_ip}"
echo "Origin IP: ${origin_ip}"
echo

echo "Confirm connection successfull to vanity and origin WITHOUT the origin-cloaking-secret header"
echo "VANITY:"
curl --verbose --resolve "${vanity_url}:443:${vanity_ip}" "https://${vanity_url}/.well-known/jwks.json" --output response_vanity.txt --silent

echo
echo

echo "ORIGIN:"
curl --verbose --resolve "${vanity_url}:443:${origin_ip}" "https://${vanity_url}/.well-known/jwks.json" --output response_origin.txt --silent

echo
echo

echo "Response body diff:"
echo "------------"
diff response_vanity.txt response_origin.txt
echo "------------"
```


