### PR TITLE
[DCMAW-10882] update CODEOWNERS to require SRE approvals before merging PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,10 @@
 # The following below will be requested for review when someone opens a pull request.
 
 * @govuk-one-login/mobile-id-check @govuk-one-login/mobile-leads
+
+# All changes in .github directory to be checked by SRE
+.github/ @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
+
+# All changes to Dockerfiles and CloudFormation templates to be checked by SRE
+**/template.yaml @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
+**/Dockerfile @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads


### PR DESCRIPTION
​DCMAW-10882

### What changed
Updated CODEOWNERS with new GitHub Team `@govuk-one-login/mobile-id-check-sre`. Code change means `@govuk-one-login/mobile-leads` can approve if SREs not available to approve.
Approvals are needed for code changes in .github dir and in any changes to template.yaml or dockerfiles.

### Why did it change
This change was brought in so SREs must approve platform related changes in async. Can be approved by team leads if SREs not available.

## Checklists
- [X] There is a ticket raised for this PR that is present in the branch name
- [X] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
