### PR TITLE
DCMAW-11057: sts-mock update tests to use absolute path

### DIFF
--- a/sts-mock/run-tests.sh
+++ b/sts-mock/run-tests.sh
@@ -5,6 +5,8 @@ remove_quotes() {
   echo "$1" | tr -d '"'
 }
 
+cd /sts-mock
+
 export STS_MOCK_API_URL=$(remove_quotes "$CFN_StsMockApiUrl")
 
 if npm run test:api; then


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-11057

### What changed
Updates sts-mock `run-tests.sh` file to correctly `cd` into the sts-mock directory

### Why did it change
Tests failing in pipeline because the tests were running in the wrong directory

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
