### PR TITLE
[DCMAW-11501] Set up CSLS logging 

### DIFF
--- a/backend-api/infra/api/private.yaml
+++ b/backend-api/infra/api/private.yaml
@@ -29,7 +29,7 @@ Resources:
       StageName: !Ref Environment
       OpenApiVersion: 3.0.1
       AccessLogSetting:
-        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncCredentialPrivateApiAccessLogs}
+        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncPrivateApiAccessLogs}
         Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
       MethodSettings:
         - LoggingLevel: INFO
@@ -51,8 +51,17 @@ Resources:
           Parameters:
             Location: ./openApiSpecs/async-private-spec.yaml
 
-  AsyncCredentialPrivateApiAccessLogs:
+  AsyncPrivateApiAccessLogs:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs-v2
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs
       RetentionInDays: 30
+
+  AsyncPrivateApiSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncPrivateApiAccessLogs
+    Condition: isNotDev

--- a/backend-api/infra/api/proxy.yaml
+++ b/backend-api/infra/api/proxy.yaml
@@ -42,6 +42,15 @@ Resources:
       RetentionInDays: 30
     Condition: ProxyApiDeployment
 
+  ProxyApiSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter    
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref ProxyApiAccessLogs
+    Condition: DeployProxyCsls
+    
   ProxyApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:

--- a/backend-api/infra/api/sessions.yaml
+++ b/backend-api/infra/api/sessions.yaml
@@ -39,6 +39,15 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-sessions-api-access-logs
       RetentionInDays: 30
 
+  SessionsApiSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref SessionsApiAccessLogs
+    Condition: isNotDev
+
   SessionsApiDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:

--- a/backend-api/infra/functions/activeSession.yaml
+++ b/backend-api/infra/functions/activeSession.yaml
@@ -63,6 +63,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-active-session
 
+  AsyncActiveSessionSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncActiveSessionLogGroup
+    Condition: isNotDev
+
   AsyncActiveSessionLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/backend-api/infra/functions/biometricToken.yaml
+++ b/backend-api/infra/functions/biometricToken.yaml
@@ -65,6 +65,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-biometric-token
 
+  AsyncBiometricTokenSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncBiometricTokenLogGroup
+    Condition: isNotDev
+
   AsyncBiometricTokenLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/backend-api/infra/functions/credential.yaml
+++ b/backend-api/infra/functions/credential.yaml
@@ -42,6 +42,15 @@ Resources:
     Properties:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-credential
+    
+  AsyncCredentialSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncCredentialLogGroup
+    Condition: isNotDev
 
   AsyncCredentialFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/backend-api/infra/functions/finishBiometricSession.yaml
+++ b/backend-api/infra/functions/finishBiometricSession.yaml
@@ -55,6 +55,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-finish-biometric-session
 
+  AsyncFinishBiometricSessionSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncFinishBiometricSessionLogGroup
+    Condition: isNotDev
+
   AsyncFinishBiometricSessionLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/backend-api/infra/functions/jwks.yaml
+++ b/backend-api/infra/functions/jwks.yaml
@@ -93,6 +93,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-jwks
 
+  JsonWebKeysFunctionSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref JsonWebKeysFunctionLogGroup
+    Condition: isNotDev
+
   JsonWebKeysCustomResource:
     Type: AWS::CloudFormation::CustomResource
     Properties:

--- a/backend-api/infra/functions/proxy.yaml
+++ b/backend-api/infra/functions/proxy.yaml
@@ -36,6 +36,15 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-proxy-lambda
     Condition: ProxyApiDeployment
 
+  ProxyLambdaSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref ProxyLambdaLogGroup
+    Condition: DeployProxyCsls
+
   ProxyLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/backend-api/infra/functions/token.yaml
+++ b/backend-api/infra/functions/token.yaml
@@ -51,6 +51,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-token
 
+  AsyncTokenSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncTokenLogGroup
+    Condition: isNotDev
+
   AsyncTokenLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/backend-api/infra/functions/txmaEvent.yaml
+++ b/backend-api/infra/functions/txmaEvent.yaml
@@ -39,6 +39,15 @@ Resources:
       RetentionInDays: 30
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-txma-event
 
+  AsyncTxmaEventSubscriptionFilter:    
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: 
+        !FindInMap [CslsConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncTxmaEventLogGroup
+    Condition: isNotDev
+
   AsyncTxmaEventFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:

--- a/backend-api/infra/parent.yaml
+++ b/backend-api/infra/parent.yaml
@@ -185,6 +185,16 @@ Mappings:
     production:
       BaseDns: review-b-async.account.gov.uk
 
+  CslsConfiguration:    
+    build:      
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    staging:      
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    integration:      
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    production:     
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+
   EnvironmentVariables:
     dev:
       STSBASEURL: 'https://sts-mock.review-b-async.dev.account.gov.uk'
@@ -248,6 +258,9 @@ Conditions:
       - !Ref Environment
       - dev
 
+  isNotDev: 
+    !Not [!Equals [!Ref Environment, dev]]
+
   isNotDevOrBuild: !Or
     - !Equals
       - !Ref Environment
@@ -305,6 +318,10 @@ Conditions:
       - !Ref Environment
       - staging
 
+  DeployProxyCsls: !And
+    - Condition: ProxyApiDeployment
+    - Condition: isNotDev
+    
 # This condition is in place so that we can add a resource to this parent.yaml template that is never deployed.
   NeverDeploy: !Equals
     - !Ref SamValidateLintWorkaround

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -59,6 +59,16 @@ Parameters:
     Default: unused
 
 Mappings:
+  CslsConfiguration:
+    build:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    integration:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    production:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+    staging:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+
   DNS:
     build:
       BaseDns: review-b-async.build.account.gov.uk
@@ -239,6 +249,10 @@ Conditions:
       - !Ref DeployAlarmsInDev
       - true
 
+  DeployProxyCsls: !And
+    - !Condition ProxyApiDeployment
+    - !Condition isNotDev
+
   DevelopmentStack: !And
     - !Equals
       - !Ref Environment
@@ -300,6 +314,11 @@ Conditions:
   isDev: !Equals
     - !Ref Environment
     - dev
+
+  isNotDev: !Not
+    - !Equals
+      - !Ref Environment
+      - dev
 
   isNotDevOrBuild: !Or
     - !Equals
@@ -923,6 +942,17 @@ Resources:
       TreatMissingData: notBreaching
     Condition: DeployAlarms
 
+  AsyncActiveSessionSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncActiveSessionLogGroup
+    Condition: isNotDev
+
   AsyncBiometricToken4XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1481,6 +1511,17 @@ Resources:
       TreatMissingData: notBreaching
     Condition: DeployAlarms
 
+  AsyncBiometricTokenSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncBiometricTokenLogGroup
+    Condition: isNotDev
+
   AsyncCredential4XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -2027,11 +2068,16 @@ Resources:
       TreatMissingData: notBreaching
     Condition: DeployAlarms
 
-  AsyncCredentialPrivateApiAccessLogs:
-    Type: AWS::Logs::LogGroup
+  AsyncCredentialSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs-v2
-      RetentionInDays: 30
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncCredentialLogGroup
+    Condition: isNotDev
 
   AsyncFinishBiometricSession4XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2552,6 +2598,34 @@ Resources:
       Threshold: 60
       TreatMissingData: notBreaching
     Condition: DeployAlarms
+
+  AsyncFinishBiometricSessionSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncFinishBiometricSessionLogGroup
+    Condition: isNotDev
+
+  AsyncPrivateApiAccessLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-private-api-access-logs
+      RetentionInDays: 30
+
+  AsyncPrivateApiSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncPrivateApiAccessLogs
+    Condition: isNotDev
 
   AsyncToken4XXHighThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -3075,6 +3149,17 @@ Resources:
       TreatMissingData: notBreaching
     Condition: DeployAlarms
 
+  AsyncTokenSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncTokenLogGroup
+    Condition: isNotDev
+
   AsyncTxmaEventFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -3158,6 +3243,17 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-txma-event
       RetentionInDays: 30
+
+  AsyncTxmaEventSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref AsyncTxmaEventLogGroup
+    Condition: isNotDev
 
   CodeDeployServiceRole:
     Type: AWS::IAM::Role
@@ -3392,6 +3488,17 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-jwks
       RetentionInDays: 30
 
+  JsonWebKeysFunctionSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref JsonWebKeysFunctionLogGroup
+    Condition: isNotDev
+
   KMSEncryptionKey:
     Type: AWS::KMS::Key
     Properties:
@@ -3470,7 +3577,7 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       AccessLogSetting:
-        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncCredentialPrivateApiAccessLogs}
+        DestinationArn: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncPrivateApiAccessLogs}
         Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
       AlwaysDeploy: true
       Auth:
@@ -3632,6 +3739,17 @@ Resources:
       Type: A
     Condition: ProxyApiDeployment
 
+  ProxyApiSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref ProxyApiAccessLogs
+    Condition: DeployProxyCsls
+
   ProxyLambda:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -3729,6 +3847,17 @@ Resources:
           ToPort: 443
       VpcId: !ImportValue devplatform-vpc-VpcId
     Condition: ProxyApiDeployment
+
+  ProxyLambdaSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref ProxyLambdaLogGroup
+    Condition: DeployProxyCsls
 
   SessionsApi:
     Type: AWS::Serverless::Api
@@ -3862,6 +3991,17 @@ Resources:
               - !Ref Environment
               - BaseDns
       Type: A
+
+  SessionsApiSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !FindInMap
+        - CslsConfiguration
+        - !Ref Environment
+        - CSLSEGRESS
+      FilterPattern: ""
+      LogGroupName: !Ref SessionsApiAccessLogs
+    Condition: isNotDev
 
   SessionsApiWebAclAssociation:
     Type: AWS::WAFv2::WebACLAssociation

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -187,7 +187,7 @@ describe("Backend application infrastructure", () => {
         AccessLogSetting: {
           DestinationArn: {
             "Fn::Sub":
-              "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncCredentialPrivateApiAccessLogs}",
+              "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AsyncPrivateApiAccessLogs}",
           },
         },
       });
@@ -198,7 +198,7 @@ describe("Backend application infrastructure", () => {
         RetentionInDays: 30,
         LogGroupName: {
           "Fn::Sub":
-            "/aws/apigateway/${AWS::StackName}-private-api-access-logs-v2",
+            "/aws/apigateway/${AWS::StackName}-private-api-access-logs",
         },
       });
     });
@@ -680,6 +680,24 @@ describe("Backend application infrastructure", () => {
         };
         template.hasResourceProperties("AWS::Logs::LogGroup", {
           LogGroupName: Match.objectLike(expectedLogName),
+        });
+      });
+    });
+
+    test("All log groups have a CSLS subscription filter", () => {
+      const log_groups = template.findResources("AWS::Logs::LogGroup");
+      const logs_list = Object.keys(log_groups);
+      console.log(logs_list);
+      logs_list.forEach((log_name) => {
+        template.hasResourceProperties("AWS::Logs::SubscriptionFilter", {
+          LogGroupName: Match.objectLike({ Ref: log_name }),
+          DestinationArn: Match.objectLike({
+            "Fn::FindInMap": [
+              "CslsConfiguration",
+              { Ref: "Environment" },
+              "CSLSEGRESS",
+            ],
+          }),
         });
       });
     });


### PR DESCRIPTION
​[DCMAW-11501](https://govukverify.atlassian.net/browse/DCMAW-11501)

### What changed
Set up Subscription Filters to forward logs to CSLS in Build and above environments.
Subscription Filters will deploy in Build for proxy resources using DeployProxyCsls condition.
Add a test to check that all Cloudwatch log groups have an associated filter.
Provide DestinationArn using mapping.

[DCMAW-11501]: https://govukverify.atlassian.net/browse/DCMAW-11501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ