### PR TITLE
DCMAW-11006: remove duplicate dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,25 +62,3 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
-  - package-ecosystem: "npm"
-    directory: "test-resources"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "03:00"
-    open-pull-requests-limit: 5
-    groups:
-      backend-version:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      backend-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
DCMAW-11006: Removes duplicate block in dependabot.yml config file.

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
