### PR TITLE
DCMAW-11530: allow IPVCore VPCe to invoke private API

### DIFF
--- a/backend-api/infra/api/private.yaml
+++ b/backend-api/infra/api/private.yaml
@@ -5,11 +5,26 @@ Resources:
     Properties:
       Name: !Sub ${AWS::StackName}-private-api
       Description: Private API gateway for Client Credentials flow
-      EndpointConfiguration: PRIVATE
+      EndpointConfiguration:
+        Type: PRIVATE
+        VPCEndpointIds: !If
+          - IntegrateIpvCore
+          - - !FindInMap
+              - PrivateApigw
+              - !Ref Environment
+              - IpvCoreVpceId
+          - - Ref: "AWS::NoValue"
       Auth:
         ResourcePolicy:
           IntrinsicVpceWhitelist:
             - !ImportValue devplatform-vpc-ExecuteApiGatewayEndpointId
+            - !If
+              - IntegrateIpvCore
+              - !FindInMap
+                - PrivateApigw
+                - !Ref Environment
+                - IpvCoreVpceId
+              - Ref: "AWS::NoValue"
       StageName: !Ref Environment
       OpenApiVersion: 3.0.1
       AccessLogSetting:

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -57,7 +57,7 @@ Mappings:
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
-      IpvCoreVpceId: "vpce-05d65e10c17d56327"
+      IpvCoreVpceId: ""
     build:
       ApiBurstLimit: 10
       ApiRateLimit: 10

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -57,18 +57,23 @@ Mappings:
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: "vpce-05d65e10c17d56327"
     build:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: ""
     staging:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: "vpce-0555f751a645d7639"
     integration:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      IpvCoreVpceId: ""
     production:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      IpvCoreVpceId: ""
 
   SessionsApigw:
     dev:
@@ -260,6 +265,10 @@ Conditions:
         - !Ref Environment
         - dev
     - !Equals [!Ref DeployAlarmsInDev, true]
+
+  IntegrateIpvCore: !Equals
+      - !Ref Environment
+      - staging
 
 Globals:
   Function:

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -139,7 +139,7 @@ Mappings:
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
-      IpvCoreVpceId: vpce-05d65e10c17d56327
+      IpvCoreVpceId: ""
     integration:
       ApiBurstLimit: 0
       ApiRateLimit: 0

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -135,18 +135,23 @@ Mappings:
     build:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: ""
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: vpce-05d65e10c17d56327
     integration:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      IpvCoreVpceId: ""
     production:
       ApiBurstLimit: 0
       ApiRateLimit: 0
+      IpvCoreVpceId: ""
     staging:
       ApiBurstLimit: 10
       ApiRateLimit: 10
+      IpvCoreVpceId: vpce-0555f751a645d7639
 
   ProxyApigw:
     build:
@@ -217,6 +222,10 @@ Conditions:
       - !Equals
         - !Ref AWS::StackName
         - mob-async-backend
+
+  IntegrateIpvCore: !Equals
+    - !Ref Environment
+    - staging
 
   IsDevOrBuild: !Or
     - !Equals
@@ -2310,13 +2319,28 @@ Resources:
         ResourcePolicy:
           IntrinsicVpceWhitelist:
             - !ImportValue devplatform-vpc-ExecuteApiGatewayEndpointId
+            - !If
+              - IntegrateIpvCore
+              - !FindInMap
+                - PrivateApigw
+                - !Ref Environment
+                - IpvCoreVpceId
+              - !Ref AWS::NoValue
       DefinitionBody:
         Fn::Transform:
           Name: AWS::Include
           Parameters:
             Location: ./openApiSpecs/async-private-spec.yaml
       Description: Private API gateway for Client Credentials flow
-      EndpointConfiguration: PRIVATE
+      EndpointConfiguration:
+        Type: PRIVATE
+        VPCEndpointIds: !If
+          - IntegrateIpvCore
+          - - !FindInMap
+              - PrivateApigw
+              - !Ref Environment
+              - IpvCoreVpceId
+          - - !Ref AWS::NoValue
       MethodSettings:
         - DataTraceEnabled: false
           HttpMethod: '*'

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -54,7 +54,10 @@ describe("Backend application infrastructure", () => {
     test("The endpoints are Private", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
         Name: { "Fn::Sub": "${AWS::StackName}-private-api" },
-        EndpointConfiguration: "PRIVATE",
+        EndpointConfiguration: {
+          "Type": "PRIVATE",
+          "VPCEndpointIds": { "Fn::FindInMap": ["PrivateApigw", { "Ref": "Environment" }, "VPCEndpointIds"] }
+        },
       });
     });
 

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -97,6 +97,21 @@ describe("Backend application infrastructure", () => {
         expect(methodSettings.asArray()[0].MetricsEnabled).toBe(true);
       });
 
+      test("IPV Core VPCe mappings are set", () => {
+        const expectedIpvCoreVpceIdMapping = {
+          dev: "",
+          build: "",
+          staging: "vpce-0555f751a645d7639",
+          integration: "",
+          production: "",
+        };
+        const mappingHelper = new Mappings(template);
+        mappingHelper.validatePrivateAPIMapping({
+          environmentFlags: expectedIpvCoreVpceIdMapping,
+          mappingBottomLevelKey: "IpvCoreVpceId",
+        });
+      });
+
       test("Rate and burst limit mappings are set", () => {
         const expectedBurstLimits = {
           dev: 10,

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -55,14 +55,22 @@ describe("Backend application infrastructure", () => {
       template.hasResourceProperties("AWS::Serverless::Api", {
         Name: { "Fn::Sub": "${AWS::StackName}-private-api" },
         EndpointConfiguration: {
-          "Type": "PRIVATE",
-          "VPCEndpointIds": {
-            "Fn::If": [ 
-              "IntegrateIpvCore", 
-              [{"Fn::FindInMap": ["PrivateApigw", { Ref: "Environment" }, "IpvCoreVpceId"]}],
-              [{ Ref: "AWS::NoValue" }]
-            ]
-          }
+          Type: "PRIVATE",
+          VPCEndpointIds: {
+            "Fn::If": [
+              "IntegrateIpvCore",
+              [
+                {
+                  "Fn::FindInMap": [
+                    "PrivateApigw",
+                    { Ref: "Environment" },
+                    "IpvCoreVpceId",
+                  ],
+                },
+              ],
+              [{ Ref: "AWS::NoValue" }],
+            ],
+          },
         },
       });
     });

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -56,7 +56,13 @@ describe("Backend application infrastructure", () => {
         Name: { "Fn::Sub": "${AWS::StackName}-private-api" },
         EndpointConfiguration: {
           "Type": "PRIVATE",
-          "VPCEndpointIds": { "Fn::FindInMap": ["PrivateApigw", { "Ref": "Environment" }, "VPCEndpointIds"] }
+          "VPCEndpointIds": {
+            "Fn::If": [ 
+              "IntegrateIpvCore", 
+              [{"Fn::FindInMap": ["PrivateApigw", { Ref: "Environment" }, "IpvCoreVpceId"]}],
+              [{ Ref: "AWS::NoValue" }]
+            ]
+          }
         },
       });
     });


### PR DESCRIPTION
[​DCMAW-11530](https://govukverify.atlassian.net/browse/DCMAW-11530)

### What changed
- Adds mapping to provide IPV Core VPC endpoint ID for each environment
- Adds condition to only integrate with IPV Core when environment is staging (to be rolled out to int and prod)
- Updates the private API resource policy to whitelist VPCe
- Updates the private API settings to include VPCe ID
- Update infra tests accordingly

### Why did it change
To integrate with IPV Core

## Checklists
- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

## Screenshots
Screenshot of private API settings including VPCe (testing in dev env)
<img width="623" alt="Screenshot 2025-02-14 at 12 47 22" src="https://github.com/user-attachments/assets/1ddd1856-1f5b-4ab2-ac08-b4ad6246048d" />

Screenshot of private API resource policy showing whitelisted VPCe (testing in dev)
<img width="1082" alt="Screenshot 2025-02-14 at 12 48 30" src="https://github.com/user-attachments/assets/985cfa8f-47b4-4afe-a3db-3f4bc211c3df" />
