### PR TITLE
[DCMAW-11339] SQS queue and DLQ alarms (#478)

### DIFF
--- a/backend-api/infra/monitoring/sqsAlarms.yaml
+++ b/backend-api/infra/monitoring/sqsAlarms.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  VendorProcessingSqsOldMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "Trigger an alarm when the age of the oldest message in Vendor Processing SQS queue is 30 minutes or older. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-low-threshold-vendor-processing-sqs-old-message"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Threshold: 1800
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingSQS.QueueName
+
+  VendorProcessingDlqNewMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "Trigger an alarm when new message gets added to Vendor Processing SQS DLQ. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-low-threshold-vendor-processing-dlq-new-message"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Threshold: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName
+
+  VendorProcessingDlqOldMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "Trigger an alarm when the age of the oldest message in Vendor Processing SQS DLQ is 3 days or older. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-low-threshold-vendor-processing-dlq-old-message"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Threshold: 259200
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName
+
+  VendorProcessingDlqOldMessageHighThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmDescription: !Sub
+        - "Trigger an alarm when the age of the oldest message in Vendor Processing SQS DLQ is 10 days or older. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [StaticVariables, urls, WarningAlarmsRunbook]
+      AlarmName: !Sub "${AWS::StackName}-high-threshold-vendor-processing-dlq-old-message"
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Threshold: 864000
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName

--- a/backend-api/infra/queue/vendorProcessing.yaml
+++ b/backend-api/infra/queue/vendorProcessing.yaml
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600
-      KmsMasterKeyId: !Sub VendorProcessingKMSEncryptionKey
+      KmsMasterKeyId: !Ref VendorProcessingKeyAlias
 
   VendorProcessingKMSEncryptionKey:
     Type: AWS::KMS::Key

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -3990,8 +3990,95 @@ Resources:
   VendorProcessingDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      KmsMasterKeyId: !Sub VendorProcessingKMSEncryptionKey
+      KmsMasterKeyId: !Ref VendorProcessingKeyAlias
       MessageRetentionPeriod: 1209600
+
+  VendorProcessingDlqNewMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Trigger an alarm when new message gets added to Vendor Processing SQS DLQ. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-low-threshold-vendor-processing-dlq-new-message
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Period: 60
+      Statistic: Maximum
+      Threshold: 1
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
+
+  VendorProcessingDlqOldMessageHighThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Trigger an alarm when the age of the oldest message in Vendor Processing SQS DLQ is 10 days or older. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-high-threshold-vendor-processing-dlq-old-message
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Period: 60
+      Statistic: Maximum
+      Threshold: 864000
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
+
+  VendorProcessingDlqOldMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Trigger an alarm when the age of the oldest message in Vendor Processing SQS DLQ is 3 days or older. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-low-threshold-vendor-processing-dlq-old-message
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingDLQ.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Period: 60
+      Statistic: Maximum
+      Threshold: 259200
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
 
   VendorProcessingKMSEncryptionKey:
     Type: AWS::KMS::Key
@@ -4034,6 +4121,35 @@ Resources:
         deadLetterTargetArn: !GetAtt VendorProcessingDLQ.Arn
         maxReceiveCount: 360
       VisibilityTimeout: 10
+
+  VendorProcessingSqsOldMessageLowThresholdAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Trigger an alarm when the age of the oldest message in Vendor Processing SQS queue is 30 minutes or older. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-low-threshold-vendor-processing-sqs-old-message
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt VendorProcessingSQS.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Period: 60
+      Statistic: Maximum
+      Threshold: 1800
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
 
   WellKnown5XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -220,6 +220,7 @@ describe("Backend application infrastructure", () => {
         "high-threshold-async-biometric-token-4xx-api-gw": false,
         "high-threshold-async-finish-biometric-session-5xx-api-gw": false,
         "high-threshold-async-finish-biometric-session-4xx-api-gw": false,
+        "high-threshold-vendor-processing-dlq-old-message": false,
       };
 
       const alarms = template.findResources("AWS::CloudWatch::Alarm");
@@ -288,6 +289,10 @@ describe("Backend application infrastructure", () => {
         ["credential-lambda-low-completion"],
         ["active-session-lambda-error-rate"],
         ["active-session-lambda-low-completion"],
+        ["low-threshold-vendor-processing-sqs-old-message"],
+        ["low-threshold-vendor-processing-dlq-new-message"],
+        ["low-threshold-vendor-processing-dlq-old-message"],
+        ["high-threshold-vendor-processing-dlq-old-message"],
       ])(
         "The %s alarm is configured to send an event to the warnings SNS topic on Alarm and OK actions",
         (alarmName: string) => {


### PR DESCRIPTION
​[DCMAW-11501](https://govukverify.atlassian.net/browse/DCMAW-11501)

What changed
Set up Subscription Filters to forward logs to CSLS in Build and above environments.
Subscription Filters will deploy in Dev and Build for proxy resources.
Add a test to check that all Cloudwatch log groups have an associated filter.

[DCMAW-11501]: https://govukverify.atlassian.net/browse/DCMAW-11501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ