### PR TITLE
DCMAW-11565: Use ReadId Proxy in lower environments

### DIFF
--- a/backend-api/infra/functions/biometricToken.yaml
+++ b/backend-api/infra/functions/biometricToken.yaml
@@ -29,7 +29,10 @@ Resources:
           BIOMETRIC_SUBMITTER_KEY_SECRET_PATH_BRP: !FindInMap [EnvironmentVariables, !Ref Environment, BiometricSubmitterKeySecretPathBrp]
           BIOMETRIC_SUBMITTER_KEY_SECRET_PATH_DL: !FindInMap [EnvironmentVariables, !Ref Environment, BiometricSubmitterKeySecretPathDl]
           BIOMETRIC_SUBMITTER_KEY_SECRET_CACHE_DURATION_IN_SECONDS: !FindInMap [ EnvironmentVariables, !Ref Environment, BiometricSubmitterKeySecretCacheDurationInSeconds ]
-          READID_BASE_URL: !FindInMap [EnvironmentVariables, !Ref Environment, ReadIdBaseUrl]
+          READID_BASE_URL: !If
+            - UseDevOverrideReadIdBaseUrl
+            - !Ref DevOverrideReadIdBaseUrl
+            - !FindInMap [EnvironmentVariables, !Ref Environment, ReadIdBaseUrl]
       Role: !GetAtt AsyncBiometricTokenLambdaRole.Arn
       VpcConfig:
         SubnetIds:

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -170,7 +170,7 @@ Mappings:
   EnvironmentVariables:
     dev:
       STSBASEURL: 'https://sts-mock.review-b-async.dev.account.gov.uk'
-      ReadIdBaseUrl: 'https://readid-mock.review-b-async.dev.account.gov.uk/v2'
+      ReadIdBaseUrl: 'https://readid-proxy.review-b-async.dev.account.gov.uk/v2'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -179,7 +179,7 @@ Mappings:
 
     build:
       STSBASEURL: 'https://sts-mock.review-b-async.build.account.gov.uk'
-      ReadIdBaseUrl: 'https://readid-mock.review-b-async.build.account.gov.uk/v2'
+      ReadIdBaseUrl: 'https://readid-proxy.review-b-async.build.account.gov.uk/v2'
       ClientRegistrySecretPath: 'build/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -188,7 +188,7 @@ Mappings:
 
     staging:
       STSBASEURL: 'https://token.staging.account.gov.uk'
-      ReadIdBaseUrl: '' #TODO: Update this value with new ReadID URL once available
+      ReadIdBaseUrl: 'https://readid-proxy.review-b-async.staging.account.gov.uk'
       ClientRegistrySecretPath: 'staging/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -197,7 +197,7 @@ Mappings:
 
     integration:
       STSBASEURL: 'https://token.integration.account.gov.uk'
-      ReadIdBaseUrl: '' #TODO: Update this value with new ReadID URL once available
+      ReadIdBaseUrl: 'https://readid-proxy.review-b-async.integration.account.gov.uk'
       ClientRegistrySecretPath: 'integration/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -206,7 +206,7 @@ Mappings:
 
     production:
       STSBASEURL: 'https://token.account.gov.uk'
-      ReadIdBaseUrl: '' #TODO: Update this value with new ReadID URL once available
+      ReadIdBaseUrl: 'https://readid-proxy.review-b-async.account.gov.uk'
       ClientRegistrySecretPath: 'production/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/production/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/production/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -31,6 +31,12 @@ Parameters:
     Type: String
     Default: none
 
+  DevOverrideReadIdBaseUrl:
+    Description: |
+      Override the ReadIdBaseUrl value for development deployments
+    Type: String
+    Default: none
+
   DeployAlarmsInDev:
     Description: Set to `true` to deploy alarms in a dev environment
     Type: String
@@ -258,6 +264,11 @@ Conditions:
   UseDevOverrideStsBaseUrl: !Not
     - !Equals
       - !Ref DevOverrideStsBaseUrl
+      - none
+
+  UseDevOverrideReadIdBaseUrl: !Not
+    - !Equals
+      - !Ref DevOverrideReadIdBaseUrl
       - none
 
   DevelopmentStack: !And

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -14,6 +14,12 @@ Parameters:
     Type: String
     Default: false
 
+  DevOverrideReadIdBaseUrl:
+    Description: |
+      Override the ReadIdBaseUrl value for development deployments
+    Type: String
+    Default: none
+
   DevOverrideStsBaseUrl:
     Description: |
       Override the STS_BASE_URL value for development deployments
@@ -255,6 +261,11 @@ Conditions:
   UseCodeSigning: !Not
     - !Equals
       - !Ref CodeSigningConfigArn
+      - none
+
+  UseDevOverrideReadIdBaseUrl: !Not
+    - !Equals
+      - !Ref DevOverrideReadIdBaseUrl
       - none
 
   UseDevOverrideStsBaseUrl: !Not
@@ -1045,10 +1056,13 @@ Resources:
             - EnvironmentVariables
             - !Ref Environment
             - BiometricSubmitterKeySecretPathPassport
-          READID_BASE_URL: !FindInMap
-            - EnvironmentVariables
-            - !Ref Environment
-            - ReadIdBaseUrl
+          READID_BASE_URL: !If
+            - UseDevOverrideReadIdBaseUrl
+            - !Ref DevOverrideReadIdBaseUrl
+            - !FindInMap
+              - EnvironmentVariables
+              - !Ref Environment
+              - ReadIdBaseUrl
       Events:
         AsyncBiometricToken:
           Properties:

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -72,7 +72,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: build/clientRegistry
-      ReadIdBaseUrl: https://readid-mock.review-b-async.build.account.gov.uk/v2
+      ReadIdBaseUrl: https://readid-proxy.review-b-async.build.account.gov.uk/v2
       STSBASEURL: https://sts-mock.review-b-async.build.account.gov.uk
     dev:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
@@ -80,7 +80,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: dev/clientRegistry
-      ReadIdBaseUrl: https://readid-mock.review-b-async.dev.account.gov.uk/v2
+      ReadIdBaseUrl: https://readid-proxy.review-b-async.dev.account.gov.uk/v2
       STSBASEURL: https://sts-mock.review-b-async.dev.account.gov.uk
     integration:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
@@ -88,7 +88,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /integration/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: integration/clientRegistry
-      ReadIdBaseUrl: ""
+      ReadIdBaseUrl: https://readid-proxy.review-b-async.integration.account.gov.uk
       STSBASEURL: https://token.integration.account.gov.uk
     production:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
@@ -96,7 +96,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /production/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /production/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: production/clientRegistry
-      ReadIdBaseUrl: ""
+      ReadIdBaseUrl: https://readid-proxy.review-b-async.account.gov.uk
       STSBASEURL: https://token.account.gov.uk
     staging:
       BiometricSubmitterKeySecretCacheDurationInSeconds: 900
@@ -104,7 +104,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: staging/clientRegistry
-      ReadIdBaseUrl: ""
+      ReadIdBaseUrl: https://readid-proxy.review-b-async.staging.account.gov.uk
       STSBASEURL: https://token.staging.account.gov.uk
 
   KMS:

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -33,13 +33,14 @@ describe("Backend application infrastructure", () => {
       });
     });
 
-    test("ReadIdBaseUrl assigned ID Check mock values in dev and build and vendor values in staging, integration and production", () => {
+    test("ReadIdBaseUrl is the ReadID Proxy", () => {
       const expectedEnvironmentVariablesValues = {
-        dev: "https://readid-mock.review-b-async.dev.account.gov.uk/v2",
-        build: "https://readid-mock.review-b-async.build.account.gov.uk/v2",
-        staging: "", // To be updated with new ReadID URL once available
-        integration: "", // To be updated with new ReadID URL once available
-        production: "", // To be updated with new ReadID URL once available
+        dev: "https://readid-proxy.review-b-async.dev.account.gov.uk/v2",
+        build: "https://readid-proxy.review-b-async.build.account.gov.uk/v2",
+        staging: "https://readid-proxy.review-b-async.staging.account.gov.uk",
+        integration:
+          "https://readid-proxy.review-b-async.integration.account.gov.uk",
+        production: "https://readid-proxy.review-b-async.account.gov.uk",
       };
 
       const mappingHelper = new Mappings(template);

--- a/backend-api/tests/infra-tests/template.test.ts
+++ b/backend-api/tests/infra-tests/template.test.ts
@@ -103,8 +103,6 @@ describe("Template", () => {
     expect(mainKeys).toEqual(parentKeys);
 
     parentKeys.forEach((key) => {
-      console.log("main " + key, main.Outputs[key]);
-      console.log("parent " + key, parent.Outputs[key]);
       expect(isDeepStrictEqual(main.Outputs[key], parent.Outputs[key])).toBe(
         true,
       );


### PR DESCRIPTION
### What changed
Now the ReadId proxy has been deployed into dev and build, all requests to the ReadId api should go through the ReadId proxy. This enables performance analytics/logging of requests that are sent to ReadId.

The deploy-backend.sh script has been updated to prompt the user to override the ReadId proxy url, if desired.

## Testing
Requests are being sent outbound from the biometricToken handler to the ReadId proxy (see Url and success message): 
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/5adc1f04-53f7-44e4-a389-e2361bb0602d" />

The deploy

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [ ] There is a ticket raised for this PR that is present in the branch name
- [ ] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
