### PR TITLE
DCMAW-11007: Add TxMA event happy path assertions to backend API test

### DIFF
--- a/backend-api/generate_env_file.sh
+++ b/backend-api/generate_env_file.sh
@@ -4,11 +4,9 @@ set -eu
 if [ $# -ge 1 ] && [ -n "$1" ] ; then
   STACK_IDENTIFIER="$1"
   BACKEND_STACK_NAME="${STACK_IDENTIFIER}-async-backend"
-  TEST_RESOURCES_STACK_NAME="${STACK_IDENTIFIER}-test-resources"
 else
   # default stack name in dev
   BACKEND_STACK_NAME="mob-async-backend"
-  TEST_RESOURCES_STACK_NAME="mob-test-resources"
 fi
 
 echo "Generating .env file for the $BACKEND_STACK_NAME stack"
@@ -17,7 +15,7 @@ PRIVATE_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STAC
 PROXY_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='ProxyApiUrl'].OutputValue" --output text)
 SESSIONS_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='SessionsApiUrl'].OutputValue" --output text)
 STS_MOCK_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='StsMockApiUrl'].OutputValue" --output text)
-EVENTS_API_URL=$(aws cloudformation describe-stacks --stack-name "$TEST_RESOURCES_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='EventsApiUrl'].OutputValue" --output text)
+EVENTS_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='EventsApiUrl'].OutputValue" --output text)
 
 echo "TEST_ENVIRONMENT=dev" > .env
 {

--- a/backend-api/generate_env_file.sh
+++ b/backend-api/generate_env_file.sh
@@ -4,9 +4,11 @@ set -eu
 if [ $# -ge 1 ] && [ -n "$1" ] ; then
   STACK_IDENTIFIER="$1"
   BACKEND_STACK_NAME="${STACK_IDENTIFIER}-async-backend"
+  TEST_RESOURCES_STACK_NAME="${STACK_IDENTIFIER}-test-resources"
 else
   # default stack name in dev
   BACKEND_STACK_NAME="mob-async-backend"
+  TEST_RESOURCES_STACK_NAME="mob-test-resources"
 fi
 
 echo "Generating .env file for the $BACKEND_STACK_NAME stack"
@@ -15,6 +17,7 @@ PRIVATE_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STAC
 PROXY_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='ProxyApiUrl'].OutputValue" --output text)
 SESSIONS_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='SessionsApiUrl'].OutputValue" --output text)
 STS_MOCK_API_URL=$(aws cloudformation describe-stacks --stack-name "$BACKEND_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='StsMockApiUrl'].OutputValue" --output text)
+EVENTS_API_URL=$(aws cloudformation describe-stacks --stack-name "$TEST_RESOURCES_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='EventsApiUrl'].OutputValue" --output text)
 
 echo "TEST_ENVIRONMENT=dev" > .env
 {
@@ -23,4 +26,5 @@ echo "TEST_ENVIRONMENT=dev" > .env
   echo "PROXY_API_URL=${PROXY_API_URL}"
   echo "SESSIONS_API_URL=${SESSIONS_API_URL}"
   echo "STS_MOCK_API_URL=${STS_MOCK_API_URL}"
+  echo "EVENTS_API_URL=${EVENTS_API_URL}"
 } >> .env

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -31,6 +31,12 @@ Parameters:
     Type: String
     Default: none
 
+  DevOverrideEventsBaseUrl:
+    Description: |
+      Override the EventsBaseUrl value for development deployments
+    Type: String
+    Default: none
+
   DevOverrideReadIdBaseUrl:
     Description: |
       Override the ReadIdBaseUrl value for development deployments
@@ -177,6 +183,7 @@ Mappings:
     dev:
       STSBASEURL: 'https://sts-mock.review-b-async.dev.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-proxy.review-b-async.dev.account.gov.uk/v2'
+      EventsBaseUrl: 'https://events.review-b-async.dev.account.gov.uk'
       ClientRegistrySecretPath: 'dev/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -186,6 +193,7 @@ Mappings:
     build:
       STSBASEURL: 'https://sts-mock.review-b-async.build.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-proxy.review-b-async.build.account.gov.uk/v2'
+      EventsBaseUrl: 'https://events.review-b-async.build.account.gov.uk'
       ClientRegistrySecretPath: 'build/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -195,6 +203,7 @@ Mappings:
     staging:
       STSBASEURL: 'https://token.staging.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-proxy.review-b-async.staging.account.gov.uk'
+      EventsBaseUrl: 'https://events.review-b-async.staging.account.gov.uk'
       ClientRegistrySecretPath: 'staging/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'
@@ -264,6 +273,11 @@ Conditions:
   UseDevOverrideStsBaseUrl: !Not
     - !Equals
       - !Ref DevOverrideStsBaseUrl
+      - none
+
+  UseDevOverrideEventsBaseUrl: !Not
+    - !Equals
+      - !Ref DevOverrideEventsBaseUrl
       - none
 
   UseDevOverrideReadIdBaseUrl: !Not
@@ -376,6 +390,13 @@ Outputs:
       - UseDevOverrideStsBaseUrl
       - !Ref DevOverrideStsBaseUrl
       - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
+
+  EventsApiUrl:
+    Description: Events API Gateway base URL
+    Value: !If
+      - UseDevOverrideEventsBaseUrl
+      - !Ref DevOverrideEventsBaseUrl
+      - !FindInMap [EnvironmentVariables, !Ref Environment, EventsBaseUrl]
 
   TxmaSqsQueueArn:
     Condition: IsDevOrBuild

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -203,7 +203,6 @@ Mappings:
     staging:
       STSBASEURL: 'https://token.staging.account.gov.uk'
       ReadIdBaseUrl: 'https://readid-proxy.review-b-async.staging.account.gov.uk'
-      EventsBaseUrl: 'https://events.review-b-async.staging.account.gov.uk'
       ClientRegistrySecretPath: 'staging/clientRegistry'
       BiometricSubmitterKeySecretPathPassport: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT'
       BiometricSubmitterKeySecretPathBrp: '/staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_BRP'

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -374,16 +374,17 @@ Outputs:
     Description: Sessions API Gateway base URL
     Value: !Sub https://${SessionsApiDomainName}
 
+  PrivateApiUrl:
+    Description: Private API Gateway base URL
+    Value: !Sub https://${PrivateApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}
+
   ProxyApiUrl:
     Condition: ProxyApiDeployment
     Description: Proxy API Gateway Pretty DNS
     Value: !Sub https://${ProxyApiDomainName}
 
-  PrivateApiUrl:
-    Description: Private API Gateway base URL
-    Value: !Sub https://${PrivateApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}
-
   StsMockApiUrl:
+    Condition: IsDevOrBuild
     Description: STS Mock API Gateway base URL
     Value: !If
       - UseDevOverrideStsBaseUrl
@@ -391,6 +392,7 @@ Outputs:
       - !FindInMap [EnvironmentVariables, !Ref Environment, STSBASEURL]
 
   EventsApiUrl:
+    Condition: IsDevOrBuild
     Description: Events API Gateway base URL
     Value: !If
       - UseDevOverrideEventsBaseUrl

--- a/backend-api/run-tests-locally.sh
+++ b/backend-api/run-tests-locally.sh
@@ -2,7 +2,6 @@
 set -eu
 
 BACKEND_STACK_NAME="${1:-mob}-async-backend"
-TEST_RESOURCES_STACK_NAME="${1:-mob}-test-resources"
 
 echo "Running test against ${BACKEND_STACK_NAME}"
 
@@ -17,11 +16,6 @@ aws cloudformation describe-stacks \
   --stack-name "$BACKEND_STACK_NAME" \
   --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' \
   --output text > cf-output.txt
-
-aws cloudformation describe-stacks \
-  --stack-name "$TEST_RESOURCES_STACK_NAME" \
-  --query "Stacks[0].Outputs[?OutputKey=='EventsApiUrl'].{key: OutputKey, value: OutputValue}" \
-  --output text >> cf-output.txt
 
 eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
 awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt >> docker-vars.env

--- a/backend-api/run-tests-locally.sh
+++ b/backend-api/run-tests-locally.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -eu
 
-stack_name="${1:-mob}-async-backend"
+BACKEND_STACK_NAME="${1:-mob}-async-backend"
+TEST_RESOURCES_STACK_NAME="${1:-mob}-test-resources"
 
-echo "Running test against ${stack_name}"
+echo "Running test against ${BACKEND_STACK_NAME}"
 
 rm -rf docker-vars.env
 
@@ -13,20 +14,25 @@ ENVIRONMENT="dev"
 IS_LOCAL_TEST="true"
 
 aws cloudformation describe-stacks \
-  --stack-name "$stack_name" \
+  --stack-name "$BACKEND_STACK_NAME" \
   --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' \
-  --output text >cf-output.txt
+  --output text > cf-output.txt
+
+aws cloudformation describe-stacks \
+  --stack-name "$TEST_RESOURCES_STACK_NAME" \
+  --query "Stacks[0].Outputs[?OutputKey=='EventsApiUrl'].{key: OutputKey, value: OutputValue}" \
+  --output text >> cf-output.txt
 
 eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
-awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt >>docker-vars.env
+awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt >> docker-vars.env
 
 {
   echo TEST_REPORT_DIR="$TEST_REPORT_DIR"
   echo TEST_REPORT_ABSOLUTE_DIR="/results"
   echo TEST_ENVIRONMENT="$ENVIRONMENT"
-  echo SAM_STACK_NAME="$stack_name"
+  echo SAM_STACK_NAME="$BACKEND_STACK_NAME"
   echo IS_LOCAL_TEST="$IS_LOCAL_TEST"
-} >>docker-vars.env
+} >> docker-vars.env
 
 aws configure export-credentials --format env-no-export >> docker-vars.env
 

--- a/backend-api/run-tests.sh
+++ b/backend-api/run-tests.sh
@@ -10,6 +10,7 @@ export PROXY_API_URL=$(remove_quotes "$CFN_ProxyApiUrl")
 export PRIVATE_API_URL=$(remove_quotes "$CFN_PrivateApiUrl")
 export SESSIONS_API_URL=$(remove_quotes "$CFN_SessionsApiUrl")
 export STS_MOCK_API_URL=$(remove_quotes "$CFN_StsMockApiUrl")
+export EVENTS_API_URL=$(remove_quotes "$CFN_EventsApiUrl")
 
 mkdir -pv results
 

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -14,6 +14,12 @@ Parameters:
     Type: String
     Default: false
 
+  DevOverrideEventsBaseUrl:
+    Description: |
+      Override the EventsBaseUrl value for development deployments
+    Type: String
+    Default: none
+
   DevOverrideReadIdBaseUrl:
     Description: |
       Override the ReadIdBaseUrl value for development deployments
@@ -78,6 +84,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /build/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: build/clientRegistry
+      EventsBaseUrl: https://events.review-b-async.build.account.gov.uk
       ReadIdBaseUrl: https://readid-proxy.review-b-async.build.account.gov.uk/v2
       STSBASEURL: https://sts-mock.review-b-async.build.account.gov.uk
     dev:
@@ -86,6 +93,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /dev/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: dev/clientRegistry
+      EventsBaseUrl: https://events.review-b-async.dev.account.gov.uk
       ReadIdBaseUrl: https://readid-proxy.review-b-async.dev.account.gov.uk/v2
       STSBASEURL: https://sts-mock.review-b-async.dev.account.gov.uk
     integration:
@@ -110,6 +118,7 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: staging/clientRegistry
+      EventsBaseUrl: https://events.review-b-async.staging.account.gov.uk
       ReadIdBaseUrl: https://readid-proxy.review-b-async.staging.account.gov.uk
       STSBASEURL: https://token.staging.account.gov.uk
 
@@ -261,6 +270,11 @@ Conditions:
   UseCodeSigning: !Not
     - !Equals
       - !Ref CodeSigningConfigArn
+      - none
+
+  UseDevOverrideEventsBaseUrl: !Not
+    - !Equals
+      - !Ref DevOverrideEventsBaseUrl
       - none
 
   UseDevOverrideReadIdBaseUrl: !Not
@@ -3253,6 +3267,16 @@ Resources:
     Condition: DeployAlarms
 
 Outputs:
+  EventsApiUrl:
+    Description: Events API Gateway base URL
+    Value: !If
+      - UseDevOverrideEventsBaseUrl
+      - !Ref DevOverrideEventsBaseUrl
+      - !FindInMap
+        - EnvironmentVariables
+        - !Ref Environment
+        - EventsBaseUrl
+
   PrivateApiUrl:
     Description: Private API Gateway base URL
     Value: !Sub https://${PrivateApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -3275,6 +3275,7 @@ Outputs:
         - EnvironmentVariables
         - !Ref Environment
         - EventsBaseUrl
+    Condition: IsDevOrBuild
 
   PrivateApiUrl:
     Description: Private API Gateway base URL
@@ -3298,6 +3299,7 @@ Outputs:
         - EnvironmentVariables
         - !Ref Environment
         - STSBASEURL
+    Condition: IsDevOrBuild
 
   TxmaKmsEncryptionKeyArn:
     Description: TxMA KMS Encryption Key ARN

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -118,7 +118,6 @@ Mappings:
       BiometricSubmitterKeySecretPathDl: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_DL
       BiometricSubmitterKeySecretPathPassport: /staging/BIOMETRIC_SUBMITTER_ACCESS_KEY_NFC_PASSPORT
       ClientRegistrySecretPath: staging/clientRegistry
-      EventsBaseUrl: https://events.review-b-async.staging.account.gov.uk
       ReadIdBaseUrl: https://readid-proxy.review-b-async.staging.account.gov.uk
       STSBASEURL: https://token.staging.account.gov.uk
 

--- a/backend-api/tests/api-tests/biometricToken.test.ts
+++ b/backend-api/tests/api-tests/biometricToken.test.ts
@@ -2,7 +2,12 @@ import { expect } from "@jest/globals";
 import "../../tests/testUtils/matchers";
 import { SESSIONS_API_INSTANCE } from "./utils/apiInstance";
 import { expectedSecurityHeaders, mockSessionId } from "./utils/apiTestData";
-import { getValidSessionId } from "./utils/apiTestHelpers";
+import {
+  EventResponse,
+  getValidSessionId,
+  pollForEvents,
+} from "./utils/apiTestHelpers";
+import { AxiosResponse } from "axios";
 
 describe("POST /async/biometricToken", () => {
   describe("Given request body is invalid", () => {
@@ -53,8 +58,14 @@ describe("POST /async/biometricToken", () => {
   });
 
   describe("Given there is a valid request", () => {
-    it("Returns a 200 response with biometric access token and opaque ID", async () => {
-      const sessionId = await getValidSessionId();
+    let sessionId: string | null;
+    let biometricTokenResponse: AxiosResponse;
+    let eventsResponse: EventResponse[];
+    let pk: string;
+    let event: object;
+
+    beforeAll(async () => {
+      sessionId = await getValidSessionId();
       if (!sessionId)
         throw new Error(
           "Failed to get valid session ID to call biometricToken endpoint",
@@ -65,19 +76,43 @@ describe("POST /async/biometricToken", () => {
         documentType: "NFC_PASSPORT",
       };
 
-      const response = await SESSIONS_API_INSTANCE.post(
+      biometricTokenResponse = await SESSIONS_API_INSTANCE.post(
         "/async/biometricToken",
         requestBody,
       );
 
-      expect(response.status).toBe(200);
-      expect(response.data).toStrictEqual({
+      eventsResponse = await pollForEvents({
+        partitionKey: `SESSION#${sessionId}`,
+        sortKeyPrefix: `TXMA#EVENT_NAME#DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED`,
+        numberOfEvents: 1,
+      });
+
+      ({ pk, event } = eventsResponse[0]);
+    }, 20000);
+
+    describe("Writing to TxMA", () => {
+      it("Writes an event with the correct session ID", () => {
+        expect(pk).toEqual(`SESSION#${sessionId}`);
+      });
+
+      it("Writes an event with the correct event_name", () => {
+        expect(event).toEqual(
+          expect.objectContaining({
+            event_name: "DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED",
+          }),
+        );
+      });
+    });
+
+    it("Returns a 200 response with biometric access token and opaque ID", () => {
+      expect(biometricTokenResponse.status).toBe(200);
+      expect(biometricTokenResponse.data).toStrictEqual({
         accessToken: expect.any(String),
         opaqueId: expect.toBeValidUuid(),
       });
-      expect(response.headers).toEqual(
+      expect(biometricTokenResponse.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),
       );
-    }, 15000);
+    }, 5000);
   });
 });

--- a/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
+++ b/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
@@ -1,10 +1,12 @@
-import { AxiosInstance } from "axios";
+import { AxiosInstance, AxiosResponse } from "axios";
 import { randomUUID, UUID } from "crypto";
 import "dotenv/config";
 import { PRIVATE_API_INSTANCE, PROXY_API_INSTANCE } from "./utils/apiInstance";
 import {
   ClientDetails,
+  EventResponse,
   getFirstRegisteredClient,
+  pollForEvents,
 } from "./utils/apiTestHelpers";
 
 const getApisToTest = (): {
@@ -116,8 +118,15 @@ describe.each(apis)(
     });
 
     describe("Given the request is valid and the client is registered", () => {
-      it("Returns a 200 OK response and the access token", async () => {
-        const response = await axiosInstance.post(
+      let tokenResponse: AxiosResponse;
+      let accessTokenParts: string[];
+      let header: object;
+      let payload: object;
+      let eventsResponse: EventResponse[];
+      let event: object;
+
+      beforeAll(async () => {
+        tokenResponse = await axiosInstance.post(
           `/async/token`,
           "grant_type=client_credentials",
           {
@@ -127,11 +136,37 @@ describe.each(apis)(
           },
         );
 
-        const accessTokenParts = response.data.access_token.split(".");
-        const header = JSON.parse(fromBase64(accessTokenParts[0])) as object;
-        const payload = JSON.parse(fromBase64(accessTokenParts[1])) as object;
+        accessTokenParts = tokenResponse.data.access_token.split(".");
+        header = JSON.parse(fromBase64(accessTokenParts[0])) as object;
+        payload = JSON.parse(fromBase64(accessTokenParts[1])) as object;
 
-        expect(response.data).toHaveProperty("access_token");
+        eventsResponse = await pollForEvents({
+          partitionKey: `SESSION#UNKNOWN`,
+          sortKeyPrefix: `TXMA#EVENT_NAME#DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED`,
+          numberOfEvents: 1,
+        });
+
+        ({ event } = getEventUnderTest(eventsResponse));
+      }, 20000);
+
+      describe("Writing to TxMA", () => {
+        it("Writes an event with the correct session ID", () => {
+          const { pk } = eventsResponse[0];
+
+          expect(pk).toEqual("SESSION#UNKNOWN");
+        });
+
+        it("Writes an event with the correct event_name", () => {
+          expect(event).toEqual(
+            expect.objectContaining({
+              event_name: "DCMAW_ASYNC_CLIENT_CREDENTIALS_TOKEN_ISSUED",
+            }),
+          );
+        });
+      });
+
+      it("Returns a 200 OK response and the access token", async () => {
+        expect(tokenResponse.data).toHaveProperty("access_token");
         expect(header).toHaveProperty("kid");
         expect(header).toHaveProperty("alg", "ES256");
         expect(header).toHaveProperty("typ", "JWT");
@@ -140,9 +175,9 @@ describe.each(apis)(
         expect(payload).toHaveProperty("exp");
         expect(payload).toHaveProperty("iss");
         expect(payload).toHaveProperty("scope", "dcmaw.session.async_create");
-        expect(response.data).toHaveProperty("expires_in", 3600);
-        expect(response.data).toHaveProperty("token_type", "Bearer");
-        expect(response.status).toBe(200);
+        expect(tokenResponse.data).toHaveProperty("expires_in", 3600);
+        expect(tokenResponse.data).toHaveProperty("token_type", "Bearer");
+        expect(tokenResponse.status).toBe(200);
       });
     });
 
@@ -387,4 +422,30 @@ function getRequestBody(
 function makeSignatureUnverifiable(accessToken: string, newSignature: string) {
   accessToken = accessToken.substring(0, accessToken.lastIndexOf(".") + 1);
   return accessToken + newSignature;
+}
+
+function getEventUnderTest(events: EventResponse[]) {
+  const eventsFound = events.find((event) => {
+    const timestamp = (event.event as any).timestamp;
+    return isEventLessThanOrEqualTo60SecondsOld(timestamp);
+  });
+
+  if (!eventsFound) {
+    throw new Error(
+      "Could not find an event created within the testing time frame.",
+    );
+  }
+
+  return eventsFound;
+}
+
+function isEventLessThanOrEqualTo60SecondsOld(timestamp: number) {
+  const SIXTY_SECONDS = 60;
+  const validFrom = getTimeNowInSeconds() - SIXTY_SECONDS;
+
+  return timestamp >= validFrom;
+}
+
+function getTimeNowInSeconds() {
+  return Math.floor(Date.now() / 1000);
 }

--- a/backend-api/tests/api-tests/utils/apiInstance.ts
+++ b/backend-api/tests/api-tests/utils/apiInstance.ts
@@ -60,7 +60,15 @@ function getStsMockInstance() {
   return getInstance(apiUrl);
 }
 
+function getEventsApiInstance() {
+  const apiUrl = process.env.EVENTS_API_URL;
+  if (!apiUrl)
+    throw new Error("EVENTS_API_URL needs to be defined for API tests");
+  return getInstance(apiUrl, true);
+}
+
 export const SESSIONS_API_INSTANCE = getSessionsApiInstance();
 export const PROXY_API_INSTANCE = getProxyApiInstance();
 export const PRIVATE_API_INSTANCE = getPrivateApiInstance();
 export const STS_MOCK_API_INSTANCE = getStsMockInstance();
+export const EVENTS_API_INSTANCE = getEventsApiInstance();

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -130,7 +130,7 @@ export async function pollForEvents({
     await new Promise((resolve) => setTimeout(resolve, delayMillis));
   }
 
-  const INITIAL_DELAY_MILLIS = 500; // initial wait time before calling API
+  const INITIAL_DELAY_MILLIS = 1000; // initial wait time before calling API
   const MAX_BACKOFF_MILLIS = 10000; // maximum wait time between API calls
 
   function calculateExponentialBackoff(attempts: number) {

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -130,7 +130,7 @@ export async function pollForEvents({
     await new Promise((resolve) => setTimeout(resolve, delayMillis));
   }
 
-  const INITIAL_DELAY_MILLIS = 1000; // initial wait time before calling API
+  const INITIAL_DELAY_MILLIS = 500; // initial wait time before calling API
   const MAX_BACKOFF_MILLIS = 10000; // maximum wait time between API calls
 
   function calculateExponentialBackoff(attempts: number) {

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -2,12 +2,13 @@ import {
   GetSecretValueCommand,
   SecretsManagerClient,
 } from "@aws-sdk/client-secrets-manager";
+import { randomUUID } from "crypto";
 import {
+  EVENTS_API_INSTANCE,
   PROXY_API_INSTANCE,
   SESSIONS_API_INSTANCE,
   STS_MOCK_API_INSTANCE,
 } from "./apiInstance";
-import { randomUUID } from "crypto";
 
 export interface ClientDetails {
   client_id: string;
@@ -89,4 +90,96 @@ export async function getValidSessionId(): Promise<string | null> {
     },
   );
   return activeSessionResponse.data["sessionId"] ?? null;
+}
+
+export type EventResponse = {
+  pk: string;
+  sk: string;
+  event: object;
+};
+
+function isValidEventResponse(
+  eventResponse: unknown,
+): eventResponse is EventResponse {
+  return (
+    typeof eventResponse === "object" &&
+    eventResponse !== null &&
+    "pk" in eventResponse &&
+    typeof eventResponse.pk === "string" &&
+    "sk" in eventResponse &&
+    typeof eventResponse.sk === "string" &&
+    "event" in eventResponse &&
+    typeof eventResponse.event === "object"
+  );
+}
+
+export async function pollForEvents({
+  partitionKey,
+  sortKeyPrefix,
+  numberOfEvents,
+}: {
+  partitionKey: string;
+  sortKeyPrefix: string;
+  numberOfEvents: number;
+}): Promise<EventResponse[]> {
+  function currentTime() {
+    return Date.now();
+  }
+
+  async function wait(delayMillis: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, delayMillis));
+  }
+
+  const INITIAL_DELAY_MILLIS = 500; // initial wait time before calling API
+  const MAX_BACKOFF_MILLIS = 10000; // maximum wait time between API calls
+
+  function calculateExponentialBackoff(attempts: number) {
+    return Math.min(2 ** attempts * INITIAL_DELAY_MILLIS, MAX_BACKOFF_MILLIS);
+  }
+
+  const POLLING_DURATION_MILLIS = 40000;
+  const pollEndTime = currentTime() + POLLING_DURATION_MILLIS;
+
+  let events: unknown[] = [];
+  let waitTime = 0;
+  let attempts = 0;
+
+  while (
+    events.length < numberOfEvents &&
+    currentTime() + waitTime < pollEndTime
+  ) {
+    await wait(waitTime);
+    events = await getEvents({ partitionKey, sortKeyPrefix });
+
+    waitTime = calculateExponentialBackoff(attempts++);
+  }
+
+  if (events.length < numberOfEvents)
+    throw new Error(
+      `Only found ${events.length} events for pkPrefix=${partitionKey} and skPrefix=${sortKeyPrefix}. Expected to find at least ${numberOfEvents} events.`,
+    );
+
+  if (events.some((event) => !isValidEventResponse(event)))
+    throw new Error("Response from /events is malformed");
+
+  return events as EventResponse[];
+}
+
+// Call /events API
+async function getEvents({
+  partitionKey,
+  sortKeyPrefix,
+}: {
+  partitionKey: string;
+  sortKeyPrefix: string;
+}): Promise<unknown[]> {
+  const response = await EVENTS_API_INSTANCE.get("events", {
+    params: {
+      pkPrefix: partitionKey,
+      skPrefix: sortKeyPrefix,
+    },
+  });
+
+  const events = response.data;
+  return Array.isArray(events) ? events : []; // If response is malformed, return empty array so polling can be retried
 }

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -34,52 +34,13 @@ describe("Backend application infrastructure", () => {
     });
 
     test("Events base url is set", () => {
-      interface EnvironmentFlags {
-        dev: string | boolean | number;
-        build: string | boolean | number;
-        staging: string | boolean | number;
-        integration: string | boolean | number;
-        production: string | boolean | number;
-      }
-
-      const environments = [
-        "dev",
-        "build",
-        "staging",
-        "integration",
-        "production",
-      ];
-
-      function validatePartialEnvironmentVariablesMapping(args: {
-        environmentFlags: Partial<EnvironmentFlags>;
-        mappingBottomLevelKey: string;
-      }) {
-        validateMapping({
-          ...args,
-          mappingTopLevelKey: "EnvironmentVariables",
-        });
-      }
-
-      function validateMapping(args: {
-        environmentFlags: Partial<EnvironmentFlags>;
-        mappingTopLevelKey: string;
-        mappingBottomLevelKey: string;
-      }) {
-        const mappings = template.findMappings(args.mappingTopLevelKey);
-        for (const env of environments) {
-          expect(
-            mappings[args.mappingTopLevelKey][env][args.mappingBottomLevelKey],
-          ).toStrictEqual(args.environmentFlags[env as keyof EnvironmentFlags]);
-          // Typescript needs you to strongly type the key if it's also used as a type
-        }
-      }
-
       const expectedEnvironmentVariablesValues = {
         dev: "https://events.review-b-async.dev.account.gov.uk",
         build: "https://events.review-b-async.build.account.gov.uk",
       };
 
-      validatePartialEnvironmentVariablesMapping({
+      const mappingHelper = new Mappings(template);
+      mappingHelper.validatePartialEnvironmentVariablesMapping({
         environmentFlags: expectedEnvironmentVariablesValues,
         mappingBottomLevelKey: "EventsBaseUrl",
       });

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -33,6 +33,58 @@ describe("Backend application infrastructure", () => {
       });
     });
 
+    test("Events base url is set", () => {
+      interface EnvironmentFlags {
+        dev: string | boolean | number;
+        build: string | boolean | number;
+        staging: string | boolean | number;
+        integration: string | boolean | number;
+        production: string | boolean | number;
+      }
+
+      const environments = [
+        "dev",
+        "build",
+        "staging",
+        "integration",
+        "production",
+      ];
+
+      function validatePartialEnvironmentVariablesMapping(args: {
+        environmentFlags: Partial<EnvironmentFlags>;
+        mappingBottomLevelKey: string;
+      }) {
+        validateMapping({
+          ...args,
+          mappingTopLevelKey: "EnvironmentVariables",
+        });
+      }
+
+      function validateMapping(args: {
+        environmentFlags: Partial<EnvironmentFlags>;
+        mappingTopLevelKey: string;
+        mappingBottomLevelKey: string;
+      }) {
+        const mappings = template.findMappings(args.mappingTopLevelKey);
+        for (const env of environments) {
+          expect(
+            mappings[args.mappingTopLevelKey][env][args.mappingBottomLevelKey],
+          ).toStrictEqual(args.environmentFlags[env as keyof EnvironmentFlags]);
+          // Typescript needs you to strongly type the key if it's also used as a type
+        }
+      }
+
+      const expectedEnvironmentVariablesValues = {
+        dev: "https://events.review-b-async.dev.account.gov.uk",
+        build: "https://events.review-b-async.build.account.gov.uk",
+      };
+
+      validatePartialEnvironmentVariablesMapping({
+        environmentFlags: expectedEnvironmentVariablesValues,
+        mappingBottomLevelKey: "EventsBaseUrl",
+      });
+    });
+
     test("ReadIdBaseUrl is the ReadID Proxy", () => {
       const expectedEnvironmentVariablesValues = {
         dev: "https://readid-proxy.review-b-async.dev.account.gov.uk/v2",

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -33,19 +33,6 @@ describe("Backend application infrastructure", () => {
       });
     });
 
-    test("Events base url is set", () => {
-      const expectedEnvironmentVariablesValues = {
-        dev: "https://events.review-b-async.dev.account.gov.uk",
-        build: "https://events.review-b-async.build.account.gov.uk",
-      };
-
-      const mappingHelper = new Mappings(template);
-      mappingHelper.validatePartialEnvironmentVariablesMapping({
-        environmentFlags: expectedEnvironmentVariablesValues,
-        mappingBottomLevelKey: "EventsBaseUrl",
-      });
-    });
-
     test("ReadIdBaseUrl is the ReadID Proxy", () => {
       const expectedEnvironmentVariablesValues = {
         dev: "https://readid-proxy.review-b-async.dev.account.gov.uk/v2",

--- a/backend-api/tests/infra-tests/helpers/mappings.ts
+++ b/backend-api/tests/infra-tests/helpers/mappings.ts
@@ -67,4 +67,28 @@ export class Mappings {
       // Typescript needs you to strongly type the key if it's also used as a type
     }
   }
+
+  validatePartialEnvironmentVariablesMapping(args: {
+    environmentFlags: Partial<EnvironmentFlags>;
+    mappingBottomLevelKey: string;
+  }) {
+    this.validateMappingPartialEnvironmentFlags({
+      ...args,
+      mappingTopLevelKey: "EnvironmentVariables",
+    });
+  }
+
+  private validateMappingPartialEnvironmentFlags(args: {
+    environmentFlags: Partial<EnvironmentFlags>;
+    mappingTopLevelKey: string;
+    mappingBottomLevelKey: string;
+  }) {
+    const mappings = this.template.findMappings(args.mappingTopLevelKey);
+    for (const env of this.environments) {
+      expect(
+        mappings[args.mappingTopLevelKey][env][args.mappingBottomLevelKey],
+      ).toStrictEqual(args.environmentFlags[env as keyof EnvironmentFlags]);
+      // Typescript needs you to strongly type the key if it's also used as a type
+    }
+  }
 }

--- a/helper-scripts/deploy_backend.sh
+++ b/helper-scripts/deploy_backend.sh
@@ -24,6 +24,7 @@ DEV_OVERRIDE_BACKEND_STACK_NAME="BackendStackName"
 DEV_OVERRIDE_PROXY_BASE_URL="DevOverrideProxyBaseUrl"
 DEV_OVERRIDE_SESSIONS_BASE_URL="DevOverrideSessionsBaseUrl"
 DEV_OVERRIDE_STS_BASE_URL="DevOverrideStsBaseUrl"
+DEV_OVERRIDE_EVENTS_BASE_URL="DevOverrideEventsBaseUrl"
 DEV_OVERRIDE_READID_PROXY_BASE_URL="DevOverrideReadIdBaseUrl"
 DEPLOY_ALARMS_IN_DEV="DeployAlarmsInDev"
 
@@ -32,6 +33,7 @@ ASYNC_DOMAIN="review-b-async.dev.account.gov.uk"
 PROXY_URL="https://proxy-${BACKEND_STACK_NAME}.${ASYNC_DOMAIN}"
 SESSIONS_URL="https://sessions-${BACKEND_STACK_NAME}.${ASYNC_DOMAIN}"
 STS_MOCK_URL="https://sts-${TEST_RESOURCES_STACK_NAME}.${ASYNC_DOMAIN}"
+EVENTS_URL="https://events-${TEST_RESOURCES_STACK_NAME}.${ASYNC_DOMAIN}"
 
 deploy_cf_dist=false
 deploy_backend_api_stack=false
@@ -39,6 +41,28 @@ enable_alarms=false
 deploy_test_resources=false
 publish_sts_mock_keys_to_s3=false
 overrideReadIdBaseUrl=false
+
+
+# Ask the user if they want to deploy the backend-cf-dist stack
+while true; do
+  echo
+  echo "Each backend stack requires a cloudfront distribution in front of it. The stack name is of the form ${BACKEND_STACK_NAME}-cf-dist. If it already exists this can be skipped."
+  read -r -p "Do you want to deploy a cloudfront distribution stack? [y/N]: " yn
+
+  case "$yn" in
+    [yY])
+      deploy_cf_dist=true
+      break
+      ;;
+    [nN] | "")
+      echo "Skipping cf-dist stack deployment"
+      break
+      ;;
+    *)
+      echo "Invalid input. Please enter 'y' or 'n'."
+      ;;
+  esac
+done
 
 # Ask the user about deploying test-resources
 while true; do
@@ -83,27 +107,6 @@ if [ $deploy_test_resources == true ]; then
     esac
   done
 fi
-
-# Ask the user if they want to deploy the backend-cf-dist stack
-while true; do
-  echo
-  echo "Each backend stack requires a cloudfront distribution in front of it. The stack name is of the form ${BACKEND_STACK_NAME}-cf-dist. If it already exists this can be skipped."
-  read -r -p "Do you want to deploy a cloudfront distribution stack? [y/N]: " yn
-
-  case "$yn" in
-    [yY])
-      deploy_cf_dist=true
-      break
-      ;;
-    [nN] | "")
-      echo "Skipping cf-dist stack deployment"
-      break
-      ;;
-    *)
-      echo "Invalid input. Please enter 'y' or 'n'."
-      ;;
-  esac
-done
 
 # Ask the user if they want to deploy backend-api
 while true; do
@@ -182,6 +185,7 @@ fi
 
 if [[ $deploy_backend_api_stack == true ]]; then
   parameter_overrides="${DEV_OVERRIDE_STS_BASE_URL}=${STS_MOCK_URL}"
+  parameter_overrides+=" ${DEV_OVERRIDE_EVENTS_BASE_URL}=${EVENTS_URL}"
 
   if [[ $enable_alarms == true ]]; then
       parameter_overrides+=" $DEPLOY_ALARMS_IN_DEV=true"
@@ -205,6 +209,8 @@ if [[ $deploy_backend_api_stack == true ]]; then
       --capabilities CAPABILITY_NAMED_IAM \
       --resolve-s3
 
+  aws cloudformation wait stack-create-complete --stack-name "${BACKEND_STACK_NAME}" || aws cloudformation wait stack-update-complete --stack-name "${BACKEND_STACK_NAME}"
+
   ./generate_env_file.sh "$STACK_IDENTIFIER"
   cd ../helper-scripts || exit
 fi
@@ -225,6 +231,8 @@ if [[ $deploy_test_resources == true ]]; then
       ${DEV_OVERRIDE_SESSIONS_BASE_URL}=${SESSIONS_URL}" \
     --capabilities CAPABILITY_NAMED_IAM \
     --resolve-s3
+
+  aws cloudformation wait stack-create-complete --stack-name "${TEST_RESOURCES_STACK_NAME}" || aws cloudformation wait stack-update-complete --stack-name "${TEST_RESOURCES_STACK_NAME}"
 
   npm run build:env $STACK_IDENTIFIER
   cd ../helper-scripts || exit


### PR DESCRIPTION
​DCMAW-11007

### What changed
- Adds TxMA event assertions to happy path API tests for:
  - POST /async/token
  - POST /async/biometricToken
- Adds test functions to the backend-api directory
  - `getEventsApiInstance()`
  - `pollForEvents()`
  - Function to check if an event was created in the last 60 seconds
- Adds Events API URL to the backend for testing
  - Adds Events env var to deploy and test scripts

### Evidence

##### If the function that checks an event's timestamp cannot find an event created in the last 60 seconds, an error is thrown:

<img width="1001" alt="Screenshot 2025-02-20 at 12 12 19" src="https://github.com/user-attachments/assets/fc78a173-82ea-4539-b976-87393b617dee" />