### PR TITLE
DCMAW-10829: Get biometric access token from ReadID

### DIFF
--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -40,11 +40,11 @@ describe("getBiometricToken", () => {
     });
   });
 
-  describe("Given there is an error making network request", () => {
+  describe("Given there is an error when making network request", () => {
     beforeEach(async () => {
       mockSendHttpRequest = jest
         .fn()
-        .mockRejectedValue(new Error("Unexpected network error"));
+        .mockRejectedValue(new Error("mockError"));
 
       result = await getBiometricToken(
         "https://mockUrl.com",

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -14,11 +14,12 @@ describe("getBiometricToken", () => {
 
   describe("On every call", () => {
     beforeEach(async () => {
-      global.fetch = jest.fn(() =>
-        Promise.resolve(),
-      ) as jest.Mock;
+      global.fetch = jest.fn(() => Promise.resolve()) as jest.Mock;
 
-      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
+      result = await getBiometricToken(
+        "https://mockUrl.com",
+        "mockSubmitterKey",
+      );
     });
 
     it("Logs network call attempt at debug level", () => {
@@ -26,8 +27,8 @@ describe("getBiometricToken", () => {
         messageCode:
           "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT",
       });
-    })
-  })
+    });
+  });
 
   describe("Given there is an error making network request", () => {
     beforeEach(async () => {
@@ -35,7 +36,10 @@ describe("getBiometricToken", () => {
         Promise.reject(new Error("Unexpected network error")),
       ) as jest.Mock;
 
-      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
+      result = await getBiometricToken(
+        "https://mockUrl.com",
+        "mockSubmitterKey",
+      );
     });
 
     it("Logs error", () => {
@@ -68,7 +72,10 @@ describe("getBiometricToken", () => {
           } as unknown as Response),
         ) as jest.Mock;
 
-        result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
+        result = await getBiometricToken(
+          "https://mockUrl.com",
+          "mockSubmitterKey",
+        );
       });
 
       it("Logs error", () => {
@@ -94,7 +101,10 @@ describe("getBiometricToken", () => {
           } as Response),
         ) as jest.Mock;
 
-        result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
+        result = await getBiometricToken(
+          "https://mockUrl.com",
+          "mockSubmitterKey",
+        );
       });
 
       it("Logs error", () => {
@@ -126,7 +136,10 @@ describe("getBiometricToken", () => {
         } as Response),
       ) as jest.Mock;
 
-      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
+      result = await getBiometricToken(
+        "https://mockUrl.com",
+        "mockSubmitterKey",
+      );
     });
 
     it("Logs success at debug level", () => {

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -15,7 +15,7 @@ describe("getBiometricToken", () => {
 
   describe("On every call", () => {
     beforeEach(async () => {
-      async function httpRequestOverrideMockResponse() {
+      async function mockSendHttpRequestResponse() {
         return {
           statusCode: 200,
           body: "mockBody",
@@ -28,7 +28,7 @@ describe("getBiometricToken", () => {
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        httpRequestOverrideMockResponse,
+        mockSendHttpRequestResponse,
       );
     });
 
@@ -42,14 +42,14 @@ describe("getBiometricToken", () => {
 
   describe("Given an error is caught when requesting a biometric access token", () => {
     beforeEach(async () => {
-      async function httpRequestOverrideMockError() {
+      async function mockSendHttpRequestErrorResponse() {
         throw new Error("mockError");
       }
 
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        httpRequestOverrideMockError as unknown as ISendHttpRequest,
+        mockSendHttpRequestErrorResponse as unknown as ISendHttpRequest,
       );
     });
 
@@ -68,7 +68,7 @@ describe("getBiometricToken", () => {
   describe("Given the response is invalid", () => {
     describe("Given response body is undefined", () => {
       beforeEach(async () => {
-        async function httpRequestOverrideMockBodyUndefined() {
+        async function mockSendHttpRequestResponseBodyUndefined() {
           return {
             statusCode: 200,
             body: undefined,
@@ -81,7 +81,7 @@ describe("getBiometricToken", () => {
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          httpRequestOverrideMockBodyUndefined,
+          mockSendHttpRequestResponseBodyUndefined,
         );
       });
 
@@ -99,7 +99,7 @@ describe("getBiometricToken", () => {
 
     describe("Given response body cannot be parsed", () => {
       beforeEach(async () => {
-        async function httpRequestOverrideMockBodyInvalidJSON() {
+        async function mockSendHttpRequestResponseBodyInvalidJson() {
           return {
             statusCode: 200,
             body: "Invalid JSON",
@@ -112,7 +112,7 @@ describe("getBiometricToken", () => {
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          httpRequestOverrideMockBodyInvalidJSON,
+          mockSendHttpRequestResponseBodyInvalidJson,
         );
       });
 
@@ -136,7 +136,7 @@ describe("getBiometricToken", () => {
         expires_in: 3600,
         token_type: "Bearer",
       });
-      async function sendHttpRequestOverrideMockValidResponse() {
+      async function mockSendHttpRequestValidResponse() {
         return {
           statusCode: 200,
           body: mockBody,
@@ -149,7 +149,7 @@ describe("getBiometricToken", () => {
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        sendHttpRequestOverrideMockValidResponse,
+        mockSendHttpRequestValidResponse,
       );
     });
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -18,7 +18,7 @@ describe("getBiometricToken", () => {
         Promise.resolve(),
       ) as jest.Mock;
 
-      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
     });
 
     it("Logs network call attempt at debug level", () => {
@@ -35,7 +35,7 @@ describe("getBiometricToken", () => {
         Promise.reject(new Error("Unexpected network error")),
       ) as jest.Mock;
 
-      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
     });
 
     it("Logs error", () => {
@@ -68,7 +68,7 @@ describe("getBiometricToken", () => {
           } as unknown as Response),
         ) as jest.Mock;
 
-        result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+        result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
       });
 
       it("Logs error", () => {
@@ -94,7 +94,7 @@ describe("getBiometricToken", () => {
           } as Response),
         ) as jest.Mock;
 
-        result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+        result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
       });
 
       it("Logs error", () => {
@@ -126,7 +126,7 @@ describe("getBiometricToken", () => {
         } as Response),
       ) as jest.Mock;
 
-      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      result = await getBiometricToken("https://mockUrl.com", "mockSubmitterKey");
     });
 
     it("Logs success at debug level", () => {

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -55,12 +55,6 @@ describe("getBiometricToken", () => {
   });
 
   describe("Given the response is invalid", () => {
-    describe("Given response is undefined", () => {
-      it("Returns an empty failure", async () => {
-        /// Write test
-      });
-    });
-
     describe("Given response body is undefined", () => {
       beforeEach(async () => {
         global.fetch = jest.fn(() =>

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -58,7 +58,11 @@ describe("getBiometricToken", () => {
 
   describe("Given valid request is made", () => {
     it("Returns successResult containing biometric token", async () => {
-      const mockData = JSON.stringify({ access_token: "mockBiometricToken" });
+      const mockData = JSON.stringify({
+        access_token: "mockBiometricToken",
+        expires_in: 3600,
+        token_type: "Bearer",
+      });
       global.fetch = jest.fn(() =>
         Promise.resolve({
           status: 200,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -2,6 +2,32 @@ import { successResult } from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
 
 describe("getBiometricToken", () => {
+  describe("Given there is an error making network request", () => {
+    it("Returns an empty failure", async () => {
+      /// Write test
+    })
+  })
+
+  describe("Given the response is invalid", () => {
+    describe("Given response is undefined", () => {
+      it("Returns an empty failure", async () => {
+        /// Write test
+      })
+    })
+
+    describe("Given response body is undefined", () => {
+      it("Returns an empty failure", async () => {
+        /// Write test
+      })
+    })
+
+    describe("Given response body cannot be parsed", () => {
+      it("Returns an empty failure", async () => {
+        /// Write test
+      })
+    })
+  })
+
   it("Returns successResult containing a string", async () => {
     const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -1,10 +1,16 @@
-import { successResult } from "../../utils/result";
+import { emptyFailure, successResult } from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
 
 describe("getBiometricToken", () => {
   describe("Given there is an error making network request", () => {
     it("Returns an empty failure", async () => {
-      /// Write test
+      global.fetch = jest.fn(() =>
+        Promise.reject(new Error("Unexpected network error")),
+      ) as jest.Mock;
+
+      const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+
+      expect(result).toEqual(emptyFailure());
     });
   });
 
@@ -30,6 +36,16 @@ describe("getBiometricToken", () => {
 
   describe("Given valid request is made", () => {
     it("Returns successResult containing biometric token", async () => {
+      const mockData = JSON.stringify({ access_token: "mockBiometricToken" });
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          headers: new Headers({ "Content-Type": "text/plain" }),
+          text: () => Promise.resolve(mockData),
+        } as Response),
+      ) as jest.Mock;
+
       const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
 
       expect(result).toEqual(successResult("mockBiometricToken"));

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -5,8 +5,10 @@ import "../../testUtils/matchers";
 
 describe("getBiometricToken", () => {
   let result: Result<string, void>;
+  let consoleDebugSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;
   beforeEach(() => {
+    consoleDebugSpy = jest.spyOn(console, "debug");
     consoleErrorSpy = jest.spyOn(console, "error");
   });
 
@@ -92,7 +94,7 @@ describe("getBiometricToken", () => {
   });
 
   describe("Given valid request is made", () => {
-    it("Returns successResult containing biometric token", async () => {
+    beforeEach(async () => {
       const mockData = JSON.stringify({
         access_token: "mockBiometricToken",
         expires_in: 3600,
@@ -108,7 +110,16 @@ describe("getBiometricToken", () => {
       ) as jest.Mock;
 
       result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+    });
 
+    it("Logs success at debug level", () => {
+      expect(consoleDebugSpy).toHaveBeenCalledWithLogFields({
+        messageCode:
+          "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS",
+      });
+    });
+
+    it("Returns successResult containing biometric token", () => {
       expect(result).toEqual(successResult("mockBiometricToken"));
     });
   });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -2,12 +2,12 @@ import { emptyFailure, Result, successResult } from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
 import { expect } from "@jest/globals";
 import "../../testUtils/matchers";
+import { ISendHttpRequest } from "../../services/http/sendHttpRequest";
 
 describe("getBiometricToken", () => {
   let result: Result<string, void>;
   let consoleDebugSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;
-  let mockSendHttpRequest;
   beforeEach(() => {
     consoleDebugSpy = jest.spyOn(console, "debug");
     consoleErrorSpy = jest.spyOn(console, "error");
@@ -40,14 +40,16 @@ describe("getBiometricToken", () => {
     });
   });
 
-  describe("Given there is an error when requesting biometric access token", () => {
+  describe("Given an error is caught when requesting a biometric access token", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest.fn().mockRejectedValue(new Error("mockError"));
+      async function httpRequestOverrideMockError() {
+        throw new Error("mockError");
+      }
 
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        mockSendHttpRequest,
+        httpRequestOverrideMockError as unknown as ISendHttpRequest,
       );
     });
 
@@ -129,7 +131,7 @@ describe("getBiometricToken", () => {
 
   describe("Given valid request is made", () => {
     beforeEach(async () => {
-      const mockData = JSON.stringify({
+      const mockBody = JSON.stringify({
         access_token: "mockBiometricToken",
         expires_in: 3600,
         token_type: "Bearer",
@@ -137,7 +139,7 @@ describe("getBiometricToken", () => {
       async function sendHttpRequestOverrideMockValidResponse() {
         return {
           statusCode: 200,
-          body: mockData,
+          body: mockBody,
           headers: {
             mockHeaderKey: "mockHeaderValue",
           },

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -42,9 +42,7 @@ describe("getBiometricToken", () => {
 
   describe("Given there is an error when making network request", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest
-        .fn()
-        .mockRejectedValue(new Error("mockError"));
+      mockSendHttpRequest = jest.fn().mockRejectedValue(new Error("mockError"));
 
       result = await getBiometricToken(
         "https://mockUrl.com",

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -1,15 +1,32 @@
-import { emptyFailure, successResult } from "../../utils/result";
+import { emptyFailure, Result, successResult } from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
+import { expect } from "@jest/globals";
+import "../../testUtils/matchers";
 
 describe("getBiometricToken", () => {
+  let result: Result<string, void>;
+  let consoleErrorSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error");
+  });
+
   describe("Given there is an error making network request", () => {
-    it("Returns an empty failure", async () => {
+    beforeEach(async () => {
       global.fetch = jest.fn(() =>
         Promise.reject(new Error("Unexpected network error")),
       ) as jest.Mock;
 
-      const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+    });
 
+    it("Logs error", () => {
+      expect(consoleErrorSpy).toHaveBeenCalledWithLogFields({
+        messageCode:
+          "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE",
+      });
+    });
+
+    it("Returns an empty failure", () => {
       expect(result).toEqual(emptyFailure());
     });
   });
@@ -22,7 +39,7 @@ describe("getBiometricToken", () => {
     });
 
     describe("Given response body is undefined", () => {
-      it("Returns an empty failure", async () => {
+      beforeEach(async () => {
         global.fetch = jest.fn(() =>
           Promise.resolve({
             status: 200,
@@ -32,14 +49,23 @@ describe("getBiometricToken", () => {
           } as unknown as Response),
         ) as jest.Mock;
 
-        const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+        result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      });
 
+      it("Logs error", () => {
+        expect(consoleErrorSpy).toHaveBeenCalledWithLogFields({
+          messageCode:
+            "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE",
+        });
+      });
+
+      it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
       });
     });
 
     describe("Given response body cannot be parsed", () => {
-      it("Returns an empty failure", async () => {
+      beforeEach(async () => {
         global.fetch = jest.fn(() =>
           Promise.resolve({
             status: 200,
@@ -49,8 +75,17 @@ describe("getBiometricToken", () => {
           } as Response),
         ) as jest.Mock;
 
-        const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+        result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      });
 
+      it("Logs error", () => {
+        expect(consoleErrorSpy).toHaveBeenCalledWithLogFields({
+          messageCode:
+            "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE",
+        });
+      });
+
+      it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
       });
     });
@@ -72,7 +107,7 @@ describe("getBiometricToken", () => {
         } as Response),
       ) as jest.Mock;
 
-      const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
 
       expect(result).toEqual(successResult("mockBiometricToken"));
     });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -40,7 +40,7 @@ describe("getBiometricToken", () => {
     });
   });
 
-  describe("Given an error is caught when requesting a biometric access token", () => {
+  describe("Given an error is caught when requesting token", () => {
     beforeEach(async () => {
       async function mockSendHttpRequestError() {
         throw new Error("mockError");

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -28,9 +28,11 @@ describe("getBiometricToken", () => {
     })
   })
 
-  it("Returns successResult containing a string", async () => {
-    const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+  describe("Given valid request is made", () => {
+    it("Returns successResult containing biometric token", async () => {
+      const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
 
-    expect(result).toEqual(successResult("mockBiometricToken"));
-  });
+      expect(result).toEqual(successResult("mockBiometricToken"));
+    });
+  })
 });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -40,7 +40,7 @@ describe("getBiometricToken", () => {
     });
   });
 
-  describe("Given there is an error when making network request", () => {
+  describe("Given there is an error when requesting biometric access token", () => {
     beforeEach(async () => {
       mockSendHttpRequest = jest.fn().mockRejectedValue(new Error("mockError"));
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -12,6 +12,23 @@ describe("getBiometricToken", () => {
     consoleErrorSpy = jest.spyOn(console, "error");
   });
 
+  describe("On every call", () => {
+    beforeEach(async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve(),
+      ) as jest.Mock;
+
+      result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+    });
+
+    it("Logs network call attempt at debug level", () => {
+      expect(consoleDebugSpy).toHaveBeenCalledWithLogFields({
+        messageCode:
+          "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT",
+      });
+    })
+  })
+
   describe("Given there is an error making network request", () => {
     beforeEach(async () => {
       global.fetch = jest.fn(() =>

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -29,7 +29,18 @@ describe("getBiometricToken", () => {
 
     describe("Given response body cannot be parsed", () => {
       it("Returns an empty failure", async () => {
-        /// Write test
+        global.fetch = jest.fn(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({ "Content-Type": "text/plain" }),
+            text: () => Promise.resolve("Invalid JSON"),
+          } as Response),
+        ) as jest.Mock;
+
+        const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+
+        expect(result).toEqual(emptyFailure());
       });
     });
   });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -9,6 +9,15 @@ describe("getBiometricToken", () => {
   let consoleDebugSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;
   let mockSendHttpRequest: ISendHttpRequest;
+  const expectedArguments = {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Innovalor-Authorization": "mockSubmitterKey",
+    },
+    method: "POST",
+    url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
+  };
+
   beforeEach(() => {
     consoleDebugSpy = jest.spyOn(console, "debug");
     consoleErrorSpy = jest.spyOn(console, "error");
@@ -59,14 +68,7 @@ describe("getBiometricToken", () => {
 
     it("Returns an empty failure", () => {
       expect(result).toEqual(emptyFailure());
-      expect(mockSendHttpRequest).toBeCalledWith({
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          "X-Innovalor-Authorization": "mockSubmitterKey",
-        },
-        method: "POST",
-        url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
-      });
+      expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
     });
   });
 
@@ -97,14 +99,7 @@ describe("getBiometricToken", () => {
 
       it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
-        expect(mockSendHttpRequest).toBeCalledWith({
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "X-Innovalor-Authorization": "mockSubmitterKey",
-          },
-          method: "POST",
-          url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
-        });
+        expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
       });
     });
 
@@ -134,14 +129,7 @@ describe("getBiometricToken", () => {
 
       it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
-        expect(mockSendHttpRequest).toBeCalledWith({
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "X-Innovalor-Authorization": "mockSubmitterKey",
-          },
-          method: "POST",
-          url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
-        });
+        expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
       });
     });
   });
@@ -176,14 +164,7 @@ describe("getBiometricToken", () => {
 
     it("Returns successResult containing biometric token", () => {
       expect(result).toEqual(successResult("mockBiometricToken"));
-      expect(mockSendHttpRequest).toBeCalledWith({
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          "X-Innovalor-Authorization": "mockSubmitterKey",
-        },
-        method: "POST",
-        url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
-      });
+      expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
     });
   });
 });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -15,18 +15,20 @@ describe("getBiometricToken", () => {
 
   describe("On every call", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: JSON.stringify("mockBody"),
-        headers: {
-          mockHeaderKey: "mockHeaderValue",
-        },
-      });
+      async function httpRequestOverrideMockResponse() {
+        return {
+          statusCode: 200,
+          body: "mockBody",
+          headers: {
+            mockHeaderKey: "mockHeaderValue",
+          },
+        };
+      }
 
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        mockSendHttpRequest,
+        httpRequestOverrideMockResponse,
       );
     });
 
@@ -66,18 +68,20 @@ describe("getBiometricToken", () => {
   describe("Given the response is invalid", () => {
     describe("Given response body is undefined", () => {
       beforeEach(async () => {
-        mockSendHttpRequest = jest.fn().mockResolvedValue({
-          statusCode: 200,
-          body: undefined,
-          headers: {
-            mockHeaderKey: "mockHeaderValue",
-          },
-        });
+        async function httpRequestOverrideMockBodyUndefined() {
+          return {
+            statusCode: 200,
+            body: undefined,
+            headers: {
+              mockHeaderKey: "mockHeaderValue",
+            },
+          };
+        }
 
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          mockSendHttpRequest,
+          httpRequestOverrideMockBodyUndefined,
         );
       });
 
@@ -95,18 +99,20 @@ describe("getBiometricToken", () => {
 
     describe("Given response body cannot be parsed", () => {
       beforeEach(async () => {
-        mockSendHttpRequest = jest.fn().mockResolvedValue({
-          statusCode: 200,
-          body: "Invalid JSON",
-          headers: {
-            mockHeaderKey: "mockHeaderValue",
-          },
-        });
+        async function httpRequestOverrideMockBodyInvalidJSON() {
+          return {
+            statusCode: 200,
+            body: "Invalid JSON",
+            headers: {
+              mockHeaderKey: "mockHeaderValue",
+            },
+          };
+        }
 
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          mockSendHttpRequest,
+          httpRequestOverrideMockBodyInvalidJSON,
         );
       });
 
@@ -130,19 +136,20 @@ describe("getBiometricToken", () => {
         expires_in: 3600,
         token_type: "Bearer",
       });
-
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: mockData,
-        headers: {
-          mockHeaderKey: "mockHeaderValue",
-        },
-      });
+      async function sendHttpRequestOverrideMockValidResponse() {
+        return {
+          statusCode: 200,
+          body: mockData,
+          headers: {
+            mockHeaderKey: "mockHeaderValue",
+          },
+        };
+      }
 
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        mockSendHttpRequest,
+        sendHttpRequestOverrideMockValidResponse,
       );
     });
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -15,7 +15,7 @@ describe("getBiometricToken", () => {
 
   describe("On every call", () => {
     beforeEach(async () => {
-      async function mockSendHttpRequestResponse() {
+      async function mockSendHttpRequest() {
         return {
           statusCode: 200,
           body: "mockBody",
@@ -28,7 +28,7 @@ describe("getBiometricToken", () => {
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        mockSendHttpRequestResponse,
+        mockSendHttpRequest,
       );
     });
 
@@ -42,14 +42,14 @@ describe("getBiometricToken", () => {
 
   describe("Given an error is caught when requesting a biometric access token", () => {
     beforeEach(async () => {
-      async function mockSendHttpRequestErrorResponse() {
+      async function mockSendHttpRequestError() {
         throw new Error("mockError");
       }
 
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
-        mockSendHttpRequestErrorResponse as unknown as ISendHttpRequest,
+        mockSendHttpRequestError as unknown as ISendHttpRequest,
       );
     });
 
@@ -68,7 +68,7 @@ describe("getBiometricToken", () => {
   describe("Given the response is invalid", () => {
     describe("Given response body is undefined", () => {
       beforeEach(async () => {
-        async function mockSendHttpRequestResponseBodyUndefined() {
+        async function mockSendHttpRequestBodyUndefined() {
           return {
             statusCode: 200,
             body: undefined,
@@ -81,7 +81,7 @@ describe("getBiometricToken", () => {
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          mockSendHttpRequestResponseBodyUndefined,
+          mockSendHttpRequestBodyUndefined,
         );
       });
 
@@ -99,7 +99,7 @@ describe("getBiometricToken", () => {
 
     describe("Given response body cannot be parsed", () => {
       beforeEach(async () => {
-        async function mockSendHttpRequestResponseBodyInvalidJson() {
+        async function mockSendHttpRequestBodyInvalidJson() {
           return {
             statusCode: 200,
             body: "Invalid JSON",
@@ -112,7 +112,7 @@ describe("getBiometricToken", () => {
         result = await getBiometricToken(
           "https://mockUrl.com",
           "mockSubmitterKey",
-          mockSendHttpRequestResponseBodyInvalidJson,
+          mockSendHttpRequestBodyInvalidJson,
         );
       });
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -5,28 +5,28 @@ describe("getBiometricToken", () => {
   describe("Given there is an error making network request", () => {
     it("Returns an empty failure", async () => {
       /// Write test
-    })
-  })
+    });
+  });
 
   describe("Given the response is invalid", () => {
     describe("Given response is undefined", () => {
       it("Returns an empty failure", async () => {
         /// Write test
-      })
-    })
+      });
+    });
 
     describe("Given response body is undefined", () => {
       it("Returns an empty failure", async () => {
         /// Write test
-      })
-    })
+      });
+    });
 
     describe("Given response body cannot be parsed", () => {
       it("Returns an empty failure", async () => {
         /// Write test
-      })
-    })
-  })
+      });
+    });
+  });
 
   describe("Given valid request is made", () => {
     it("Returns successResult containing biometric token", async () => {
@@ -34,5 +34,5 @@ describe("getBiometricToken", () => {
 
       expect(result).toEqual(successResult("mockBiometricToken"));
     });
-  })
+  });
 });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -23,7 +23,18 @@ describe("getBiometricToken", () => {
 
     describe("Given response body is undefined", () => {
       it("Returns an empty failure", async () => {
-        /// Write test
+        global.fetch = jest.fn(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({ "Content-Type": "text/plain" }),
+            text: () => Promise.resolve(null),
+          } as unknown as Response),
+        ) as jest.Mock;
+
+        const result = await getBiometricToken("mockUrl", "mockSubmitterKey");
+
+        expect(result).toEqual(emptyFailure());
       });
     });
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -22,7 +22,7 @@ export const getBiometricToken: GetBiometricToken = async (
   const httpRequest = {
     url: readIdUrl,
     method: "POST" as HttpMethod,
-    headers: headers,
+    headers,
   };
 
   let response;

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -33,8 +33,6 @@ export const getBiometricToken: GetBiometricToken = async (
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
       {
         data: {
-          readIdUrl,
-          headers,
           httpRequest,
         },
       },

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,28 +1,33 @@
 import { logger } from "../../common/logging/logger";
 import { LogMessage } from "../../common/logging/LogMessage";
-import { sendHttpRequest } from "../../services/http/sendHttpRequest";
+import {
+  sendHttpRequest,
+  SuccessfulHttpResponse,
+} from "../../services/http/sendHttpRequest";
 import { emptyFailure, Result, successResult } from "../../utils/result";
 
 export type GetBiometricToken = (
   url: string,
   submitterKey: string,
+  sendHttpRequestOverride?: () => Promise<SuccessfulHttpResponse>,
 ) => Promise<Result<string, void>>;
 
 export const getBiometricToken: GetBiometricToken = async (
   url: string,
   submitterKey: string,
+  sendHttpRequestOverride?: () => Promise<SuccessfulHttpResponse>,
 ) => {
   const readIdUrl = `${url}/oauth/token?grant_type=client_credentials`;
   const headers = {
     "X-Innovalor-Authorization": submitterKey,
     "Content-Type": "application/x-www-form-urlencoded",
   };
-
   const httpRequest = {
     url: readIdUrl,
     method: "POST" as const,
     headers,
   };
+  const makeHttpRequest = sendHttpRequestOverride ?? sendHttpRequest;
 
   let response;
   try {
@@ -34,7 +39,7 @@ export const getBiometricToken: GetBiometricToken = async (
         },
       },
     );
-    response = await sendHttpRequest(httpRequest);
+    response = await makeHttpRequest(httpRequest);
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,9 +1,6 @@
 import { logger } from "../../common/logging/logger";
 import { LogMessage } from "../../common/logging/LogMessage";
-import {
-  HttpMethod,
-  sendHttpRequest,
-} from "../../services/http/sendHttpRequest";
+import { sendHttpRequest } from "../../services/http/sendHttpRequest";
 import { emptyFailure, Result, successResult } from "../../utils/result";
 
 export type GetBiometricToken = (
@@ -23,7 +20,7 @@ export const getBiometricToken: GetBiometricToken = async (
 
   const httpRequest = {
     url: readIdUrl,
-    method: "POST" as HttpMethod,
+    method: "POST" as const,
     headers,
   };
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -27,7 +27,7 @@ export const getBiometricToken: GetBiometricToken = async (
     method: "POST" as const,
     headers,
   };
-  const requestBiometricToken = sendHttpRequestAdapter;
+
   let response;
   try {
     logger.debug(
@@ -40,7 +40,7 @@ export const getBiometricToken: GetBiometricToken = async (
         },
       },
     );
-    response = await requestBiometricToken(httpRequest);
+    response = await sendHttpRequestAdapter(httpRequest);
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -17,15 +17,13 @@ export const getBiometricToken: GetBiometricToken = async (
   submitterKey: string,
   sendHttpRequestAdapter: ISendHttpRequest = sendHttpRequest,
 ) => {
-  const readIdUrl = `${url}/oauth/token?grant_type=client_credentials`;
-  const headers = {
-    "X-Innovalor-Authorization": submitterKey,
-    "Content-Type": "application/x-www-form-urlencoded",
-  };
   const httpRequest = {
-    url: readIdUrl,
+    url: `${url}/oauth/token?grant_type=client_credentials`,
     method: "POST" as const,
-    headers,
+    headers: {
+      "X-Innovalor-Authorization": submitterKey,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
   };
   const httpRequestLogData = {
     ...httpRequest,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -27,7 +27,7 @@ export const getBiometricToken: GetBiometricToken = async (
     method: "POST" as const,
     headers,
   };
-  const makeHttpRequest = sendHttpRequestOverride ?? sendHttpRequest;
+  const requestBiometricToken = sendHttpRequestOverride ?? sendHttpRequest;
 
   let response;
   try {
@@ -41,7 +41,7 @@ export const getBiometricToken: GetBiometricToken = async (
         },
       },
     );
-    response = await makeHttpRequest(httpRequest);
+    response = await requestBiometricToken(httpRequest);
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -40,20 +40,39 @@ export const getBiometricToken: GetBiometricToken = async (
       },
     );
     response = await sendHttpRequest(httpRequest);
-  } catch {
+  } catch (error) {
+    logger.error(
+      LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
+      error as Error,
+    );
     return emptyFailure();
   }
 
   if (response == null || response.body == null) {
+    logger.error(
+      LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
+      {
+        data: {
+          response,
+        },
+      },
+    );
     return emptyFailure();
   }
 
   let parsedBody;
   try {
     parsedBody = JSON.parse(response.body);
-  } catch {
+  } catch (error) {
+    logger.error(
+      LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
+      error as Error,
+    );
     return emptyFailure();
   }
 
+  logger.debug(
+    LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS,
+  );
   return successResult(parsedBody.access_token);
 };

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -28,11 +28,10 @@ export const getBiometricToken: GetBiometricToken = async (
     headers,
   };
   const httpRequestLogData = {
-    url: httpRequest.url,
-    method: httpRequest.method,
-    //Omitting submitterKey in headers as it is a secret and should not be logged
+    ...httpRequest,
     headers: {
-      "Content-Type": httpRequest.headers["Content-Type"],
+      ...httpRequest.headers,
+      "X-Innovalor-Authorization": "Secret value and cannot be logged",
     },
   };
 

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -46,7 +46,7 @@ export const getBiometricToken: GetBiometricToken = async (
     return emptyFailure();
   }
 
-  if (response == null || response.body == null) {
+  if (response?.body == null) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
       {

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -31,8 +31,12 @@ export const getBiometricToken: GetBiometricToken = async (
     url: httpRequest.url,
     method: httpRequest.method,
     //Omitting submitterKey in headers as it is a secret and should not be logged
-    headers: httpRequest.headers["Content-Type"],
+    headers: {
+      "Content-Type": httpRequest.headers["Content-Type"],
+    },
   };
+
+  console.log(httpRequestLogData);
 
   let response;
   try {

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -28,15 +28,18 @@ export const getBiometricToken: GetBiometricToken = async (
     headers,
   };
 
+  const httpRequestLogData = {
+    url: httpRequest.url,
+    method: httpRequest.method,
+  };
+
   let response;
   try {
     logger.debug(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
       {
         data: {
-          // Omitting submitterKey here as it is a secret and should not be logged
-          url: readIdUrl,
-          headers,
+          httpRequestLogData,
         },
       },
     );
@@ -44,7 +47,12 @@ export const getBiometricToken: GetBiometricToken = async (
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
-      error as Error,
+      {
+        data: {
+          error,
+          httpRequestLogData,
+        },
+      },
     );
     return emptyFailure();
   }
@@ -55,6 +63,7 @@ export const getBiometricToken: GetBiometricToken = async (
       {
         data: {
           response,
+          httpRequestLogData,
         },
       },
     );
@@ -67,7 +76,12 @@ export const getBiometricToken: GetBiometricToken = async (
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
-      error as Error,
+      {
+        data: {
+          error,
+          httpRequestLogData,
+        },
+      },
     );
     return emptyFailure();
   }

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,3 +1,5 @@
+import { logger } from "../../common/logging/logger";
+import { LogMessage } from "../../common/logging/LogMessage";
 import {
   HttpMethod,
   sendHttpRequest,
@@ -27,6 +29,16 @@ export const getBiometricToken: GetBiometricToken = async (
 
   let response;
   try {
+    logger.debug(
+      LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
+      {
+        data: {
+          readIdUrl,
+          headers,
+          httpRequest,
+        },
+      },
+    );
     response = await sendHttpRequest(httpRequest);
   } catch {
     return emptyFailure();

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -9,13 +9,13 @@ import { emptyFailure, Result, successResult } from "../../utils/result";
 export type GetBiometricToken = (
   url: string,
   submitterKey: string,
-  sendHttpRequestOverride?: ISendHttpRequest,
+  sendHttpRequestAdapter?: ISendHttpRequest,
 ) => Promise<Result<string, void>>;
 
 export const getBiometricToken: GetBiometricToken = async (
   url: string,
   submitterKey: string,
-  sendHttpRequestOverride?: ISendHttpRequest,
+  sendHttpRequestAdapter: ISendHttpRequest = sendHttpRequest,
 ) => {
   const readIdUrl = `${url}/oauth/token?grant_type=client_credentials`;
   const headers = {
@@ -27,8 +27,7 @@ export const getBiometricToken: GetBiometricToken = async (
     method: "POST" as const,
     headers,
   };
-  const requestBiometricToken = sendHttpRequestOverride ?? sendHttpRequest;
-
+  const requestBiometricToken = sendHttpRequestAdapter;
   let response;
   try {
     logger.debug(

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -27,10 +27,13 @@ export const getBiometricToken: GetBiometricToken = async (
     method: "POST" as const,
     headers,
   };
-
   const httpRequestLogData = {
     url: httpRequest.url,
     method: httpRequest.method,
+    headers: {
+      // Omitting submitterKey as it is a secret and should not be logged
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
   };
 
   let response;

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,10 +1,47 @@
-import { Result, successResult } from "../../utils/result";
+import {
+  HttpMethod,
+  sendHttpRequest,
+} from "../../services/http/sendHttpRequest";
+import { emptyFailure, Result, successResult } from "../../utils/result";
 
 export type GetBiometricToken = (
   url: string,
   submitterKey: string,
 ) => Promise<Result<string, void>>;
 
-export const getBiometricToken: GetBiometricToken = async () => {
-  return successResult("mockBiometricToken");
+export const getBiometricToken: GetBiometricToken = async (
+  url: string,
+  submitterKey: string,
+) => {
+  const readIdUrl = `${url}/oauth/token?grant_type=client_credentials`;
+  const headers = {
+    "X-Innovalor-Authorization": submitterKey,
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+
+  const httpRequest = {
+    url: readIdUrl,
+    method: "POST" as HttpMethod,
+    headers: headers,
+  };
+
+  let response;
+  try {
+    response = await sendHttpRequest(httpRequest);
+  } catch {
+    return emptyFailure();
+  }
+
+  if (response == null || response.body == null) {
+    return emptyFailure();
+  }
+
+  let parsedBody;
+  try {
+    parsedBody = JSON.parse(response.body);
+  } catch {
+    return emptyFailure();
+  }
+
+  return successResult(parsedBody.access_token);
 };

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -30,10 +30,8 @@ export const getBiometricToken: GetBiometricToken = async (
   const httpRequestLogData = {
     url: httpRequest.url,
     method: httpRequest.method,
-    headers: {
-      // Omitting submitterKey as it is a secret and should not be logged
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+    //Omitting submitterKey in headers as it is a secret and should not be logged
+    headers: httpRequest.headers["Content-Type"],
   };
 
   let response;

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -36,8 +36,6 @@ export const getBiometricToken: GetBiometricToken = async (
     },
   };
 
-  console.log(httpRequestLogData);
-
   let response;
   try {
     logger.debug(

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -35,7 +35,9 @@ export const getBiometricToken: GetBiometricToken = async (
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
       {
         data: {
-          httpRequest,
+          // Omitting submitterKey here as it is a secret and should not be logged
+          url: readIdUrl,
+          headers,
         },
       },
     );

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -2,20 +2,20 @@ import { logger } from "../../common/logging/logger";
 import { LogMessage } from "../../common/logging/LogMessage";
 import {
   ISendHttpRequest,
-  sendHttpRequest,
+  sendHttpRequest as sendHttpRequestDefault,
 } from "../../services/http/sendHttpRequest";
 import { emptyFailure, Result, successResult } from "../../utils/result";
 
 export type GetBiometricToken = (
   url: string,
   submitterKey: string,
-  sendHttpRequestAdapter?: ISendHttpRequest,
+  sendHttpRequest?: ISendHttpRequest,
 ) => Promise<Result<string, void>>;
 
 export const getBiometricToken: GetBiometricToken = async (
   url: string,
   submitterKey: string,
-  sendHttpRequestAdapter: ISendHttpRequest = sendHttpRequest,
+  sendHttpRequest: ISendHttpRequest = sendHttpRequestDefault,
 ) => {
   const httpRequest = {
     url: `${url}/oauth/token?grant_type=client_credentials`,
@@ -43,7 +43,7 @@ export const getBiometricToken: GetBiometricToken = async (
         },
       },
     );
-    response = await sendHttpRequestAdapter(httpRequest);
+    response = await sendHttpRequest(httpRequest);
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -39,7 +39,7 @@ export const getBiometricToken: GetBiometricToken = async (
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
       {
         data: {
-          httpRequestLogData,
+          httpRequest: httpRequestLogData,
         },
       },
     );
@@ -50,7 +50,7 @@ export const getBiometricToken: GetBiometricToken = async (
       {
         data: {
           error,
-          httpRequestLogData,
+          httpRequest: httpRequestLogData,
         },
       },
     );
@@ -63,7 +63,7 @@ export const getBiometricToken: GetBiometricToken = async (
       {
         data: {
           response,
-          httpRequestLogData,
+          httpRequest: httpRequestLogData,
         },
       },
     );
@@ -79,7 +79,7 @@ export const getBiometricToken: GetBiometricToken = async (
       {
         data: {
           error,
-          httpRequestLogData,
+          httpRequest: httpRequestLogData,
         },
       },
     );

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,21 +1,21 @@
 import { logger } from "../../common/logging/logger";
 import { LogMessage } from "../../common/logging/LogMessage";
 import {
+  ISendHttpRequest,
   sendHttpRequest,
-  SuccessfulHttpResponse,
 } from "../../services/http/sendHttpRequest";
 import { emptyFailure, Result, successResult } from "../../utils/result";
 
 export type GetBiometricToken = (
   url: string,
   submitterKey: string,
-  sendHttpRequestOverride?: () => Promise<SuccessfulHttpResponse>,
+  sendHttpRequestOverride?: ISendHttpRequest,
 ) => Promise<Result<string, void>>;
 
 export const getBiometricToken: GetBiometricToken = async (
   url: string,
   submitterKey: string,
-  sendHttpRequestOverride?: () => Promise<SuccessfulHttpResponse>,
+  sendHttpRequestOverride?: ISendHttpRequest,
 ) => {
   const readIdUrl = `${url}/oauth/token?grant_type=client_credentials`;
   const headers = {

--- a/backend-api/src/functions/common/logging/LogMessage.ts
+++ b/backend-api/src/functions/common/logging/LogMessage.ts
@@ -34,6 +34,11 @@ export class LogMessage implements LogAttributes {
     "MOBILE_ASYNC_BIOMETRIC_TOKEN_REQUEST_BODY_INVALID",
     "The incoming request body was missing or invalid.",
   );
+  static readonly BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT =
+    new LogMessage(
+      "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT",
+      "Attempting to retrieve biometric access token from ReadID",
+    );
 
   private constructor(
     public readonly messageCode: string,

--- a/backend-api/src/functions/common/logging/LogMessage.ts
+++ b/backend-api/src/functions/common/logging/LogMessage.ts
@@ -39,6 +39,16 @@ export class LogMessage implements LogAttributes {
       "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT",
       "Attempting to retrieve biometric access token from ReadID",
     );
+  static readonly BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE =
+    new LogMessage(
+      "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE",
+      "Failed to retrieve biometric access token from ReadID",
+    );
+  static readonly BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS =
+    new LogMessage(
+      "MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS",
+      "Successfully retrieved biometric access token from ReadID",
+    );
 
   private constructor(
     public readonly messageCode: string,

--- a/backend-api/src/functions/services/http/sendHttpRequest.ts
+++ b/backend-api/src/functions/services/http/sendHttpRequest.ts
@@ -63,9 +63,7 @@ export type RetryConfig = {
   delayInMillis?: number;
 };
 
-export type HttpMethod =
-  | "GET"
-  | "POST"
+export type HttpMethod = "GET" | "POST";
 
 export type HttpHeaders = {
   [key: string]: string;

--- a/backend-api/src/functions/services/http/sendHttpRequest.ts
+++ b/backend-api/src/functions/services/http/sendHttpRequest.ts
@@ -63,7 +63,9 @@ export type RetryConfig = {
   delayInMillis?: number;
 };
 
-export type HttpMethod = "GET";
+export type HttpMethod =
+  | "GET"
+  | "POST"
 
 export type HttpHeaders = {
   [key: string]: string;

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -160,7 +160,7 @@ Mappings:
   EnvironmentVariables:
     dev:
       STSBASEURL: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk'
-      ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.dev.account.gov.uk'
+      ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -169,7 +169,7 @@ Mappings:
 
     build:
       STSBASEURL: 'https://mob-sts-mock.review-b-async.build.account.gov.uk'
-      ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.build.account.gov.uk'
+      ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.build.account.gov.uk/v2'
       ClientRegistrySecretPath: 'build/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'


### PR DESCRIPTION
## DCMAW-10829

### What changed
- Adds functionality to `getBiometricToken()` to send request to ReadID's `/token` endpoint with `submitterKey` to retrieve biometric access token
- Adds `POST` functionality in `sendHttpRequest()`
- Updates `template.yaml` to use v2 of ReadID mock
- Adds logs when making request to ReadID for biometric access token:
  - `MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT`
    - `level: "debug"` - will only appear in `dev`
  - `MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE`
    -  `level: "error"` - will appear in all environments
  - `MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS`
    - `level: "debug"` - will only appear in `dev`

### Why did it change
ReadID host a `/token` endpoint. This used for exchanging the submitter access key for a temporary access key that is scoped for use by the mobile apps. The submitter access keys have been retrieved 

### Next steps

This PR covers the logic required to get a biometric access token from ReadID however a follow-up PR will be raised to adapt `sendHttpRequest()` to allow for an exponential backoff retry policy, currently it is static

## Evidence

### Manual testing

First time integrating with our ReadID Mock in this account so made a real request to it and confirmed I received the expected response from the mock

### Automation testing

Deployed stack and ran `api` tests - all passing

### New log messages

`MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT`

<img width="1428" alt="Screenshot 2025-01-15 at 23 13 44" src="https://github.com/user-attachments/assets/20055290-2cfe-42d6-bc52-cc5ed6c8f974" />

`MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE`

<img width="1433" alt="Screenshot 2025-01-16 at 00 04 55" src="https://github.com/user-attachments/assets/83eb02d5-528a-427a-a4ff-a01889783c88" />

`MOBILE_ASYNC_BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_SUCCESS`

<img width="1419" alt="Screenshot 2025-01-15 at 23 14 16" src="https://github.com/user-attachments/assets/e96e44de-a5bd-4c4c-bbf9-0b919511d7c0" />

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
