### PR TITLE
Revert "DCMAW-13943: Update rate limits and reserved concurrency for STS Mock /token endpoint"

### DIFF
--- a/test-resources/infra/parent.yaml
+++ b/test-resources/infra/parent.yaml
@@ -66,14 +66,8 @@ Mappings:
       ApiBurstLimit: 10
       ApiRateLimit: 10
     build:
-      ApiBurstLimit: 400
-      ApiRateLimit: 200
-
-  StsMockTokenLambda:
-    dev:
-      ReservedConcurrency: 0
-    build:
-      ReservedConcurrency: 160
+      ApiBurstLimit: 200
+      ApiRateLimit: 100
 
   EventsApiGateway:
     dev:

--- a/test-resources/infra/sts-mock/token/function.yaml
+++ b/test-resources/infra/sts-mock/token/function.yaml
@@ -15,10 +15,8 @@ Resources:
           - src/functions/sts-mock/token/tokenHandler.ts
     Properties:
       Description: Mock STS token function for exchanging an access token for a service token
-      FunctionName: !Sub ${AWS::StackName}-sts-mock-token
+      FunctionName: !Sub ${AWS::StackName}-sts-mock-token      
       Handler: tokenHandler.lambdaHandler
-      ReservedConcurrentExecutions:
-        !FindInMap [StsMockTokenLambda, !Ref Environment, ReservedConcurrency]
       Timeout: 5
       Events:
         Token:

--- a/test-resources/template.yaml
+++ b/test-resources/template.yaml
@@ -63,17 +63,11 @@ Mappings:
 
   StsMockApiGateway:
     build:
-      ApiBurstLimit: 400
-      ApiRateLimit: 200
+      ApiBurstLimit: 200
+      ApiRateLimit: 100
     dev:
       ApiBurstLimit: 10
       ApiRateLimit: 10
-
-  StsMockTokenLambda:
-    build:
-      ReservedConcurrency: 160
-    dev:
-      ReservedConcurrency: 0
 
   TestResourcesApiGateway:
     build:
@@ -940,10 +934,6 @@ Resources:
           Type: Api
       FunctionName: !Sub ${AWS::StackName}-sts-mock-token
       Handler: tokenHandler.lambdaHandler
-      ReservedConcurrentExecutions: !FindInMap
-        - StsMockTokenLambda
-        - !Ref Environment
-        - ReservedConcurrency
       Role: !GetAtt TokenFunctionRole.Arn
       Timeout: 5
       VpcConfig:

--- a/test-resources/tests/infrastructure-tests/application.test.ts
+++ b/test-resources/tests/infrastructure-tests/application.test.ts
@@ -54,11 +54,11 @@ describe("STS mock infrastructure", () => {
       test("rate and burst limit mappings are set", () => {
         const expectedBurstLimits = {
           dev: 10,
-          build: 400,
+          build: 200,
         };
         const expectedRateLimits = {
           dev: 10,
-          build: 200,
+          build: 100,
         };
         const mappingHelper = new Mappings(template);
         mappingHelper.validatePrivateAPIMapping({
@@ -198,22 +198,6 @@ describe("STS mock infrastructure", () => {
             ],
           },
         });
-      });
-    });
-
-    test("Token lambda has reserved concurrency set from mapping", () => {
-      const reservedConcurrentExecutions = new Capture();
-      template.hasResourceProperties("AWS::Serverless::Function", {
-        FunctionName: { "Fn::Sub": "${AWS::StackName}-sts-mock-token" },
-        ReservedConcurrentExecutions: reservedConcurrentExecutions,
-      });
-
-      expect(reservedConcurrentExecutions.asObject()).toStrictEqual({
-        "Fn::FindInMap": [
-          "StsMockTokenLambda",
-          { Ref: "Environment" },
-          "ReservedConcurrency",
-        ],
       });
     });
 


### PR DESCRIPTION
Reverts govuk-one-login/mobile-id-check-async#709