### PR TITLE
DCMAW-11006: Update STS URL in lower envs

### DIFF
--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -159,7 +159,7 @@ Mappings:
 
   EnvironmentVariables:
     dev:
-      STSBASEURL: 'https://test-resources.review-b-async.dev.account.gov.uk'
+      STSBASEURL: 'https://sts-mock.review-b-async.dev.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-mock.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
@@ -168,7 +168,7 @@ Mappings:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
 
     build:
-      STSBASEURL: 'https://test-resources.review-b-async.build.account.gov.uk'
+      STSBASEURL: 'https://sts-mock.review-b-async.build.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-mock.review-b-async.build.account.gov.uk/v2'
       ClientRegistrySecretPath: 'build/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -68,7 +68,7 @@ Mappings:
       BiometricSubmitterKeySecretPathPassport: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: build/clientRegistry
       ReadIdBaseUrl: https://readid-mock.review-b-async.build.account.gov.uk/v2
-      STSBASEURL: https://test-resources.review-b-async.build.account.gov.uk
+      STSBASEURL: https://sts-mock.review-b-async.build.account.gov.uk
     dev:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
       BiometricSubmitterKeySecretPathBrp: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP
@@ -76,7 +76,7 @@ Mappings:
       BiometricSubmitterKeySecretPathPassport: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: dev/clientRegistry
       ReadIdBaseUrl: https://readid-mock.review-b-async.dev.account.gov.uk/v2
-      STSBASEURL: https://test-resources.review-b-async.dev.account.gov.uk
+      STSBASEURL: https://sts-mock.review-b-async.dev.account.gov.uk
     integration:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
       BiometricSubmitterKeySecretPathBrp: /integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -19,8 +19,8 @@ describe("Backend application infrastructure", () => {
   describe("EnvironmentVariable mapping values", () => {
     test("STS base url is set", () => {
       const expectedEnvironmentVariablesValues = {
-        dev: "https://test-resources.review-b-async.dev.account.gov.uk",
-        build: "https://test-resources.review-b-async.build.account.gov.uk",
+        dev: "https://sts-mock.review-b-async.dev.account.gov.uk",
+        build: "https://sts-mock.review-b-async.build.account.gov.uk",
         staging: "https://token.staging.account.gov.uk",
         integration: "https://token.integration.account.gov.uk",
         production: "https://token.account.gov.uk",


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
DCMAW-11006

The STS URL used in the activeSession lambda to validate the issuer claim is incorrect. It should point to the STS API - the test-resources domain doesn't exist.

activeSession lambda logs highlighting the issue:

![image](https://github.com/user-attachments/assets/3747e085-bfe5-44a8-84aa-b929118cddf3)


Correct domain:

![image](https://github.com/user-attachments/assets/2dfc01fa-3812-4b34-9d28-feb783e18d51)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
