### PR TITLE
DCMAW-11492: Update codeowners file to enforce more fine-grained permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,9 @@
-# This is the CODEOWNERS file. These owners will be the default owners for everything in the DI-IPV-DCA-BACK repository
-# The following below will be requested for review when someone opens a pull request.
-
-* @govuk-one-login/mobile-id-check @govuk-one-login/mobile-leads
-
 # All changes in .github directory to be checked by SRE
 .github/ @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
 
 # All changes to Dockerfiles and CloudFormation templates to be checked by SRE
 **/template.yaml @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
 **/Dockerfile @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
+
+# All other changes review a review from backend engineers
+* @govuk-one-login/mobile-id-check-backend @govuk-one-login/mobile-leads

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 **/template.yaml @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
 **/Dockerfile @govuk-one-login/mobile-id-check-sre @govuk-one-login/mobile-leads
 
-# All other changes review a review from backend engineers
+# All other changes require a review from backend engineers
 * @govuk-one-login/mobile-id-check-backend @govuk-one-login/mobile-leads


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-11492

### What changed
- Removes the `govuk-one-login/mobile-id-check` team from the Codeowners file.  This team is being deprecated following the wider ID Check team split: https://github.com/govuk-one-login/configuration/pull/783
- Ensures files that don't require SRE approval require a backend approval

- [x] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
