### PR TITLE
DCMAW-11113: Updates finishBiometricSession to write ASYNC_APP_END TxMA event

### DIFF
--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
@@ -63,7 +63,12 @@ describe("Async Finish Biometric Session", () => {
   const mockSessionUpdateSuccess = jest
     .fn()
     .mockResolvedValue(
-      successResult({ attributes: validBiometricSessionFinishedAttributes }),
+      successResult({
+        attributes: {
+          ...validBiometricSessionFinishedAttributes,
+          redirectUri: "www.mockRedirectUri.com",
+        },
+      }),
     );
 
   const mockSuccessfulSessionRegistry = {
@@ -598,7 +603,7 @@ describe("Async Finish Biometric Session", () => {
         govukSigninJourneyId: "mockGovukSigninJourneyId",
         componentId: "mockIssuer",
         transactionId: "f32432a9-0965-4da9-8a2c-a98a79349d4a",
-        redirect_uri: undefined,
+        redirect_uri: "www.mockRedirectUri.com",
         suspected_fraud_signal: undefined,
         getNowInMilliseconds: Date.now,
         ipAddress: "1.1.1.1",

--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
@@ -60,16 +60,14 @@ describe("Async Finish Biometric Session", () => {
     writeGenericEvent: mockWriteGenericEventFaiilure,
   };
 
-  const mockSessionUpdateSuccess = jest
-    .fn()
-    .mockResolvedValue(
-      successResult({
-        attributes: {
-          ...validBiometricSessionFinishedAttributes,
-          redirectUri: "www.mockRedirectUri.com",
-        },
-      }),
-    );
+  const mockSessionUpdateSuccess = jest.fn().mockResolvedValue(
+    successResult({
+      attributes: {
+        ...validBiometricSessionFinishedAttributes,
+        redirectUri: "www.mockRedirectUri.com",
+      },
+    }),
+  );
 
   const mockSuccessfulSessionRegistry = {
     ...mockInertSessionRegistry,

--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
@@ -518,7 +518,7 @@ describe("Async Finish Biometric Session", () => {
           componentId: "mockIssuer",
           getNowInMilliseconds: Date.now,
           govukSigninJourneyId: "mockGovukSigninJourneyId",
-          sessionId: "mockSessionId",
+          sessionId: mockSessionId,
           sub: "mockSubjectIdentifier",
           transactionId: mockBiometricSessionId,
           ipAddress: "1.1.1.1",
@@ -597,7 +597,7 @@ describe("Async Finish Biometric Session", () => {
       expect(mockWriteGenericEventSuccess).toBeCalledWith({
         eventName: "DCMAW_ASYNC_APP_END",
         sub: "mockSubjectIdentifier",
-        sessionId: "mockSessionId",
+        sessionId: mockSessionId,
         govukSigninJourneyId: "mockGovukSigninJourneyId",
         componentId: "mockIssuer",
         transactionId: "f32432a9-0965-4da9-8a2c-a98a79349d4a",

--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.ts
@@ -83,6 +83,8 @@ export async function lambdaHandlerConstructor(
     biometricSessionId,
     sessionId,
   };
+  const sessionAttributes = updateResult.value
+    .attributes as BiometricSessionFinishedAttributes;
 
   const sendMessageToVendorProcessingQueueResult = await sendMessageToSqs(
     config.VENDOR_PROCESSING_SQS,
@@ -90,17 +92,13 @@ export async function lambdaHandlerConstructor(
   );
   if (sendMessageToVendorProcessingQueueResult.isError) {
     return await handleSendMessageToVendorProcessingQueueFailure(eventService, {
-      sessionAttributes: updateResult.value
-        .attributes as BiometricSessionFinishedAttributes,
+      sessionAttributes,
       issuer: config.ISSUER,
       biometricSessionId,
       ipAddress,
       txmaAuditEncoded,
     });
   }
-
-  const sessionAttributes = updateResult.value
-    .attributes as BiometricSessionFinishedAttributes;
 
   const writeAppEndEventResult = await eventService.writeGenericEvent({
     eventName: "DCMAW_ASYNC_APP_END",

--- a/backend-api/src/functions/services/events/tests/eventService.test.ts
+++ b/backend-api/src/functions/services/events/tests/eventService.test.ts
@@ -28,6 +28,7 @@ describe("Event Service", () => {
     "DCMAW_ASYNC_CRI_START",
     "DCMAW_ASYNC_CRI_4XXERROR",
     "DCMAW_ASYNC_CRI_5XXERROR",
+    "DCMAW_ASYNC_APP_END",
   ])("Writing generic TxMA events to SQS", (genericEventName) => {
     describe(`Given writing ${genericEventName} event to SQS fails`, () => {
       beforeEach(async () => {

--- a/backend-api/src/functions/services/events/types.ts
+++ b/backend-api/src/functions/services/events/types.ts
@@ -48,7 +48,8 @@ export interface BaseUserTxmaEvent extends BaseTxmaEvent {
 export type GenericEventNames =
   | "DCMAW_ASYNC_CRI_START"
   | "DCMAW_ASYNC_CRI_4XXERROR"
-  | "DCMAW_ASYNC_CRI_5XXERROR";
+  | "DCMAW_ASYNC_CRI_5XXERROR"
+  | "DCMAW_ASYNC_APP_END";
 
 export type EventNames =
   | GenericEventNames

--- a/backend-api/src/functions/testUtils/unitTestData.ts
+++ b/backend-api/src/functions/testUtils/unitTestData.ts
@@ -39,7 +39,7 @@ export const validBaseSessionAttributes = {
   govukSigninJourneyId: "mockGovukSigninJourneyId",
   createdAt: 12345,
   issuer: "mockIssuer",
-  sessionId: "mockSessionId",
+  sessionId: mockSessionId,
   sessionState: SessionState.AUTH_SESSION_CREATED,
   clientState: "mockClientState",
   subjectIdentifier: "mockSubjectIdentifier",

--- a/test-resources/src/functions/dequeue/getEvent.ts
+++ b/test-resources/src/functions/dequeue/getEvent.ts
@@ -63,6 +63,7 @@ export const allowedTxmaEventNames = [
   "DCMAW_ASYNC_CRI_4XXERROR",
   "DCMAW_ASYNC_CRI_5XXERROR",
   "DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED",
+  "DCMAW_ASYNC_APP_END",
 ];
 
 const allowedTxmaEventNamesWithoutSessionId = [


### PR DESCRIPTION
## ​DCMAW-11113

### What changed

- Writes `DCMAW_ASYNC_APP_END` in `async/finishBiometricSession` when request received with valid session information
- If event fails to write, return `500 Internal server error` response
- Adds `DCMAW_ASYNC_APP_END` event to dequeue lambda `getEvents` list so it can be picked up and API tested (see below re the API test)

### What didn't change

- I have not added an API test for this change as we are covering the happy path API under this ticket. This requirement has been split into a different ticket as we want to have a dev discussion re the shape of this happy with API test.

### Approach

You'll see I haven't used a helper function in this lambda for this event. My thinking was the two main things this lambda does is write the vendor processing message, and write the app end event, therefore I don't mind having these two things very clearly laid out in the lambda without handler functions. I am happy to discuss this and change if you feel any helper functions would provide value here.

### Why did it change

Auditing purposes

## Evidence

### Automated

Deployed and ran API tests - all passing

### Manual

As there is no happy path API test for this endpoint, the API tests will not currently trigger this event so I did it manually.

<img width="1270" alt="Screenshot 2025-03-10 at 11 11 39" src="https://github.com/user-attachments/assets/4d967227-3116-4d90-9f4f-d5ec708c1f56" />

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
