### PR TITLE
[DCMAW-11018] update domain name formats

### DIFF
--- a/backend-api/infra/api/proxy.yaml
+++ b/backend-api/infra/api/proxy.yaml
@@ -45,9 +45,17 @@ Resources:
   ProxyApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns
@@ -55,9 +63,9 @@ Resources:
         Types:
           - REGIONAL
       RegionalCertificateArn: !If
-        - UseWildcardCertificate
+        - DevelopmentStack
         - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV2ARN}}'
         
       SecurityPolicy: TLS_1_2
     Condition: ProxyApiDeployment
@@ -67,9 +75,20 @@ Resources:
     DependsOn: ProxyApiDomainName
     Condition: ProxyApiDeployment
     Properties:
-      DomainName: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap [DNS, !Ref Environment, BaseDns]
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
       RestApiId: !Ref ProxyApi
       Stage: !Ref ProxyApi.Stage
 
@@ -77,9 +96,20 @@ Resources:
     Type: AWS::Route53::RecordSet
     Condition: ProxyApiDeployment
     Properties:
-      Name: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap [DNS, !Ref Environment, BaseDns]
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
       Type: A
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
       AliasTarget:

--- a/backend-api/infra/api/sessions.yaml
+++ b/backend-api/infra/api/sessions.yaml
@@ -42,9 +42,17 @@ Resources:
   SessionsApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns
@@ -52,18 +60,26 @@ Resources:
         Types:
           - REGIONAL
       RegionalCertificateArn: !If
-        - UseWildcardCertificate
+        - DevelopmentStack
         - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV2ARN}}'
       SecurityPolicy: TLS_1_2
 
   SessionsApiBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
     DependsOn: SessionsApiDomainName
     Properties:
-      DomainName: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns
@@ -73,9 +89,17 @@ Resources:
   SessionsApiOriginRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Sub
-        - "origin.sessions-${AWS::StackName}.${DNS_RECORD}"
-        - DNS_RECORD: !FindInMap
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - origin.sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - origin.sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns
@@ -88,9 +112,17 @@ Resources:
   SessionsApiRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -159,8 +159,8 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSBASEURL: 'https://mob-sts-mock.review-b-async.dev.account.gov.uk'
-      ReadIdBaseUrl: 'https://mob-readid-mock.review-b-async.dev.account.gov.uk/v2'
+      STSBASEURL: 'https://sts-mock.review-b-async.dev.account.gov.uk'
+      ReadIdBaseUrl: 'https://readid-mock.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -168,8 +168,8 @@ Mappings:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
 
     build:
-      STSBASEURL: 'https://mob-sts-mock.review-b-async.build.account.gov.uk'
-      ReadIdBaseUrl: 'https://mob-readid-mock.review-b-async.build.account.gov.uk/v2'
+      STSBASEURL: 'https://sts-mock.review-b-async.build.account.gov.uk'
+      ReadIdBaseUrl: 'https://readid-mock.review-b-async.build.account.gov.uk/v2'
       ClientRegistrySecretPath: 'build/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -246,7 +246,7 @@ Conditions:
       - !Ref DevOverrideStsBaseUrl
       - none
 
-  UseWildcardCertificate: !And
+  DevelopmentStack: !And
     - !Equals [!Ref Environment, dev]
     - !Not [!Equals [!Ref AWS::StackName, mob-async-backend]]
 

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -67,16 +67,16 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: build/clientRegistry
-      ReadIdBaseUrl: https://mob-readid-mock.review-b-async.build.account.gov.uk/v2
-      STSBASEURL: https://mob-sts-mock.review-b-async.build.account.gov.uk
+      ReadIdBaseUrl: https://readid-mock.review-b-async.build.account.gov.uk/v2
+      STSBASEURL: https://sts-mock.review-b-async.build.account.gov.uk
     dev:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
       BiometricSubmitterKeySecretPathBrp: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP
       BiometricSubmitterKeySecretPathDl: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: dev/clientRegistry
-      ReadIdBaseUrl: https://mob-readid-mock.review-b-async.dev.account.gov.uk/v2
-      STSBASEURL: https://mob-sts-mock.review-b-async.dev.account.gov.uk
+      ReadIdBaseUrl: https://readid-mock.review-b-async.dev.account.gov.uk/v2
+      STSBASEURL: https://sts-mock.review-b-async.dev.account.gov.uk
     integration:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
       BiometricSubmitterKeySecretPathBrp: /integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP
@@ -209,6 +209,15 @@ Conditions:
       - !Ref DeployAlarmsInDev
       - true
 
+  DevelopmentStack: !And
+    - !Equals
+      - !Ref Environment
+      - dev
+    - !Not
+      - !Equals
+        - !Ref AWS::StackName
+        - mob-async-backend
+
   IsDevOrBuild: !Or
     - !Equals
       - !Ref Environment
@@ -243,15 +252,6 @@ Conditions:
     - !Equals
       - !Ref PermissionsBoundary
       - none
-
-  UseWildcardCertificate: !And
-    - !Equals
-      - !Ref Environment
-      - dev
-    - !Not
-      - !Equals
-        - !Ref AWS::StackName
-        - mob-async-backend
 
   isNotDevOrBuild: !Or
     - !Equals
@@ -2020,12 +2020,20 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     DependsOn: ProxyApiDomainName
     Properties:
-      DomainName: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       RestApiId: !Ref ProxyApi
       Stage: !Ref ProxyApi.Stage
     Condition: ProxyApiDeployment
@@ -2033,19 +2041,27 @@ Resources:
   ProxyApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       EndpointConfiguration:
         Types:
           - REGIONAL
       RegionalCertificateArn: !If
-        - UseWildcardCertificate
+        - DevelopmentStack
         - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV2ARN}}'
       SecurityPolicy: TLS_1_2
     Condition: ProxyApiDeployment
 
@@ -2056,12 +2072,20 @@ Resources:
         DNSName: !GetAtt ProxyApiDomainName.RegionalDomainName
         HostedZoneId: !GetAtt ProxyApiDomainName.RegionalHostedZoneId
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
-      Name: !Sub
-        - proxy-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - proxy-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - proxy.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       Type: A
     Condition: ProxyApiDeployment
 
@@ -2206,31 +2230,47 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     DependsOn: SessionsApiDomainName
     Properties:
-      DomainName: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       RestApiId: !Ref SessionsApi
       Stage: !Ref SessionsApi.Stage
 
   SessionsApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       EndpointConfiguration:
         Types:
           - REGIONAL
       RegionalCertificateArn: !If
-        - UseWildcardCertificate
+        - DevelopmentStack
         - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV2ARN}}'
       SecurityPolicy: TLS_1_2
 
   SessionsApiOriginRecordSet:
@@ -2240,12 +2280,20 @@ Resources:
         DNSName: !GetAtt SessionsApiDomainName.RegionalDomainName
         HostedZoneId: !GetAtt SessionsApiDomainName.RegionalHostedZoneId
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
-      Name: !Sub
-        - origin.sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - origin.sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - origin.sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       Type: A
 
   SessionsApiRecordSet:
@@ -2256,12 +2304,20 @@ Resources:
           Fn::Sub: ${AWS::StackName}-cf-dist-DistributionDomain
         HostedZoneId: Z2FDTNDATAQYW2
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
-      Name: !Sub
-        - sessions-${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
-            - DNS
-            - !Ref Environment
-            - BaseDns
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - sessions-${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
+        - !Sub
+          - sessions.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+              - DNS
+              - !Ref Environment
+              - BaseDns
       Type: A
 
   SessionsApiWebAclAssociation:

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -19,8 +19,8 @@ describe("Backend application infrastructure", () => {
   describe("EnvironmentVariable mapping values", () => {
     test("STS base url is set", () => {
       const expectedEnvironmentVariablesValues = {
-        dev: "https://mob-sts-mock.review-b-async.dev.account.gov.uk",
-        build: "https://mob-sts-mock.review-b-async.build.account.gov.uk",
+        dev: "https://sts-mock.review-b-async.dev.account.gov.uk",
+        build: "https://sts-mock.review-b-async.build.account.gov.uk",
         staging: "https://token.staging.account.gov.uk",
         integration: "https://token.integration.account.gov.uk",
         production: "https://token.account.gov.uk",
@@ -35,8 +35,8 @@ describe("Backend application infrastructure", () => {
 
     test("ReadIdBaseUrl assigned ID Check mock values in dev and build and vendor values in staging, integration and production", () => {
       const expectedEnvironmentVariablesValues = {
-        dev: "https://mob-readid-mock.review-b-async.dev.account.gov.uk/v2",
-        build: "https://mob-readid-mock.review-b-async.build.account.gov.uk/v2",
+        dev: "https://readid-mock.review-b-async.dev.account.gov.uk/v2",
+        build: "https://readid-mock.review-b-async.build.account.gov.uk/v2",
         staging: "", // To be updated with new ReadID URL once available
         integration: "", // To be updated with new ReadID URL once available
         production: "", // To be updated with new ReadID URL once available

--- a/sts-mock/template.yaml
+++ b/sts-mock/template.yaml
@@ -74,7 +74,7 @@ Conditions:
       - !Ref DevOverrideAsyncBackendBaseUrl
       - none
 
-  UseWildcardCertificate: !And
+  DevelopmentStack: !And
     - !Equals [!Ref Environment, dev]
     - !Not [!Equals [!Ref AWS::StackName, mob-sts-mock]]
 
@@ -114,9 +114,17 @@ Resources:
   StsMockApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: !Sub
-        - ${AWS::StackName}.${DNS_RECORD}
-        - DNS_RECORD: !FindInMap
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - ${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sts-mock.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
             - DNS
             - !Ref Environment
             - BaseDns
@@ -124,22 +132,48 @@ Resources:
         Types:
           - REGIONAL
       RegionalCertificateArn: !If
-        - UseWildcardCertificate
+        - DevelopmentStack
         - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateV2ARN}}'
       SecurityPolicy: TLS_1_2
 
   StsMockApiBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
     Properties:
-      DomainName: !Sub ${StsMockApiDomainName}
+      DomainName: !If
+        - DevelopmentStack
+        - !Sub
+          - ${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sts-mock.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
       RestApiId: !Ref StsMockApi
       Stage: !Ref StsMockApi.Stage
 
   StsMockApiRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !Sub ${StsMockApiDomainName}
+      Name: !If
+        - DevelopmentStack
+        - !Sub
+          - ${AWS::StackName}.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
+        - !Sub
+          - sts-mock.${DNS_RECORD}
+          - DNS_RECORD: !FindInMap
+            - DNS
+            - !Ref Environment
+            - BaseDns
       Type: A
       HostedZoneId: !Sub '{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}'
       AliasTarget:
@@ -206,7 +240,7 @@ Resources:
           ASYNC_BACKEND_BASE_URL: !If
             - UseDevOverrideAsyncBackendBaseUrl
             - !Ref DevOverrideAsyncBackendBaseUrl
-            - !Sub https://sessions-mob-async-backend.review-b-async.${Environment}.account.gov.uk
+            - !Sub https://sessions.review-b-async.${Environment}.account.gov.uk
           KEY_STORAGE_BUCKET_NAME: !Ref JwksBucket
       VpcConfig:
         SubnetIds:


### PR DESCRIPTION
[​DCMAW-11018](https://govukverify.atlassian.net/browse/DCMAW-10844)

### What changed
Uses wildcard cert and original domain name format for development stacks and new certs and domain name format for non development stacks. (Due to hard domain name length limits set by AWS - 64 chars)

https://github.com/govuk-one-login/mobile-id-check-async/pull/357
https://github.com/govuk-one-login/mobile-id-check-async-infra/pull/20
https://github.com/govuk-one-login/mobile-id-check-readid-mock/pull/20

## Checklists

- [X] There is a ticket raised for this PR that is present in the branch name
- [X] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
