### PR TITLE
DCMAW-11505: update regional certs for apis to use new ssm params

### DIFF
--- a/backend-api/infra/api/proxy.yaml
+++ b/backend-api/infra/api/proxy.yaml
@@ -64,8 +64,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateARN:1}}'
         
       SecurityPolicy: TLS_1_2
     Condition: ProxyApiDeployment

--- a/backend-api/infra/api/sessions.yaml
+++ b/backend-api/infra/api/sessions.yaml
@@ -61,8 +61,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   SessionsApiBasePathMapping:

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -2749,8 +2749,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneProxyCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
     Condition: ProxyApiDeployment
 
@@ -2958,8 +2958,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneSessionsCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   SessionsApiOriginRecordSet:

--- a/test-resources/infra/dequeue/api.yaml
+++ b/test-resources/infra/dequeue/api.yaml
@@ -100,8 +100,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneEventsCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneEventsCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   EventsApiBasePathMapping:

--- a/test-resources/infra/sts-mock/token/api.yaml
+++ b/test-resources/infra/sts-mock/token/api.yaml
@@ -55,8 +55,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   StsMockApiBasePathMapping:

--- a/test-resources/template.yaml
+++ b/test-resources/template.yaml
@@ -315,8 +315,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneEventsCertificateV1ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneEventsCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   EventsApiRecordSet:
@@ -594,8 +594,8 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !If
         - DevelopmentStack
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateV1ARN}}'
-        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateV2ARN}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneWildcardCertificateARN:1}}'
+        - !Sub '{{resolve:ssm:/${Environment}/Platform/ACM/AsyncPrimaryZoneStsMockCertificateARN:1}}'
       SecurityPolicy: TLS_1_2
 
   StsMockApiRecordSet:


### PR DESCRIPTION
[​DCMAW-11505](https://govukverify.atlassian.net/browse/DCMAW-11505)

### What changed
Points to the SSM parameter and pins to version 1.

### Why did it change
Uses the inbuilt versioning functionality of SSM parameters. Rather than add-switch-remove.

infra PR --> https://github.com/govuk-one-login/mobile-id-check-async-infra/pull/34

### Scenarios Tested
- not pinning a numerical version
- pinning a non-numerical version
- using a different name for the wildcard param
- errors with regionalCertificateArn if statement

## Checklists
- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
