### PR TITLE
DCMAW-10829: Enhances http request retry strategy with exponential backoff and full jitter     

### DIFF
--- a/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
@@ -110,7 +110,14 @@ export class PublicKeyGetter implements IPublicKeyGetter {
   }
 
   private getJwksFromResponseBody(responseBody: string): Result<IJwks, string> {
-    const jwks = JSON.parse(responseBody);
+    let jwks;
+    try {
+      jwks = JSON.parse(responseBody);
+    } catch {
+      return errorResult(
+        `Response body could not be parsed as JSON. Response body: ${responseBody}`,
+      );
+    }
 
     if (!this.isJwks(jwks)) {
       return errorResult("Response does not match the expected JWKS structure");

--- a/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
@@ -72,7 +72,7 @@ export class PublicKeyGetter implements IPublicKeyGetter {
   }
 
   private async getJwk(jwksEndpoint: string, kid: string): Promise<IJwk> {
-    const response = await this.sendHttpRequest(
+    const getJwtResult = await this.sendHttpRequest(
       {
         url: jwksEndpoint,
         method: "GET",
@@ -80,7 +80,13 @@ export class PublicKeyGetter implements IPublicKeyGetter {
       { maxAttempts: 3, delayInMillis: 100 },
     );
 
-    const { body } = response;
+    if (getJwtResult.isError) {
+      throw new Error(`${getJwtResult.value}`);
+    }
+
+    const getJwtResponse = getJwtResult.value;
+
+    const { body } = getJwtResponse;
     if (!body) {
       throw new Error("Empty response body");
     }

--- a/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
@@ -6,6 +6,7 @@ import {
   successResult,
 } from "../../utils/result";
 import {
+  HttpError,
   ISendHttpRequest,
   sendHttpRequest,
 } from "../../services/http/sendHttpRequest";
@@ -48,15 +49,14 @@ export class PublicKeyGetter implements IPublicKeyGetter {
   ): Promise<Result<Uint8Array | KeyLike>> {
     const jwksUri = stsBaseUrl + "/.well-known/jwks.json";
 
-    let jwk;
-    try {
-      jwk = await this.getJwk(jwksUri, kid);
-    } catch (error) {
+    const getJwkResult = await this.getJwk(jwksUri, kid);
+    if (getJwkResult.isError) {
       return errorResult({
-        errorMessage: `Error getting JWK - ${error}`,
+        errorMessage: `Error getting JWK - ${getJwkResult.value}`,
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     }
+    const jwk = getJwkResult.value;
 
     let publicKey;
     try {
@@ -71,7 +71,10 @@ export class PublicKeyGetter implements IPublicKeyGetter {
     return successResult(publicKey);
   }
 
-  private async getJwk(jwksEndpoint: string, kid: string): Promise<IJwk> {
+  private async getJwk(
+    jwksEndpoint: string,
+    kid: string,
+  ): Promise<Result<IJwk, GetJwkError>> {
     const getJwtResult = await this.sendHttpRequest(
       {
         url: jwksEndpoint,
@@ -81,35 +84,39 @@ export class PublicKeyGetter implements IPublicKeyGetter {
     );
 
     if (getJwtResult.isError) {
-      throw new Error(`${getJwtResult.value}`);
+      return errorResult(getJwtResult.value);
     }
 
     const getJwtResponse = getJwtResult.value;
 
     const { body } = getJwtResponse;
     if (!body) {
-      throw new Error("Empty response body");
+      return errorResult("Empty response body");
     }
 
-    const jwks = await this.getJwksFromResponseBody(body);
+    const getJwksResult = this.getJwksFromResponseBody(body);
+    if (getJwksResult.isError) {
+      return getJwksResult;
+    }
+    const jwks = getJwksResult.value;
 
     const jwk = jwks.keys.find((key: IJwk) => key.kid && key.kid === kid);
 
     if (!jwk) {
-      throw new Error("JWKS does not contain key matching provided key ID");
+      return errorResult("JWKS does not contain key matching provided key ID");
     }
 
-    return jwk;
+    return successResult(jwk);
   }
 
-  private async getJwksFromResponseBody(responseBody: string): Promise<IJwks> {
+  private getJwksFromResponseBody(responseBody: string): Result<IJwks, string> {
     const jwks = JSON.parse(responseBody);
 
     if (!this.isJwks(jwks)) {
-      throw new Error("Response does not match the expected JWKS structure");
+      return errorResult("Response does not match the expected JWKS structure");
     }
 
-    return jwks;
+    return successResult(jwks);
   }
 
   private readonly isJwks = (data: unknown): data is IJwks => {
@@ -122,3 +129,5 @@ export class PublicKeyGetter implements IPublicKeyGetter {
     );
   };
 }
+
+export type GetJwkError = string | HttpError;

--- a/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/publicKeyGetter.ts
@@ -120,7 +120,9 @@ export class PublicKeyGetter implements IPublicKeyGetter {
     }
 
     if (!this.isJwks(jwks)) {
-      return errorResult("Response does not match the expected JWKS structure");
+      return errorResult(
+        `Response body does not match the expected JWKS structure. Response body: ${responseBody}`,
+      );
     }
 
     return successResult(jwks);

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
@@ -1,6 +1,10 @@
 import { IJwks, IPublicKeyGetter, PublicKeyGetter } from "../publicKeyGetter";
 import { importJWK } from "jose";
-import { ErrorCategory } from "../../../utils/result";
+import {
+  ErrorCategory,
+  errorResult,
+  successResult,
+} from "../../../utils/result";
 
 describe("Public Key Getter", () => {
   let mockJwks: IJwks;
@@ -30,13 +34,15 @@ describe("Public Key Getter", () => {
         },
       ],
     };
-    mockSendHttpRequest = jest.fn().mockResolvedValue({
-      statusCode: 200,
-      body: JSON.stringify(mockJwks),
-      headers: {
-        "Cache-Control": "max-age=60",
-      },
-    });
+    mockSendHttpRequest = jest.fn().mockResolvedValue(
+      successResult({
+        statusCode: 200,
+        body: JSON.stringify(mockJwks),
+        headers: {
+          "Cache-Control": "max-age=60",
+        },
+      }),
+    );
     publicKeyGetter = new PublicKeyGetter({
       sendHttpRequest: mockSendHttpRequest,
     });
@@ -44,7 +50,9 @@ describe("Public Key Getter", () => {
 
   describe("Given a request error happens when tyring to get the JWKS", () => {
     it("Returns error result", async () => {
-      mockSendHttpRequest = jest.fn().mockRejectedValueOnce("Some HTTP error");
+      mockSendHttpRequest = jest
+        .fn()
+        .mockResolvedValueOnce(errorResult(new Error("Some HTTP error")));
       publicKeyGetter = new PublicKeyGetter({
         sendHttpRequest: mockSendHttpRequest,
       });
@@ -55,7 +63,7 @@ describe("Public Key Getter", () => {
 
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
-        errorMessage: "Error getting JWK - Some HTTP error",
+        errorMessage: "Error getting JWK - Error: Error: Some HTTP error",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });
@@ -63,12 +71,14 @@ describe("Public Key Getter", () => {
 
   describe("Given there is no response body", () => {
     it("Returns error result", async () => {
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        headers: {
-          "Cache-Control": "max-age=60",
-        },
-      });
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          headers: {
+            "Cache-Control": "max-age=60",
+          },
+        }),
+      );
       publicKeyGetter = new PublicKeyGetter({
         sendHttpRequest: mockSendHttpRequest,
       });
@@ -87,13 +97,15 @@ describe("Public Key Getter", () => {
 
   describe("Given the response does not contain valid JWKS", () => {
     it("Returns error result", async () => {
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: JSON.stringify("notJson"),
-        headers: {
-          "Cache-Control": "max-age=60",
-        },
-      });
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          body: JSON.stringify("notJson"),
+          headers: {
+            "Cache-Control": "max-age=60",
+          },
+        }),
+      );
       publicKeyGetter = new PublicKeyGetter({
         sendHttpRequest: mockSendHttpRequest,
       });
@@ -130,13 +142,15 @@ describe("Public Key Getter", () => {
   describe("Given converting JWK to a key object fails", () => {
     it("Returns error result", async () => {
       delete mockJwks.keys[0].crv;
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: JSON.stringify(mockJwks),
-        headers: {
-          "Cache-Control": "max-age=60",
-        },
-      });
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          body: JSON.stringify(mockJwks),
+          headers: {
+            "Cache-Control": "max-age=60",
+          },
+        }),
+      );
       publicKeyGetter = new PublicKeyGetter({
         sendHttpRequest: mockSendHttpRequest,
       });

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
@@ -63,7 +63,7 @@ describe("Public Key Getter", () => {
 
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
-        errorMessage: "Error getting JWK - Error: Error: Some HTTP error",
+        errorMessage: "Error getting JWK - Error: Some HTTP error",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });
@@ -89,7 +89,7 @@ describe("Public Key Getter", () => {
 
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
-        errorMessage: "Error getting JWK - Error: Empty response body",
+        errorMessage: "Error getting JWK - Empty response body",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });
@@ -117,7 +117,7 @@ describe("Public Key Getter", () => {
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
         errorMessage:
-          "Error getting JWK - Error: Response does not match the expected JWKS structure",
+          "Error getting JWK - Response does not match the expected JWKS structure",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });
@@ -133,7 +133,7 @@ describe("Public Key Getter", () => {
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
         errorMessage:
-          "Error getting JWK - Error: JWKS does not contain key matching provided key ID",
+          "Error getting JWK - JWKS does not contain key matching provided key ID",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
@@ -145,7 +145,7 @@ describe("Public Key Getter", () => {
       expect(result.isError).toBe(true);
       expect(result.value).toStrictEqual({
         errorMessage:
-          "Error getting JWK - Response does not match the expected JWKS structure",
+          "Error getting JWK - Response body does not match the expected JWKS structure. Response body: {}",
         errorCategory: ErrorCategory.SERVER_ERROR,
       });
     });

--- a/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
+++ b/backend-api/src/functions/asyncActiveSession/tokenService/tests/publicKeyGetter.test.ts
@@ -95,12 +95,40 @@ describe("Public Key Getter", () => {
     });
   });
 
+  describe("Given the response body cannot be parsed as JSON", () => {
+    it("Returns error result", async () => {
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          body: "notJson",
+          headers: {
+            "Cache-Control": "max-age=60",
+          },
+        }),
+      );
+      publicKeyGetter = new PublicKeyGetter({
+        sendHttpRequest: mockSendHttpRequest,
+      });
+      const result = await publicKeyGetter.getPublicKey(
+        "https://mockJwksEndpoint.com",
+        "mockKid",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.value).toStrictEqual({
+        errorMessage:
+          "Error getting JWK - Response body could not be parsed as JSON. Response body: notJson",
+        errorCategory: ErrorCategory.SERVER_ERROR,
+      });
+    });
+  });
+
   describe("Given the response does not contain valid JWKS", () => {
     it("Returns error result", async () => {
       mockSendHttpRequest = jest.fn().mockResolvedValue(
         successResult({
           statusCode: 200,
-          body: JSON.stringify("notJson"),
+          body: JSON.stringify({}),
           headers: {
             "Cache-Control": "max-age=60",
           },

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -23,7 +23,9 @@ describe("getBiometricToken", () => {
     url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
   };
   const expectedRetryConfig = {
-    retryableStatusCodes: [429, 500, 502, 503, 504],
+    retryableStatusCodes: [
+      429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+    ],
   };
 
   beforeEach(() => {

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -14,13 +14,16 @@ describe("getBiometricToken", () => {
   let consoleDebugSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;
   let mockSendHttpRequest: ISendHttpRequest;
-  const expectedArguments = {
+  const expectedHttpRequest = {
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       "X-Innovalor-Authorization": "mockSubmitterKey",
     },
     method: "POST",
     url: "https://mockUrl.com/oauth/token?grant_type=client_credentials",
+  };
+  const expectedRetryConfig = {
+    retryableStatusCodes: [429, 500, 502, 503, 504],
   };
 
   beforeEach(() => {
@@ -78,7 +81,10 @@ describe("getBiometricToken", () => {
 
     it("Returns an empty failure", () => {
       expect(result).toEqual(emptyFailure());
-      expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
+      expect(mockSendHttpRequest).toBeCalledWith(
+        expectedHttpRequest,
+        expectedRetryConfig,
+      );
     });
   });
 
@@ -111,7 +117,10 @@ describe("getBiometricToken", () => {
 
       it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
-        expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
+        expect(mockSendHttpRequest).toBeCalledWith(
+          expectedHttpRequest,
+          expectedRetryConfig,
+        );
       });
     });
 
@@ -143,7 +152,10 @@ describe("getBiometricToken", () => {
 
       it("Returns an empty failure", () => {
         expect(result).toEqual(emptyFailure());
-        expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
+        expect(mockSendHttpRequest).toBeCalledWith(
+          expectedHttpRequest,
+          expectedRetryConfig,
+        );
       });
     });
   });
@@ -180,7 +192,10 @@ describe("getBiometricToken", () => {
 
     it("Returns successResult containing biometric token", () => {
       expect(result).toEqual(successResult("mockBiometricToken"));
-      expect(mockSendHttpRequest).toBeCalledWith(expectedArguments);
+      expect(mockSendHttpRequest).toBeCalledWith(
+        expectedHttpRequest,
+        expectedRetryConfig,
+      );
     });
   });
 });

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -1,4 +1,9 @@
-import { emptyFailure, Result, successResult } from "../../utils/result";
+import {
+  emptyFailure,
+  errorResult,
+  Result,
+  successResult,
+} from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
 import { expect } from "@jest/globals";
 import "../../testUtils/matchers";
@@ -25,13 +30,15 @@ describe("getBiometricToken", () => {
 
   describe("On every call", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: "mockBody",
-        headers: {
-          mockHeaderKey: "mockHeaderValue",
-        },
-      });
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          body: "mockBody",
+          headers: {
+            mockHeaderKey: "mockHeaderValue",
+          },
+        }),
+      );
 
       result = await getBiometricToken(
         "https://mockUrl.com",
@@ -48,10 +55,13 @@ describe("getBiometricToken", () => {
     });
   });
 
-  describe("Given an error is caught when requesting token", () => {
+  describe("Given an errorResult is returned when requesting token", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest.fn().mockRejectedValue(new Error("mockError"));
-
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        errorResult({
+          description: `Unexpected network error - ${new Error("mockError")}`,
+        }),
+      );
       result = await getBiometricToken(
         "https://mockUrl.com",
         "mockSubmitterKey",
@@ -75,13 +85,15 @@ describe("getBiometricToken", () => {
   describe("Given the response is invalid", () => {
     describe("Given response body is undefined", () => {
       beforeEach(async () => {
-        mockSendHttpRequest = jest.fn().mockResolvedValue({
-          statusCode: 200,
-          body: undefined,
-          headers: {
-            mockHeaderKey: "mockHeaderValue",
-          },
-        });
+        mockSendHttpRequest = jest.fn().mockResolvedValue(
+          successResult({
+            statusCode: 200,
+            body: undefined,
+            headers: {
+              mockHeaderKey: "mockHeaderValue",
+            },
+          }),
+        );
 
         result = await getBiometricToken(
           "https://mockUrl.com",
@@ -105,13 +117,15 @@ describe("getBiometricToken", () => {
 
     describe("Given response body cannot be parsed", () => {
       beforeEach(async () => {
-        mockSendHttpRequest = jest.fn().mockResolvedValue({
-          statusCode: 200,
-          body: "Invalid JSON",
-          headers: {
-            mockHeaderKey: "mockHeaderValue",
-          },
-        });
+        mockSendHttpRequest = jest.fn().mockResolvedValue(
+          successResult({
+            statusCode: 200,
+            body: "Invalid JSON",
+            headers: {
+              mockHeaderKey: "mockHeaderValue",
+            },
+          }),
+        );
 
         result = await getBiometricToken(
           "https://mockUrl.com",
@@ -136,17 +150,19 @@ describe("getBiometricToken", () => {
 
   describe("Given valid request is made", () => {
     beforeEach(async () => {
-      mockSendHttpRequest = jest.fn().mockResolvedValue({
-        statusCode: 200,
-        body: JSON.stringify({
-          access_token: "mockBiometricToken",
-          expires_in: 3600,
-          token_type: "Bearer",
+      mockSendHttpRequest = jest.fn().mockResolvedValue(
+        successResult({
+          statusCode: 200,
+          body: JSON.stringify({
+            access_token: "mockBiometricToken",
+            expires_in: 3600,
+            token_type: "Bearer",
+          }),
+          headers: {
+            mockHeaderKey: "mockHeaderValue",
+          },
         }),
-        headers: {
-          mockHeaderKey: "mockHeaderValue",
-        },
-      });
+      );
 
       result = await getBiometricToken(
         "https://mockUrl.com",

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -34,6 +34,9 @@ export const getBiometricToken: GetBiometricToken = async (
       "X-Innovalor-Authorization": "Secret value and cannot be logged",
     },
   };
+  const retryConfig = {
+    retryableStatusCodes: [429, 500, 502, 503, 504],
+  };
 
   logger.debug(
     LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
@@ -44,7 +47,7 @@ export const getBiometricToken: GetBiometricToken = async (
     },
   );
   const getBiometricTokenResult: Result<SuccessfulHttpResponse, HttpError> =
-    await sendHttpRequest(httpRequest);
+    await sendHttpRequest(httpRequest, retryConfig);
   if (getBiometricTokenResult.isError) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -1,8 +1,10 @@
 import { logger } from "../../common/logging/logger";
 import { LogMessage } from "../../common/logging/LogMessage";
 import {
+  HttpError,
   ISendHttpRequest,
   sendHttpRequest as sendHttpRequestDefault,
+  SuccessfulHttpResponse,
 } from "../../services/http/sendHttpRequest";
 import { emptyFailure, Result, successResult } from "../../utils/result";
 
@@ -33,36 +35,38 @@ export const getBiometricToken: GetBiometricToken = async (
     },
   };
 
-  let response;
-  try {
-    logger.debug(
-      LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
-      {
-        data: {
-          httpRequest: httpRequestLogData,
-        },
+  logger.debug(
+    LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_ATTEMPT,
+    {
+      data: {
+        httpRequest: httpRequestLogData,
       },
-    );
-    response = await sendHttpRequest(httpRequest);
-  } catch (error) {
+    },
+  );
+  const getBiometricTokenResult: Result<SuccessfulHttpResponse, HttpError> =
+    await sendHttpRequest(httpRequest);
+  if (getBiometricTokenResult.isError) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
       {
         data: {
-          error,
+          error: getBiometricTokenResult.value,
           httpRequest: httpRequestLogData,
         },
       },
     );
+
     return emptyFailure();
   }
 
-  if (response?.body == null) {
+  const getBiometricTokenResponse = getBiometricTokenResult.value;
+
+  if (getBiometricTokenResponse?.body == null) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,
       {
         data: {
-          response,
+          getBiometricTokenResponse,
           httpRequest: httpRequestLogData,
         },
       },
@@ -72,7 +76,7 @@ export const getBiometricToken: GetBiometricToken = async (
 
   let parsedBody;
   try {
-    parsedBody = JSON.parse(response.body);
+    parsedBody = JSON.parse(getBiometricTokenResponse.body);
   } catch (error) {
     logger.error(
       LogMessage.BIOMETRIC_TOKEN_GET_BIOMETRIC_TOKEN_FROM_READID_FAILURE,

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.ts
@@ -35,7 +35,9 @@ export const getBiometricToken: GetBiometricToken = async (
     },
   };
   const retryConfig = {
-    retryableStatusCodes: [429, 500, 502, 503, 504],
+    retryableStatusCodes: [
+      429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+    ],
   };
 
   logger.debug(

--- a/backend-api/src/functions/services/http/sendHttpRequest.ts
+++ b/backend-api/src/functions/services/http/sendHttpRequest.ts
@@ -2,7 +2,9 @@ import { errorResult, Result, successResult } from "../../utils/result";
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_DELAY_IN_MILLIS = 100;
-const DEFAULT_RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+const DEFAULT_RETRYABLE_STATUS_CODES = [
+  408, 429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+];
 
 export const sendHttpRequest: ISendHttpRequest = async (
   httpRequest,

--- a/backend-api/src/functions/services/http/sendHttpRequest.ts
+++ b/backend-api/src/functions/services/http/sendHttpRequest.ts
@@ -2,7 +2,7 @@ import { errorResult, Result, successResult } from "../../utils/result";
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_DELAY_IN_MILLIS = 100;
-const DEFAULT_RETRYABLE_STATUS_CODES = [408, 500, 502, 503, 504];
+const DEFAULT_RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 export const sendHttpRequest: ISendHttpRequest = async (
   httpRequest,

--- a/backend-api/src/functions/services/http/sendHttpRequest.ts
+++ b/backend-api/src/functions/services/http/sendHttpRequest.ts
@@ -2,9 +2,7 @@ import { errorResult, Result, successResult } from "../../utils/result";
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_DELAY_IN_MILLIS = 100;
-const DEFAULT_RETRYABLE_STATUS_CODES = [
-  408, 429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
-];
+const DEFAULT_RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 export const sendHttpRequest: ISendHttpRequest = async (
   httpRequest,

--- a/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
+++ b/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
@@ -2,6 +2,11 @@ import { sendHttpRequest } from "../sendHttpRequest";
 
 describe("Send HTTP request", () => {
   const MOCK_JITTER_MULTIPLIER = 0.5;
+  const httpRequest = {
+    url: "https://mockEndpoint.com",
+    method: "GET",
+  } as const;
+  const retryConfig = { maxAttempts: 3, delayInMillis: 10 };
 
   let mockFetch: jest.SpyInstance;
   let mockSetTimeout: jest.SpyInstance;
@@ -38,15 +43,9 @@ describe("Send HTTP request", () => {
         .spyOn(global, "fetch")
         .mockImplementation(() => Promise.reject(new Error("mockError")));
 
-      await expect(
-        sendHttpRequest(
-          {
-            url: "https://mockEndpoint.com",
-            method: "GET",
-          },
-          { maxAttempts: 3, delayInMillis: 1 },
-        ),
-      ).rejects.toThrow("Unexpected network error - Error: mockError");
+      await expect(sendHttpRequest(httpRequest, retryConfig)).rejects.toThrow(
+        "Unexpected network error - Error: mockError",
+      );
     });
   });
 
@@ -60,15 +59,9 @@ describe("Send HTTP request", () => {
         } as Response),
       );
 
-      await expect(
-        sendHttpRequest(
-          {
-            url: "https://mockEndpoint.com",
-            method: "GET",
-          },
-          { maxAttempts: 3, delayInMillis: 1 },
-        ),
-      ).rejects.toThrow("Error making http request - mockErrorInformation");
+      await expect(sendHttpRequest(httpRequest, retryConfig)).rejects.toThrow(
+        "Error making http request - mockErrorInformation",
+      );
     });
   });
 
@@ -89,13 +82,8 @@ describe("Send HTTP request", () => {
                 Promise.resolve(JSON.stringify({ mock: "responseBody" })),
             } as Response),
           );
-        const response = await sendHttpRequest(
-          {
-            url: "https://mockEndpoint.com",
-            method: "GET",
-          },
-          { maxAttempts: 3, delayInMillis: 10 },
-        );
+
+        const response = await sendHttpRequest(httpRequest, retryConfig);
 
         expect(response).toEqual({
           body: '{"mock":"responseBody"}',
@@ -128,13 +116,8 @@ describe("Send HTTP request", () => {
                 Promise.resolve(JSON.stringify({ mock: "responseBody" })),
             } as Response),
           );
-        const response = await sendHttpRequest(
-          {
-            url: "https://mockEndpoint.com",
-            method: "GET",
-          },
-          { maxAttempts: 3, delayInMillis: 10 },
-        );
+
+        const response = await sendHttpRequest(httpRequest, retryConfig);
 
         expect(response).toEqual({
           body: '{"mock":"responseBody"}',
@@ -163,15 +146,9 @@ describe("Send HTTP request", () => {
           .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
           .mockImplementationOnce(() => Promise.reject(new Error("mockError")));
 
-        await expect(
-          sendHttpRequest(
-            {
-              url: "https://mockEndpoint.com",
-              method: "GET",
-            },
-            { maxAttempts: 3, delayInMillis: 10 },
-          ),
-        ).rejects.toThrow("Unexpected network error - Error: mockError");
+        await expect(sendHttpRequest(httpRequest, retryConfig)).rejects.toThrow(
+          "Unexpected network error - Error: mockError",
+        );
         expect(mockFetch).toHaveBeenCalledTimes(3);
         expect(mockSetTimeout).toHaveBeenNthCalledWith(
           1,

--- a/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
+++ b/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
@@ -55,11 +55,42 @@ describe("Send HTTP request", () => {
     });
   });
 
-  describe("Given the request fails with a 500 error", () => {
+  describe("Given the request fails with a non retryable statusCode", () => {
+    describe.each([[100], [199], [300], [400], [501]])(
+      "Given the status code is (%d)",
+      (statusCode: number) => {
+        beforeEach(async () => {
+          mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>
+            Promise.resolve({
+              status: statusCode,
+              text: () => Promise.resolve("mockError"),
+            } as Response),
+          );
+          response = await sendHttpRequest(httpRequest, retryConfig);
+        });
+
+        it("Does not retry the request", () => {
+          expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it("Returns a failure with status code and body", async () => {
+          expect(response).toEqual({
+            isError: true,
+            value: {
+              statusCode: statusCode,
+              description: "mockError",
+            },
+          });
+        });
+      },
+    );
+  });
+
+  describe("Given the request fails with a retryable statusCode", () => {
     beforeEach(async () => {
       mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>
         Promise.resolve({
-          status: 500,
+          status: 503,
           ok: false,
           text: () => Promise.resolve("mockErrorInformation"),
         } as Response),
@@ -68,225 +99,196 @@ describe("Send HTTP request", () => {
       response = await sendHttpRequest(httpRequest, retryConfig);
     });
 
+    it("Attempts to make 3 requests in total", () => {
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
     it("Returns error result with details from final response", async () => {
       expect(response).toEqual({
         isError: true,
         value: {
-          statusCode: 500,
+          statusCode: 503,
           description: "mockErrorInformation",
         },
       });
     });
   });
 
-  describe("Retry policy", () => {
-    describe("Given the status code is non-retryable and not 2xx", () => {
-      describe.each([[100], [199], [300], [400], [501]])(
-        "Given the status code is (%d)",
-        (statusCode: number) => {
-          beforeEach(async () => {
-            mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>
-              Promise.resolve({
-                status: statusCode,
-                text: () => Promise.resolve("mockError"),
-              } as Response),
-            );
-            response = await sendHttpRequest(httpRequest, retryConfig);
-          });
+  describe("Given there is an error on the first request attempt", () => {
+    beforeEach(async () => {
+      mockFetch = jest
+        .spyOn(global, "fetch")
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({
+              header: "mockHeader",
+            }),
+            text: () =>
+              Promise.resolve(JSON.stringify({ mock: "responseBody" })),
+          } as Response),
+        );
 
-          it("Does not retry the request", () => {
-            expect(mockFetch).toHaveBeenCalledTimes(1);
-          });
+      response = await sendHttpRequest(httpRequest, retryConfig);
+    });
 
-          it("Returns a failure with status code and body", async () => {
-            expect(response).toEqual({
-              isError: true,
-              value: {
-                statusCode: statusCode,
-                description: "mockError",
-              },
-            });
-          });
-        },
+    it("Attempts to send the request a second time", () => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("Delays successive attempts with exponential backoff", () => {
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Function),
+        10 * MOCK_JITTER_MULTIPLIER,
       );
     });
 
-    describe("Given there is an error on the first request attempt", () => {
-      beforeEach(async () => {
-        mockFetch = jest
-          .spyOn(global, "fetch")
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() =>
-            Promise.resolve({
-              status: 200,
-              ok: true,
-              headers: new Headers({
-                header: "mockHeader",
-              }),
-              text: () =>
-                Promise.resolve(JSON.stringify({ mock: "responseBody" })),
-            } as Response),
-          );
-
-        response = await sendHttpRequest(httpRequest, retryConfig);
+    it("Returns success result with details from final response", () => {
+      expect(response).toEqual({
+        isError: false,
+        value: {
+          body: '{"mock":"responseBody"}',
+          headers: { header: "mockHeader" },
+          statusCode: 200,
+        },
       });
+    });
+  });
 
-      it("Attempts to send the request a second time", () => {
-        expect(mockFetch).toHaveBeenCalledTimes(2);
-      });
-
-      it("Delays successive attempts with exponential backoff", () => {
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          1,
-          expect.any(Function),
-          10 * MOCK_JITTER_MULTIPLIER,
+  describe("Given there is an error on the second request attempt", () => {
+    beforeEach(async () => {
+      mockFetch = jest
+        .spyOn(global, "fetch")
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({
+              header: "mockHeader",
+            }),
+            text: () =>
+              Promise.resolve(JSON.stringify({ mock: "responseBody" })),
+          } as Response),
         );
-      });
 
-      it("Returns success result with details from final response", () => {
-        expect(response).toEqual({
-          isError: false,
-          value: {
-            body: '{"mock":"responseBody"}',
-            headers: { header: "mockHeader" },
-            statusCode: 200,
-          },
-        });
+      response = await sendHttpRequest(httpRequest, retryConfig);
+    });
+
+    it("Attempts to send the request a third time", () => {
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("Delays successive attempts with exponential backoff", () => {
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Function),
+        10 * MOCK_JITTER_MULTIPLIER,
+      );
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Function),
+        20 * MOCK_JITTER_MULTIPLIER,
+      );
+    });
+
+    it("Returns a success result with details from final response", () => {
+      expect(response).toEqual({
+        isError: false,
+        value: {
+          body: '{"mock":"responseBody"}',
+          headers: { header: "mockHeader" },
+          statusCode: 200,
+        },
+      });
+    });
+  });
+
+  describe("Given there is an error on the third request attempt", () => {
+    beforeEach(async () => {
+      mockFetch = jest
+        .spyOn(global, "fetch")
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")));
+
+      response = await sendHttpRequest(httpRequest, retryConfig);
+    });
+
+    it("Attempts to send the request a third time", () => {
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("Delays successive attempts with exponential backoff", () => {
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Function),
+        10 * MOCK_JITTER_MULTIPLIER,
+      );
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Function),
+        20 * MOCK_JITTER_MULTIPLIER,
+      );
+    });
+
+    it("Returns an error result with details from the final response", () => {
+      expect(response).toEqual({
+        isError: true,
+        value: {
+          description: "Unexpected network error - Error: mockError",
+        },
+      });
+    });
+  });
+
+  describe("Given a custom maxAttempts value is used - 4 maxAttempts", () => {
+    beforeEach(async () => {
+      mockFetch = jest
+        .spyOn(global, "fetch")
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
+        .mockImplementationOnce(() => Promise.reject(new Error("mockError")));
+
+      response = await sendHttpRequest(httpRequest, {
+        maxAttempts: 4,
+        delayInMillis: 10,
       });
     });
 
-    describe("Given there is an error on the second request attempt", () => {
-      beforeEach(async () => {
-        mockFetch = jest
-          .spyOn(global, "fetch")
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() =>
-            Promise.resolve({
-              status: 200,
-              ok: true,
-              headers: new Headers({
-                header: "mockHeader",
-              }),
-              text: () =>
-                Promise.resolve(JSON.stringify({ mock: "responseBody" })),
-            } as Response),
-          );
-
-        response = await sendHttpRequest(httpRequest, retryConfig);
-      });
-
-      it("Attempts to send the request a third time", () => {
-        expect(mockFetch).toHaveBeenCalledTimes(3);
-      });
-
-      it("Delays successive attempts with exponential backoff", () => {
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          1,
-          expect.any(Function),
-          10 * MOCK_JITTER_MULTIPLIER,
-        );
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          2,
-          expect.any(Function),
-          20 * MOCK_JITTER_MULTIPLIER,
-        );
-      });
-
-      it("Returns a success result with details from final response", () => {
-        expect(response).toEqual({
-          isError: false,
-          value: {
-            body: '{"mock":"responseBody"}',
-            headers: { header: "mockHeader" },
-            statusCode: 200,
-          },
-        });
-      });
+    it("Attempts to send the request a fourth time", () => {
+      expect(mockFetch).toHaveBeenCalledTimes(4);
     });
 
-    describe("Given there is an error on the third request attempt", () => {
-      beforeEach(async () => {
-        mockFetch = jest
-          .spyOn(global, "fetch")
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")));
-
-        response = await sendHttpRequest(httpRequest, retryConfig);
-      });
-
-      it("Attempts to send the request a third time", () => {
-        expect(mockFetch).toHaveBeenCalledTimes(3);
-      });
-
-      it("Delays successive attempts with exponential backoff", () => {
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          1,
-          expect.any(Function),
-          10 * MOCK_JITTER_MULTIPLIER,
-        );
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          2,
-          expect.any(Function),
-          20 * MOCK_JITTER_MULTIPLIER,
-        );
-      });
-
-      it("Returns an error result with details from the final response", () => {
-        expect(response).toEqual({
-          isError: true,
-          value: {
-            description: "Unexpected network error - Error: mockError",
-          },
-        });
-      });
+    it("Delays successive attempts with exponential backoff", () => {
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Function),
+        10 * MOCK_JITTER_MULTIPLIER,
+      );
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Function),
+        20 * MOCK_JITTER_MULTIPLIER,
+      );
+      expect(mockSetTimeout).toHaveBeenNthCalledWith(
+        3,
+        expect.any(Function),
+        40 * MOCK_JITTER_MULTIPLIER,
+      );
     });
 
-    describe("Given a custom maxAttempts value is used - 4 maxAttempts", () => {
-      beforeEach(async () => {
-        mockFetch = jest
-          .spyOn(global, "fetch")
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")))
-          .mockImplementationOnce(() => Promise.reject(new Error("mockError")));
-
-        response = await sendHttpRequest(httpRequest, {
-          maxAttempts: 4,
-          delayInMillis: 10,
-        });
-      });
-
-      it("Attempts to send the request a fourth time", () => {
-        expect(mockFetch).toHaveBeenCalledTimes(4);
-      });
-
-      it("Delays successive attempts with exponential backoff", () => {
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          1,
-          expect.any(Function),
-          10 * MOCK_JITTER_MULTIPLIER,
-        );
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          2,
-          expect.any(Function),
-          20 * MOCK_JITTER_MULTIPLIER,
-        );
-        expect(mockSetTimeout).toHaveBeenNthCalledWith(
-          3,
-          expect.any(Function),
-          40 * MOCK_JITTER_MULTIPLIER,
-        );
-      });
-
-      it("Returns an error result with details from the final response", () => {
-        expect(response).toEqual({
-          isError: true,
-          value: {
-            description: "Unexpected network error - Error: mockError",
-          },
-        });
+    it("Returns an error result with details from the final response", () => {
+      expect(response).toEqual({
+        isError: true,
+        value: {
+          description: "Unexpected network error - Error: mockError",
+        },
       });
     });
   });

--- a/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
+++ b/backend-api/src/functions/services/http/tests/sendHttpRequest.test.ts
@@ -13,17 +13,6 @@ describe("Send HTTP request", () => {
   let response: SuccessfulHttpResponse;
 
   beforeEach(() => {
-    mockFetch = jest.spyOn(global, "fetch").mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        ok: true,
-        headers: new Headers({
-          header: "mockHeader",
-        }),
-        text: () => Promise.resolve(JSON.stringify({ mock: "responseBody" })),
-      } as Response),
-    );
-
     jest.spyOn(Math, "random").mockImplementation(() => MOCK_JITTER_MULTIPLIER);
 
     mockSetTimeout = jest


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
## ​DCMAW-10829

### What changed
- sendHttpRequest:
  - Updates retry policy with exponential backoff and full jitter
  - Updates interface to use Result pattern after discussion feedback [here](https://github.com/govuk-one-login/mobile-id-check-async/pull/337#discussion_r1918082211)
- Updates functions that consume sendHttpRequest as interface has changed:
  - getBiometricToken
  - publicKeyGetter (I made 2 additional changes listed below here we can revert if we want as minimal change as possible here):
    - Updated func in publicKeyGetter to use the Result pattern instead of throwing errors some of the time [cb1e74c2c47ae5847b9ca6db848c01bebd040a33](https://github.com/govuk-one-login/mobile-id-check-async/pull/344/commits/cb1e74c2c47ae5847b9ca6db848c01bebd040a33)
    - Updated publicKeyGetter to handle parsing error explicitly [8b3852d001eccaae9b2175b4687a736ae41da8c3](https://github.com/govuk-one-login/mobile-id-check-async/pull/344/commits/8b3852d001eccaae9b2175b4687a736ae41da8c3)
    - Update error message when response body does not match the expected JWKS structure [f3e03f2f916fecf11db31fa26f3bb312f7c0ee2f](https://github.com/govuk-one-login/mobile-id-check-async/pull/344/commits/f3e03f2f916fecf11db31fa26f3bb312f7c0ee2f)

### Why did it change

#### Exponential backoff
Reduces load on target server giving it time to recover while gradually increasing the interval between retries

#### Full jitter

Prevents synchronised retries which can overwhelm the target server by altering the delay between retries by a random amount

### Sonar security hotspot

#### Status

Resolved - Akin has resolved the hotspot: https://gds.slack.com/archives/C060PANF03T/p1737366725133829

#### Summary

Sonar flagged that we are using a pseudorandom number generator and asks we check it's safe to use here. We are using it to calculate a jitter value.

[Link to hotspot](https://sonarcloud.io/project/security_hotspots?sinceLeakPeriod=true&status=SAFE&pullRequest=344&id=mobile-id-check-async)

## ​Evidence

Deployed stack and ran `api` tests - all passing

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
