### PR TITLE
DCMAW-11107: Fix flakey sam validate --lint failure

### DIFF
--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -261,6 +261,17 @@ Conditions:
         - dev
     - !Equals [!Ref DeployAlarmsInDev, true]
 
+  Never: !Equals
+    - !Ref AWS::NoValue
+    - "false"
+
+Resources:
+  # CloudFormation requires at least one resource definition per template, so this resource is here to satisfy various
+  # linting . It has no required properties, will never be deployed, and would have no effect if it were deployed.
+  NullResource:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Condition: Never
+
 Globals:
   Function:
     AutoPublishAlias: live

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -226,6 +226,10 @@ Conditions:
       - !Ref Environment
       - build
 
+  Never: !Equals
+    - !Ref AWS::NoValue
+    - "false"
+
   ProxyApiDeployment: !Or
     - !Equals
       - !Ref Environment
@@ -2299,6 +2303,10 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}-signing-key
       TargetKeyId: !Ref KMSSigningKey
+
+  NullResource:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Condition: Never
 
   PrivateApi:
     Type: AWS::Serverless::Api

--- a/backend-api/tests/infra-tests/template.test.ts
+++ b/backend-api/tests/infra-tests/template.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import * as path from "path";
 import { isDeepStrictEqual } from "util";
 import * as cfnParse from "yaml-cfn";
@@ -132,11 +132,15 @@ describe("Template", () => {
     });
   });
 
-  it("parent template should not have any Resources", () => {
+  it("parent template should only have a placeholder resource", () => {
     const parent = cfnParse.yamlParse(readFileSync(parentFilePath, "utf8"));
     const resources = parent.Resources || {};
-    const resourceKeys = Object.keys(resources);
-    expect(resourceKeys).toHaveLength(0);
+    expect(resources).toStrictEqual({
+      NullResource: {
+        Type: "AWS::CloudFormation::WaitConditionHandle",
+        Condition: "Never",
+      },
+    });
   });
 
   it("should match template.yaml with sum of its parts", () => {

--- a/test-resources/infra/parent.yaml
+++ b/test-resources/infra/parent.yaml
@@ -110,8 +110,8 @@ Conditions:
         - mob-test-resources
 
   Never: !Equals
-    - true
-    - false
+    - !Ref AWS::NoValue
+    - "false"
 
 Resources:
   # CloudFormation requires at least one resource definition per template, so this resource is here to satisfy the

--- a/test-resources/template.yaml
+++ b/test-resources/template.yaml
@@ -75,8 +75,8 @@ Conditions:
         - mob-test-resources
 
   Never: !Equals
-    - true
-    - false
+    - !Ref AWS::NoValue
+    - "false"
 
   UseCodeSigning: !Not
     - !Equals

--- a/test-resources/tests/infrastructure-tests/template.test.ts
+++ b/test-resources/tests/infrastructure-tests/template.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { load } from "js-yaml";
 import { schema } from "yaml-cfn";
 import { deepMerge, walkSync } from "../testUtils/testFunctions";
+import path from "path";
 
 const aggregatedTemplate = loadTemplateFromFile("./template.yaml");
 
@@ -16,6 +17,20 @@ describe("Sub-templates", () => {
       .map((template) => template.toJSON());
     const mergedSubTemplateJson = deepMerge(...subTemplates);
     expect(aggregatedTemplate.toJSON()).toStrictEqual(mergedSubTemplateJson);
+  });
+
+  it("Parent template should only have a placeholder resource", () => {
+    const infraFolder = path.join(__dirname, "../../infra");
+    const parentTemplatePath = path.join(infraFolder, "parent.yaml");
+    const parentTemplate = loadTemplateFromFile(parentTemplatePath).toJSON();
+
+    const resources = parentTemplate.Resources || {};
+    expect(resources).toStrictEqual({
+      NullResource: {
+        Type: "AWS::CloudFormation::WaitConditionHandle",
+        Condition: "Never",
+      },
+    });
   });
 });
 


### PR DESCRIPTION
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->
​DCMAW-11107

### What changed
There is a resource in the `parent.yaml` file to please different linting tools (particularly WebStorm). Without this the tools complain indicating that the cloudformation template is missing a Resource. 

Updated the condition that ensures this resource never deploys by tricking SAM; SAM doesn't evaluate instrinsic Cloudformation values/functions so does not realise this condition always equates to false. 

### Why did this change
Flakey pre-merge pipelines

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
