### PR TITLE
DCMAW-11115: Updates finishBiometricSession to return 200 OK response

### DIFF
--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.test.ts
@@ -539,7 +539,7 @@ describe("Async Finish Biometric Session", () => {
     });
   });
 
-  describe("Given a valid request is made", () => {
+  describe("Given a request containing a valid sessionId is made", () => {
     beforeEach(async () => {
       result = await lambdaHandlerConstructor(
         dependencies,
@@ -615,11 +615,11 @@ describe("Async Finish Biometric Session", () => {
       });
     });
 
-    it("Returns 501 Not Implemented response", async () => {
+    it("Returns 200 OK response", async () => {
       expect(result).toStrictEqual({
         headers: expectedSecurityHeaders,
-        statusCode: 501,
-        body: JSON.stringify({ error: "Not Implemented" }),
+        statusCode: 200,
+        body: "",
       });
     });
   });

--- a/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.ts
+++ b/backend-api/src/functions/asyncFinishBiometricSession/asyncFinishBiometricSessionHandler.ts
@@ -6,7 +6,7 @@ import {
 import {
   badRequestResponse,
   forbiddenResponse,
-  notImplementedResponse,
+  okResponse,
   serverErrorResponse,
   unauthorizedResponse,
 } from "../common/lambdaResponses";
@@ -123,7 +123,7 @@ export async function lambdaHandlerConstructor(
   }
 
   logger.info(LogMessage.FINISH_BIOMETRIC_SESSION_COMPLETED);
-  return notImplementedResponse;
+  return okResponse();
 }
 
 async function handleConditionalCheckFailure(

--- a/backend-api/src/functions/common/lambdaResponses.ts
+++ b/backend-api/src/functions/common/lambdaResponses.ts
@@ -8,11 +8,11 @@ const securityHeaders = {
   "X-Frame-Options": "DENY",
 };
 
-export const okResponse = (body: object): APIGatewayProxyResult => {
+export const okResponse = (body?: object): APIGatewayProxyResult => {
   return {
     headers: securityHeaders,
     statusCode: 200,
-    body: JSON.stringify(body),
+    body: body ? JSON.stringify(body) : "",
   };
 };
 

--- a/backend-api/tests/api-tests/biometricToken.test.ts
+++ b/backend-api/tests/api-tests/biometricToken.test.ts
@@ -4,10 +4,11 @@ import "../../tests/testUtils/matchers";
 import { SESSIONS_API_INSTANCE } from "./utils/apiInstance";
 import { expectedSecurityHeaders, mockSessionId } from "./utils/apiTestData";
 import {
-  EventResponse,
-  getValidSessionId,
+  createSessionForSub,
+  getActiveSessionIdFromSub,
   pollForEvents,
 } from "./utils/apiTestHelpers";
+import { randomUUID } from "crypto";
 
 describe("POST /async/biometricToken", () => {
   describe("Given request body is invalid", () => {
@@ -78,15 +79,13 @@ describe("POST /async/biometricToken", () => {
   });
 
   describe("Given the session is not in a valid state", () => {
-    let sessionId: string | null;
+    let sessionId: string;
     let biometricTokenResponse: AxiosResponse;
 
     beforeAll(async () => {
-      sessionId = await getValidSessionId();
-      if (!sessionId)
-        throw new Error(
-          "Failed to get valid session ID to call biometricToken endpoint",
-        );
+      const sub = randomUUID();
+      await createSessionForSub(sub);
+      sessionId = await getActiveSessionIdFromSub(sub);
 
       const requestBody = {
         sessionId,
@@ -133,11 +132,9 @@ describe("POST /async/biometricToken", () => {
     let biometricTokenResponse: AxiosResponse;
 
     beforeAll(async () => {
-      sessionId = await getValidSessionId();
-      if (!sessionId)
-        throw new Error(
-          "Failed to get valid session ID to call biometricToken endpoint",
-        );
+      const sub = randomUUID();
+      await createSessionForSub(sub);
+      sessionId = await getActiveSessionIdFromSub(sub);
 
       const requestBody = {
         sessionId,

--- a/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
+++ b/backend-api/tests/api-tests/clientCredentialsGrantFlow.test.ts
@@ -4,9 +4,8 @@ import "dotenv/config";
 import { PRIVATE_API_INSTANCE, PROXY_API_INSTANCE } from "./utils/apiInstance";
 import {
   ClientDetails,
-  EventResponse,
-  getActiveSessionIdFromSub,
   getFirstRegisteredClient,
+  getActiveSessionIdFromSub,
   pollForEvents,
 } from "./utils/apiTestHelpers";
 

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -6,8 +6,10 @@ import {
   expectedSecurityHeaders,
 } from "./utils/apiTestData";
 import {
+  createSessionForSub,
   EventResponse,
-  getValidSessionId,
+  getSessionId,
+  issueBiometricToken,
   pollForEvents,
 } from "./utils/apiTestHelpers";
 import { AxiosResponse } from "axios";
@@ -58,20 +60,14 @@ describe("POST /async/finishBiometricSession", () => {
   });
 
   describe("Given there is a valid request", () => {
-    let sessionId: string | null;
+    let sessionId: string;
     let response: AxiosResponse;
     let eventsResponse: EventResponse[];
     beforeAll(async () => {
-      sessionId = await getValidSessionId();
-      if (!sessionId)
-        throw new Error(
-          "Failed to get valid session ID to call biometricToken endpoint",
-        );
-      const requestBody = {
-        sessionId,
-        documentType: "NFC_PASSPORT",
-      };
-      await SESSIONS_API_INSTANCE.post("/async/biometricToken", requestBody);
+      const sub = randomUUID();
+      await createSessionForSub(sub);
+      sessionId = await getSessionId(sub);
+      await issueBiometricToken(sessionId);
 
       response = await SESSIONS_API_INSTANCE.post(
         "/async/finishBiometricSession",

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -2,8 +2,8 @@ import { randomUUID } from "crypto";
 import { SESSIONS_API_INSTANCE } from "./utils/apiInstance";
 import {
   mockBiometricSessionId,
-  mockSessionId,
   expectedSecurityHeaders,
+  mockSessionId,
 } from "./utils/apiTestData";
 import {
   createSessionForSub,
@@ -16,20 +16,22 @@ import { AxiosResponse } from "axios";
 
 describe("POST /async/finishBiometricSession", () => {
   describe("Given the request body is invalid", () => {
-    it("Returns an error and 400 status code", async () => {
-      const mockInvalidSessionId = "invalidSessionId";
-      const response = await SESSIONS_API_INSTANCE.post(
+    let response: AxiosResponse;
+    const invalidSessionId = "invalidSessionId";
+    beforeAll(async () => {
+      response = await SESSIONS_API_INSTANCE.post(
         "/async/finishBiometricSession",
         {
-          sessionId: mockInvalidSessionId,
+          sessionId: "invalidSessionId",
           biometricSessionId: mockBiometricSessionId,
         },
       );
-
+    });
+    it("Returns 400 invalid request response", async () => {
       expect(response.status).toBe(400);
       expect(response.data).toStrictEqual({
         error: "invalid_request",
-        error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${mockInvalidSessionId}`,
+        error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${invalidSessionId}`,
       });
       expect(response.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),
@@ -38,16 +40,19 @@ describe("POST /async/finishBiometricSession", () => {
   });
 
   describe("Given the session does not exist", () => {
-    it("Returns an error and 401 status code", async () => {
-      const nonExistentSessionId = mockSessionId;
-      const response = await SESSIONS_API_INSTANCE.post(
+    let response: AxiosResponse;
+    const nonExistentSessionId = mockSessionId;
+    beforeAll(async () => {
+      response = await SESSIONS_API_INSTANCE.post(
         "/async/finishBiometricSession",
         {
           sessionId: nonExistentSessionId,
           biometricSessionId: mockBiometricSessionId,
         },
       );
+    });
 
+    it("Returns 401 invalid session response", () => {
       expect(response.status).toBe(401);
       expect(response.data).toStrictEqual({
         error: "invalid_session",

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -8,7 +8,7 @@ import {
 import {
   createSessionForSub,
   EventResponse,
-  getSessionId,
+  getActiveSessionIdFromSub,
   issueBiometricToken,
   pollForEvents,
 } from "./utils/apiTestHelpers";
@@ -71,7 +71,7 @@ describe("POST /async/finishBiometricSession", () => {
     beforeAll(async () => {
       const sub = randomUUID();
       await createSessionForSub(sub);
-      sessionId = await getSessionId(sub);
+      sessionId = await getActiveSessionIdFromSub(sub);
       await issueBiometricToken(sessionId);
 
       response = await SESSIONS_API_INSTANCE.post(

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -27,6 +27,7 @@ describe("POST /async/finishBiometricSession", () => {
         },
       );
     });
+
     it("Returns 400 invalid request response", async () => {
       expect(response.status).toBe(400);
       expect(response.data).toStrictEqual({

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -17,12 +17,12 @@ import { AxiosResponse } from "axios";
 describe("POST /async/finishBiometricSession", () => {
   describe("Given the request body is invalid", () => {
     let response: AxiosResponse;
-    const invalidSessionId = "invalidSessionId";
+    const mockInvalidSessionId = "invalidSessionId";
     beforeAll(async () => {
       response = await SESSIONS_API_INSTANCE.post(
         "/async/finishBiometricSession",
         {
-          sessionId: invalidSessionId,
+          sessionId: mockInvalidSessionId,
           biometricSessionId: mockBiometricSessionId,
         },
       );
@@ -33,7 +33,7 @@ describe("POST /async/finishBiometricSession", () => {
       expect(response.statusText).toBe("Bad Request");
       expect(response.data).toStrictEqual({
         error: "invalid_request",
-        error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${invalidSessionId}`,
+        error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${mockInvalidSessionId}`,
       });
       expect(response.headers).toEqual(
         expect.objectContaining(expectedSecurityHeaders),

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -28,8 +28,9 @@ describe("POST /async/finishBiometricSession", () => {
       );
     });
 
-    it("Returns 400 invalid request response", async () => {
+    it("Returns 400 Bad Request response with invalid_request error", async () => {
       expect(response.status).toBe(400);
+      expect(response.statusText).toBe("Bad Request")
       expect(response.data).toStrictEqual({
         error: "invalid_request",
         error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${invalidSessionId}`,
@@ -53,8 +54,9 @@ describe("POST /async/finishBiometricSession", () => {
       );
     });
 
-    it("Returns 401 invalid session response", () => {
+    it("Returns 401 Unauthorized response with invalid_session error", () => {
       expect(response.status).toBe(401);
+      expect(response.statusText).toBe("Unauthorized")
       expect(response.data).toStrictEqual({
         error: "invalid_session",
         error_description: "Session not found",

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -30,7 +30,7 @@ describe("POST /async/finishBiometricSession", () => {
 
     it("Returns 400 Bad Request response with invalid_request error", async () => {
       expect(response.status).toBe(400);
-      expect(response.statusText).toBe("Bad Request")
+      expect(response.statusText).toBe("Bad Request");
       expect(response.data).toStrictEqual({
         error: "invalid_request",
         error_description: `sessionId in request body is not a valid v4 UUID. sessionId: ${invalidSessionId}`,
@@ -56,7 +56,7 @@ describe("POST /async/finishBiometricSession", () => {
 
     it("Returns 401 Unauthorized response with invalid_session error", () => {
       expect(response.status).toBe(401);
-      expect(response.statusText).toBe("Unauthorized")
+      expect(response.statusText).toBe("Unauthorized");
       expect(response.data).toStrictEqual({
         error: "invalid_session",
         error_description: "Session not found",

--- a/backend-api/tests/api-tests/finishBiometricSession.test.ts
+++ b/backend-api/tests/api-tests/finishBiometricSession.test.ts
@@ -22,7 +22,7 @@ describe("POST /async/finishBiometricSession", () => {
       response = await SESSIONS_API_INSTANCE.post(
         "/async/finishBiometricSession",
         {
-          sessionId: "invalidSessionId",
+          sessionId: invalidSessionId,
           biometricSessionId: mockBiometricSessionId,
         },
       );

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -104,6 +104,35 @@ export async function getValidSessionId(): Promise<string | null> {
   return activeSessionResponse.data["sessionId"] ?? null;
 }
 
+export const getSessionId = async (sub: string): Promise<string> => {
+  const serviceToken = await getAccessToken(sub);
+  const activeSessionResponse = await SESSIONS_API_INSTANCE.get(
+    "/async/activeSession",
+    {
+      headers: { Authorization: `Bearer ${serviceToken}` },
+    },
+  );
+
+  const sessionId = activeSessionResponse.data["sessionId"];
+
+  if (!sessionId) {
+    throw new Error(
+      "Failed to get valid session ID to call activeSession endpoint",
+    );
+  }
+
+  return sessionId;
+};
+
+export async function issueBiometricToken(sessionId: string): Promise<void> {
+  const requestBody = {
+    sessionId,
+    documentType: "NFC_PASSPORT",
+  };
+
+  await SESSIONS_API_INSTANCE.post("/async/biometricToken", requestBody);
+}
+
 export type EventResponse = {
   pk: string;
   sk: string;

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -116,7 +116,7 @@ export const getSessionId = async (sub: string): Promise<string> => {
   const sessionId = activeSessionResponse.data["sessionId"];
   if (!sessionId) {
     throw new Error(
-      "Failed to get valid session ID to call activeSession endpoint",
+      "Failed to get valid session ID in call activeSession endpoint",
     );
   }
 

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -114,7 +114,6 @@ export const getSessionId = async (sub: string): Promise<string> => {
   );
 
   const sessionId = activeSessionResponse.data["sessionId"];
-
   if (!sessionId) {
     throw new Error(
       "Failed to get valid session ID to call activeSession endpoint",

--- a/backend-api/tests/api-tests/utils/apiTestHelpers.ts
+++ b/backend-api/tests/api-tests/utils/apiTestHelpers.ts
@@ -123,14 +123,14 @@ export const getSessionId = async (sub: string): Promise<string> => {
   return sessionId;
 };
 
-export async function issueBiometricToken(sessionId: string): Promise<void> {
+export const issueBiometricToken = async (sessionId: string): Promise<void> => {
   const requestBody = {
     sessionId,
     documentType: "NFC_PASSPORT",
   };
 
   await SESSIONS_API_INSTANCE.post("/async/biometricToken", requestBody);
-}
+};
 
 export type EventResponse = {
   pk: string;


### PR DESCRIPTION
## DCMAW-11115

### What changed

- Updates `finishBiometricSession` to return `200 OK` response
- Updates `okResponse` function to cater for when the `response` `body` is empty
- Adds API test for `200` response, including assertion on the `DCMAW_ASYNC_APP_END` TxMA event
- API test helpers
  - Removes duplication in API test helpers that got a `sessionId`
  - Regarding the `sessionId` methods, the main one used was doing too much as it was creating a session with a sub and returning a sessionId, I have made it so a test will use a bespoke function for each step so it is clearer. 
  - Updated biometricToken api tests to use new helper functions where appropriate
- Minor structural updates to finishBiometricSession API tests (beforeAll() and then only assertions in the it which is the pattern we are currently using)

### Why did it change

Ongoing work to develop the `finishBiometricSession` lambda.

## When reviewing

Sandy wanted us as a team to discuss the API test approach regarding the API helper functions. 

He brought particular attention to the `getValidSessionId` function as something we might want to change. We have not been able to have this conversation as a dev team so I would ask that you specifically think about the API helper functions when reviewing. Do they make sense to you? Is the naming ok? Any changes/additions you would make? Are they used how you'd expect?

## Evidence

### Automated

Deployed stack and ran API tests - all passing

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

- [x] There is a ticket raised for this PR that is present in the branch name
- [x] No PII data logged. [See guidance here](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3502407722/PII+Logging+Considerations)
- [ ] Demo to a BA, TA, and the team.
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
