### PR TITLE
[DCMAW-10831] /async/biometricToken returns 200 with biometric access token and opaque ID

### DIFF
--- a/backend-api/openApiSpecs/async-public-spec.yaml
+++ b/backend-api/openApiSpecs/async-public-spec.yaml
@@ -236,16 +236,22 @@ paths:
                 success:
                   value:
                     {
-                      "accessToken": "string"
+                      "accessToken": "string",
+                      "opaqueId": "6ec96ea7-941c-4967-9fcf-94fc9b717a22"
                     }
               schema:
                 type: object
-                description: access token depending on passport, DL or BRP selection to access the third-party biometric check endpoints
                 required:
                   - accessToken
+                  - opaqueId
                 properties:
                   accessToken:
                     type: string
+                    description: access token depending on passport, DL or BRP selection to access the third-party biometric check endpoints
+                  opaqueId:
+                    type: string
+                    format: uuid
+                    description: generated token to be sent to the vendor when starting a new biometric session to facilitate fraud detection
         '400':
           description: Bad request
           content:
@@ -301,7 +307,6 @@ paths:
         uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AsyncBiometricTokenFunction}:live/invocations"
         type: "aws_proxy"
-
   /async/finishBiometricSession:
     post:
       summary: App signifies to backend that user interaction for biometric session is complete

--- a/backend-api/src/functions/adapters/tests/dynamoDbAdapter.test.ts
+++ b/backend-api/src/functions/adapters/tests/dynamoDbAdapter.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@jest/globals";
 import "dotenv/config";
-import "../../testUtils/matchers";
+import "../../../../tests/testUtils/matchers";
 import { DynamoDbAdapter } from "../dynamoDbAdapter";
 import { BiometricTokenIssued } from "../../common/session/updateOperations/BiometricTokenIssued/BiometricTokenIssued";
 import {

--- a/backend-api/src/functions/adapters/tests/getSecretsFromParameterStore.test.ts
+++ b/backend-api/src/functions/adapters/tests/getSecretsFromParameterStore.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@jest/globals";
-import "../../testUtils/matchers";
+import "../../../../tests/testUtils/matchers";
 import "dotenv/config";
 import { mockClient } from "aws-sdk-client-mock";
 import "aws-sdk-client-mock-jest";

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
@@ -328,8 +328,8 @@ describe("Async Biometric Token", () => {
         headers: expectedSecurityHeaders,
         statusCode: 200,
         body: JSON.stringify({
-          access_token: "mockBiometricToken",
-          opaque_id: "mock_opaque_id",
+          accessToken: "mockBiometricToken",
+          opaqueId: "mock_opaque_id",
         }),
       });
     });

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@jest/globals";
-import "../testUtils/matchers";
+import "../../../tests/testUtils/matchers";
 import "dotenv/config";
 import { APIGatewayProxyResult, Context } from "aws-lambda";
 import { buildLambdaContext } from "../testUtils/mockContext";

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
@@ -323,11 +323,14 @@ describe("Async Biometric Token", () => {
       });
     });
 
-    it("Returns 501 Not Implemented response", async () => {
+    it("Returns 200 response with biometric access token and opaque ID", async () => {
       expect(result).toStrictEqual({
         headers: expectedSecurityHeaders,
-        statusCode: 501,
-        body: JSON.stringify({ error: "Not Implemented" }),
+        statusCode: 200,
+        body: JSON.stringify({
+          access_token: "mockBiometricToken",
+          opaque_id: "mock_opaque_id",
+        }),
       });
     });
   });

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
@@ -90,8 +90,8 @@ export async function lambdaHandlerConstructor(
 
   logger.info(LogMessage.BIOMETRIC_TOKEN_COMPLETED);
   return okResponse({
-    access_token: biometricTokenResult.value,
-    opaque_id: opaqueId,
+    accessToken: biometricTokenResult.value,
+    opaqueId,
   });
 }
 

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
@@ -9,7 +9,7 @@ import {
 } from "./handlerDependencies";
 import {
   badRequestResponse,
-  notImplementedResponse,
+  okResponse,
   serverErrorResponse,
   unauthorizedResponse,
 } from "../common/lambdaResponses";
@@ -89,7 +89,10 @@ export async function lambdaHandlerConstructor(
   }
 
   logger.info(LogMessage.BIOMETRIC_TOKEN_COMPLETED);
-  return notImplementedResponse;
+  return okResponse({
+    access_token: biometricTokenResult.value,
+    opaque_id: opaqueId,
+  });
 }
 
 export const lambdaHandler = lambdaHandlerConstructor.bind(

--- a/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/getBiometricToken/getBiometricToken.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../utils/result";
 import { getBiometricToken } from "./getBiometricToken";
 import { expect } from "@jest/globals";
-import "../../testUtils/matchers";
+import "../../../../tests/testUtils/matchers";
 import { ISendHttpRequest } from "../../services/http/sendHttpRequest";
 
 describe("getBiometricToken", () => {

--- a/backend-api/src/functions/common/lambdaResponses.ts
+++ b/backend-api/src/functions/common/lambdaResponses.ts
@@ -8,6 +8,14 @@ const securityHeaders = {
   "X-Frame-Options": "DENY",
 };
 
+export const okResponse = (body: object): APIGatewayProxyResult => {
+  return {
+    headers: securityHeaders,
+    statusCode: 200,
+    body: JSON.stringify(body),
+  };
+};
+
 export const badRequestResponse = (
   error: string,
   errorDescription: string,

--- a/backend-api/tests/api-tests/biometricToken.test.ts
+++ b/backend-api/tests/api-tests/biometricToken.test.ts
@@ -28,7 +28,7 @@ describe("POST /async/biometricToken", () => {
   });
 
   describe("Given there is a valid request", () => {
-    it("Returns an error and 501 status code", async () => {
+    it("Returns a 200 response with biometric access token and opaque ID", async () => {
       const sessionId = await getValidSessionId();
       if (!sessionId)
         throw new Error(
@@ -45,8 +45,11 @@ describe("POST /async/biometricToken", () => {
         requestBody,
       );
 
-      expect(response.status).toBe(501);
-      expect(response.data).toStrictEqual({ error: "Not Implemented" });
+      expect(response.status).toBe(200);
+      expect(response.data).toStrictEqual({
+        access_token: expect.any(String),
+        opaque_id: expect.any(String),
+      });
       expect(response.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),
       );

--- a/backend-api/tests/api-tests/biometricToken.test.ts
+++ b/backend-api/tests/api-tests/biometricToken.test.ts
@@ -47,8 +47,8 @@ describe("POST /async/biometricToken", () => {
 
       expect(response.status).toBe(200);
       expect(response.data).toStrictEqual({
-        access_token: expect.any(String),
-        opaque_id: expect.any(String),
+        accessToken: expect.any(String),
+        opaqueId: expect.any(String),
       });
       expect(response.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),

--- a/backend-api/tests/api-tests/biometricToken.test.ts
+++ b/backend-api/tests/api-tests/biometricToken.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "@jest/globals";
+import "../../tests/testUtils/matchers";
 import { SESSIONS_API_INSTANCE } from "./utils/apiInstance";
 import { expectedSecurityHeaders, mockSessionId } from "./utils/apiTestData";
 import { getValidSessionId } from "./utils/apiTestHelpers";
@@ -48,7 +50,7 @@ describe("POST /async/biometricToken", () => {
       expect(response.status).toBe(200);
       expect(response.data).toStrictEqual({
         accessToken: expect.any(String),
-        opaqueId: expect.any(String),
+        opaqueId: expect.toBeValidUuid(),
       });
       expect(response.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),

--- a/backend-api/tests/testUtils/matchers.ts
+++ b/backend-api/tests/testUtils/matchers.ts
@@ -1,9 +1,9 @@
 import { expect } from "@jest/globals";
 
-const toHaveBeenCalledWithLogFields = function toHaveBeenCalledWithLogFields(
+const toHaveBeenCalledWithLogFields = (
   consoleSpy: jest.SpyInstance,
   logFields: Record<string, unknown>,
-) {
+) => {
   const messages = consoleSpy.mock.calls.map((args) => args[0]);
   const pass = messages.some((message) => {
     const messageAsObject = JSON.parse(message);
@@ -36,7 +36,7 @@ function deepEquals(subject: unknown, target: unknown): boolean {
   return JSON.stringify(subject) === JSON.stringify(target);
 }
 
-const toBeValidUuid = function toBeValidUuid(candidate: unknown) {
+const toBeValidUuid = (candidate: unknown) => {
   const pass = isValidUuid(candidate);
   return {
     pass,

--- a/backend-api/tests/testUtils/matchers.ts
+++ b/backend-api/tests/testUtils/matchers.ts
@@ -36,12 +36,34 @@ function deepEquals(subject: unknown, target: unknown): boolean {
   return JSON.stringify(subject) === JSON.stringify(target);
 }
 
+const toBeValidUuid = function toBeValidUuid(candidate: unknown) {
+  const pass = isValidUuid(candidate);
+  return {
+    pass,
+    message: pass
+      ? () => `expected ${candidate} not to be a valid UUID`
+      : () => `expected ${candidate} to be a valid UUID`,
+  };
+};
+
+const isValidUuid = (candidate: unknown): boolean => {
+  if (typeof candidate !== "string") return false;
+  const regexUUID =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return regexUUID.test(candidate);
+};
+
 expect.extend({
   toHaveBeenCalledWithLogFields,
+  toBeValidUuid,
 });
 
 declare module "expect" {
+  interface AsymmetricMatchers {
+    toBeValidUuid(): void;
+  }
   interface Matchers<R> {
     toHaveBeenCalledWithLogFields(logFields: object): R;
+    toBeValidUuid(): R;
   }
 }


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-10831

### What changed
* Updates biometric token handler to return 200 response with biometric access token from vendor, and generated opaque ID
* Updates associated tests
* Updates OpenAPI spec to reflect latest response fields

### Why did it change
* The mobile app will use the access token and opaque ID to start a biometric session with the vendor.

## Evidence

![image](https://github.com/user-attachments/assets/be212af1-6f11-496f-aedf-a7cc601b63ae)

