### PR TITLE
DCMAW-11093: Update encryption algorithm for public encryption key 

### DIFF
--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -141,7 +141,7 @@ npm run generate-proxy-open-api
 
 #### JSON Web Keys
 
-The `/.well-known/jwks.json` endpoint serves the JSON Web Key Set object. It contains a JSON Web Key object containing information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
+The `/.well-known/jwks.json` endpoint serves the JSON Web Key Set object. This object contains information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
 
 The encryption key is created in AWS KMS. The infrastructure code lives in the `./template.yaml`.
 

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -138,3 +138,15 @@ This schema is generated in the backend-api-push-to-main.yaml worfklow. To gener
 ```bash
 npm run generate-proxy-open-api
 ```
+
+#### ./well-known/jwks.json 
+
+An asymmetric encryption keypair is created in KMS. The infrastructure code lives in the `./template.yaml`.
+
+The public key object is hosted in the `/.well-known/jwks.json` endpoint on the sessions-api. The encryption algorithm is `RSA-OAEP-256` This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header.
+
+The JSON Web Keys object is stored in AWS S3. The `/.well-known/jwks.json` endpoint retrieves the object from S3 via an AWS service integration.
+
+The JSON Web Keys object is created when the stack is deployed for the first time. A Cloudformation custom resource sends a notification to the jwksWebKeys lambda and triggers the lambda. The lambda builds the JSON Web Keys object and uploads it to S3.
+
+Note: for redeployments of the application, the jwksWebKeys lambda is only invoked when the resource in the template.yaml is updated. It is not invoked when the lambda handler code changes. Updating a parameter in the Cloudformation custom resource infrastructure triggers an invocation of the jwksWebKeys lambda. 

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -141,7 +141,7 @@ npm run generate-proxy-open-api
 
 #### JSON Web Keys
 
-The `./.well-known/jwks.json` endpoint hosts the JSON Web Keys. It contains a JSON Web Key object containing information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
+The `/.well-known/jwks.json` endpoint serves the JSON Web Key Set object. It contains a JSON Web Key object containing information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
 
 The encryption key is created in AWS KMS. The infrastructure code lives in the `./template.yaml`.
 

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -141,7 +141,7 @@ npm run generate-proxy-open-api
 
 #### JSON Web Keys
 
-The `/.well-known/jwks.json` endpoint serves the JSON Web Key Set object. This object contains information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
+The `/.well-known/jwks.json` endpoint serves the JSON Web Keys Set object. This object contains information about the ID Check encryption key. This is used by STS for encrypting the service token sent to the `GET /async/activeSession` endpoint in the Authorization header. The encryption algorithm is `RSA-OAEP-256`, see [STS technical design](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service) for the public key requirements.
 
 The encryption key is created in AWS KMS. The infrastructure code lives in the `./template.yaml`.
 

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -145,8 +145,8 @@ The `/.well-known/jwks.json` endpoint serves the JSON Web Key Set object. This o
 
 The encryption key is created in AWS KMS. The infrastructure code lives in the `./template.yaml`.
 
-The JSON Web Keys object is stored in AWS S3. The `/.well-known/jwks.json` endpoint retrieves the object from S3 via an AWS service integration. Note, this integration can occasionally return a 5XX error due to the distributed nature of AWS and consumers should be advised to retry in this scenario.
+The JSON Web Keys Set object is stored in AWS S3. The `/.well-known/jwks.json` endpoint retrieves the object from S3 via an AWS service integration. Note, this integration can occasionally return a 5XX error due to the distributed nature of AWS and consumers should be advised to retry in this scenario.
 
-The JSON Web Keys object is created when the stack is deployed for the first time. A Cloudformation custom resource sends a notification to the jwksHandler and this invokes the lambda. The lambda builds the JSON Web Keys object and uploads it to S3.
+The JSON Web Keys Set object is created when the stack is deployed for the first time. A Cloudformation custom resource sends a notification to the jwksHandler and this invokes the lambda. The lambda builds the JSON Web Keys Set object and uploads it to S3.
 
 Note: for redeployments of the application, the jwksWebKeys lambda is only invoked when the resource in the template.yaml is updated. By default the lambda is not updated when the lambda handler code is updated. To facilitate automatic updates of the lambda in this scenario, a parameter has been added to the Cloudformation template containing the lambda version arn. This version arn updates when the lambda handler code is changed, causing an invocation of the lambda.

--- a/backend-api/openApiSpecs/async-public-spec.yaml
+++ b/backend-api/openApiSpecs/async-public-spec.yaml
@@ -458,7 +458,7 @@ paths:
                           "n": "kOBby1nEUcKc-94zIa2qCyqDSE1-2bLWkVjeF3DWY_0v2j9wlLSaR6asONen_HP40wftLOSPYRcKYv6Cjz3LOY7aQYznX14EXSgJxrDwQ7AleX2VS_HB34LMZEa3xmSSH7pLtw_vmJgCNss0zDQLCz1sQwZxlqphF18FdTTUrXbJ9Qk3xIrEzvL2naO2r6WoLBQ9tSr2Sz9TTcJQptfh6hOAHm66oPA6F9uCmbTDEQeI-wLiMMArtcKrGiPAFluo8f0qNkzLRMFIqyadnZ9OZ5u0-H_urOkmLJ2nbAnyTcO-9QeDlomdEMz3yEaJeUoq-jnPpVEfIbd8-07fl7M27w",
                           "e": "AQAB",
                           "use": "enc",
-                          "alg": "RS256",
+                          "alg": "RSA-OAEP-256",
                           "kid": "da48d440-8e51-4383-9a3a-b91ce5adcf2a"
                         }
                       ]

--- a/backend-api/src/functions/jwks/jwksBuilder/jwksBuilder.ts
+++ b/backend-api/src/functions/jwks/jwksBuilder/jwksBuilder.ts
@@ -137,6 +137,6 @@ const ENCRYPTION_KEY_TO_JOSE_MAP: EncryptionKeyToJose = {
   ENCRYPT_DECRYPT: {
     USE: "enc",
     KEY_SPEC: "RSA_2048",
-    ALGORITHM: "RS256",
+    ALGORITHM: "RSA-OAEP-256",
   },
 };

--- a/backend-api/src/functions/jwks/jwksBuilder/tests/jwksBuilder.test.ts
+++ b/backend-api/src/functions/jwks/jwksBuilder/tests/jwksBuilder.test.ts
@@ -137,7 +137,7 @@ describe("JWKS Builder", () => {
             n: "kOBby1nEUcKc-94zIa2qCyqDSE1-2bLWkVjeF3DWY_0v2j9wlLSaR6asONen_HP40wftLOSPYRcKYv6Cjz3LOY7aQYznX14EXSgJxrDwQ7AleX2VS_HB34LMZEa3xmSSH7pLtw_vmJgCNss0zDQLCz1sQwZxlqphF18FdTTUrXbJ9Qk3xIrEzvL2naO2r6WoLBQ9tSr2Sz9TTcJQptfh6hOAHm66oPA6F9uCmbTDEQeI-wLiMMArtcKrGiPAFluo8f0qNkzLRMFIqyadnZ9OZ5u0-H_urOkmLJ2nbAnyTcO-9QeDlomdEMz3yEaJeUoq-jnPpVEfIbd8-07fl7M27w",
             e: "AQAB",
             use: "enc",
-            alg: "RS256",
+            alg: "RSA-OAEP-256",
             kid: "da48d440-8e51-4383-9a3a-b91ce5adcf2a",
           },
           format: "jwk",
@@ -154,7 +154,7 @@ describe("JWKS Builder", () => {
         expect(buildJwksResponse.value).toStrictEqual({
           keys: [
             {
-              alg: "RS256",
+              alg: "RSA-OAEP-256",
               e: "AQAB",
               kid: keyId,
               kty: "RSA",

--- a/backend-api/src/functions/jwks/jwksBuilder/tests/mocks.ts
+++ b/backend-api/src/functions/jwks/jwksBuilder/tests/mocks.ts
@@ -12,7 +12,7 @@ const mockEncryptionJwk: EncryptionJwk = {
   n: "kOBby1nEUcKc-94zIa2qCyqDSE1-2bLWkVjeF3DWY_0v2j9wlLSaR6asONen_HP40wftLOSPYRcKYv6Cjz3LOY7aQYznX14EXSgJxrDwQ7AleX2VS_HB34LMZEa3xmSSH7pLtw_vmJgCNss0zDQLCz1sQwZxlqphF18FdTTUrXbJ9Qk3xIrEzvL2naO2r6WoLBQ9tSr2Sz9TTcJQptfh6hOAHm66oPA6F9uCmbTDEQeI-wLiMMArtcKrGiPAFluo8f0qNkzLRMFIqyadnZ9OZ5u0-H_urOkmLJ2nbAnyTcO-9QeDlomdEMz3yEaJeUoq-jnPpVEfIbd8-07fl7M27w",
   e: "AQAB",
   use: "enc",
-  alg: "RS256",
+  alg: "RSA-OAEP-256",
   kid: "da48d440-8e51-4383-9a3a-b91ce5adcf2a",
 };
 

--- a/backend-api/src/functions/jwks/jwksUploader/tests/jwksUploader.test.ts
+++ b/backend-api/src/functions/jwks/jwksUploader/tests/jwksUploader.test.ts
@@ -10,7 +10,7 @@ describe("JWKS Uploader", () => {
   const jwks: Jwks = {
     keys: [
       {
-        alg: "RS256",
+        alg: "RSA-OAEP-256",
         e: "AQAB",
         kid: "0df22121-40cc-41d7-b25c-b4da1a06ac24",
         kty: "RSA",

--- a/backend-api/src/functions/types/jwks.ts
+++ b/backend-api/src/functions/types/jwks.ts
@@ -7,5 +7,5 @@ export interface EncryptionJwk extends JsonWebKey {
   use: EncryptionJwkUse;
 }
 
-export type EncryptionJwkAlgorithm = "RS256";
+export type EncryptionJwkAlgorithm = "RSA-OAEP-256";
 export type EncryptionJwkUse = "enc";

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -276,6 +276,7 @@ Globals:
       LogFormat: JSON
     Architectures:
       - arm64
+    AutoPublishAlias: live
     Environment:
       Variables:
         SIGNING_KEY_ID: !GetAtt KMSSigningKey.Arn
@@ -479,7 +480,6 @@ Resources:
         EntryPoints:
           - src/functions/asyncCredential/asyncCredentialHandler.ts
     Properties:
-      AutoPublishAlias: live
       FunctionName: !Sub ${AWS::StackName}-credential
       Runtime: nodejs20.x
       Handler: asyncCredentialHandler.lambdaHandler
@@ -949,7 +949,6 @@ Resources:
         EntryPoints:
           - src/functions/asyncActiveSession/asyncActiveSessionHandler.ts
     Properties:
-      AutoPublishAlias: live
       FunctionName: !Sub ${AWS::StackName}-active-session
       Runtime: nodejs20.x
       Handler: asyncActiveSessionHandler.lambdaHandler
@@ -1071,7 +1070,6 @@ Resources:
         EntryPoints:
           - src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
     Properties:
-      AutoPublishAlias: live
       FunctionName: !Sub ${AWS::StackName}-biometric-token
       Runtime: nodejs20.x
       Handler: asyncBiometricTokenHandler.lambdaHandler
@@ -1497,8 +1495,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt JsonWebKeysFunction.Arn
       ServiceTimeout: 30
-      # The below value is not used by the lambda - it is a workaround to make the custom resource trigger the lambda each time the lambda code is updated
-      LambdaVersion: !Ref JsonWebKeysFunction.Version
+      LambdaVersion: !Ref JsonWebKeysFunction.Version # The below value is not used by the lambda - it is a workaround to make the custom resource trigger the lambda each time the lambda code is updated
 
   JsonWebKeysBucketApiRole:
     Type: AWS::IAM::Role

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -159,7 +159,7 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSBASEURL: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk'
+      STSBASEURL: 'https://backend-api-jl.token.dev.account.gov.uk'
       ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
@@ -1497,7 +1497,8 @@ Resources:
     Properties:
       ServiceToken: !GetAtt JsonWebKeysFunction.Arn
       ServiceTimeout: 30
-      ForceInvocationTicket: DCMAW-11093 #Change this parameter to force an invocation of the JwksWebKeys handler. Updating the lambda code does not trigger an execution of this custom resource.
+      # The below value is not used by the lambda - it is a workaround to make the custom resource trigger the lambda each time the lambda code is updated
+      LambdaVersion: !Ref JsonWebKeysFunction.Version
 
   JsonWebKeysBucketApiRole:
     Type: AWS::IAM::Role

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -1497,6 +1497,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt JsonWebKeysFunction.Arn
       ServiceTimeout: 30
+      ForceInvocationTicket: DCMAW-11093 #Change this parameter to force an invocation of the JwksWebKeys handler. Updating the lambda code does not trigger an execution of this custom resource.
 
   JsonWebKeysBucketApiRole:
     Type: AWS::IAM::Role

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -159,7 +159,7 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSBASEURL: 'https://backend-api-jl.token.dev.account.gov.uk'
+      STSBASEURL: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk'
       ReadIdBaseUrl: 'https://api-mob-readid-mock.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -503,9 +503,9 @@ describe("Backend application infrastructure", () => {
       });
 
       test("Global autoPublishAlias is set to live", () => {
-        const globalMemorySize =
+        const autoPublishAlias =
           template.toJSON().Globals.Function.AutoPublishAlias;
-        expect(globalMemorySize).toStrictEqual("live");
+        expect(autoPublishAlias).toStrictEqual("live");
       });
     });
 

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -453,7 +453,6 @@ describe("Backend application infrastructure", () => {
           "DT_LOG_COLLECTION_AUTH_TOKEN",
           "DT_TENANT",
           "DT_OPEN_TELEMETRY_ENABLE_INTEGRATION",
-          "AutoPublishAlias",
         ];
         const envVars =
           template.toJSON().Globals.Function.Environment.Variables;
@@ -501,6 +500,12 @@ describe("Backend application infrastructure", () => {
       test("Global memory size is set to 512MB", () => {
         const globalMemorySize = template.toJSON().Globals.Function.MemorySize;
         expect(globalMemorySize).toStrictEqual(512);
+      });
+
+      test("Global autoPublishAlias is set to live", () => {
+        const globalMemorySize =
+          template.toJSON().Globals.Function.AutoPublishAlias;
+        expect(globalMemorySize).toStrictEqual("live");
       });
     });
 

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -453,6 +453,7 @@ describe("Backend application infrastructure", () => {
           "DT_LOG_COLLECTION_AUTH_TOKEN",
           "DT_TENANT",
           "DT_OPEN_TELEMETRY_ENABLE_INTEGRATION",
+          "AutoPublishAlias",
         ];
         const envVars =
           template.toJSON().Globals.Function.Environment.Variables;

--- a/sts-mock/src/token/tokenEncrypter/tests/tokenEncrypter.test.ts
+++ b/sts-mock/src/token/tokenEncrypter/tests/tokenEncrypter.test.ts
@@ -22,7 +22,7 @@ describe("Token Encrypter", () => {
                 n: "0wLh4PMAjSt17zLNFw9nnBdV901AWp0uuHQzGaz1-Wz1lAs-jN7nI90sQAyiv8MDlYWLrfUZKcQAAA0yjISp9UyTr8qgqsyAKiFBIcnoH7l4qV-U-VXe3rcMjr5BzrKdVK664YiF9coGaal-QDDd1VY0fvvom3DhGnh8MoezBQPKl6pynIaSiDHZUdSe8B9LdsjsKHt4SujGRR_QlERYISC0s4pCQu2gA9qsP-pFDfcklbLtskFtWa_utiPe48Y5xgrhj5r-hMz9Zi4R55mX6nymC9gypk7q6iiXGEQcMzxPMy0kgF4437PqA-0GmjJE24pGmVhnr33UL2i0tsfviw",
                 e: "AQAB",
                 use: "enc",
-                alg: "RS256",
+                alg: "RSA-OAEP-256",
                 kid: "456d2da6-9ca8-4e1d-b8c8-081109d73015",
               },
             ],


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-11093

### What changed
Change algorithm in the JSON web key object for the encryption key from `RS256` to `RSA-OAEP-256`.

### Why did it change
To align with both the spec: https://datatracker.ietf.org/doc/html/rfc7518#section-4.1 (`RSA256` is not a valid encryption algorithm) and the STS requirements: https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3844964353/Strategic+App+App+calls+a+protected+service#Service-Token-encryption

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
