### PR TITLE
[DCMAW-14562] Emit `opaque_id` in DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED event.

### DIFF
--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
@@ -620,6 +620,7 @@ describe("Async Biometric Token", () => {
           ipAddress: "1.1.1.1",
           txmaAuditEncoded: "mockTxmaAuditEncodedHeader",
           redirect_uri: "https://www.mockRedirectUri.com",
+          opaque_id: "mock_opaque_id",
         });
       });
 

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.test.ts
@@ -620,7 +620,7 @@ describe("Async Biometric Token", () => {
           ipAddress: "1.1.1.1",
           txmaAuditEncoded: "mockTxmaAuditEncodedHeader",
           redirect_uri: "https://www.mockRedirectUri.com",
-          opaque_id: "mock_opaque_id",
+          opaqueId: "mock_opaque_id",
         });
       });
 

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
@@ -134,6 +134,7 @@ export async function lambdaHandlerConstructor(
     responseBody,
     ipAddress,
     txmaAuditEncoded,
+    opaqueId,
   });
 }
 
@@ -354,6 +355,7 @@ interface HandleOkResponseData {
   responseBody: BiometricTokenIssuedOkResponseBody;
   ipAddress: string;
   txmaAuditEncoded: string | undefined;
+  opaqueId: string | undefined;
 }
 
 async function handleOkResponse(
@@ -366,6 +368,7 @@ async function handleOkResponse(
     responseBody,
     ipAddress,
     txmaAuditEncoded,
+    opaqueId,
   } = data;
   const writeEventResult = await eventService.writeBiometricTokenIssuedEvent({
     sub: sessionAttributes.subjectIdentifier,
@@ -377,6 +380,7 @@ async function handleOkResponse(
     ipAddress,
     txmaAuditEncoded,
     redirect_uri: sessionAttributes.redirectUri,
+    opaque_id: opaqueId,
   });
 
   if (writeEventResult.isError) {

--- a/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
+++ b/backend-api/src/functions/asyncBiometricToken/asyncBiometricTokenHandler.ts
@@ -355,7 +355,7 @@ interface HandleOkResponseData {
   responseBody: BiometricTokenIssuedOkResponseBody;
   ipAddress: string;
   txmaAuditEncoded: string | undefined;
-  opaqueId: string | undefined;
+  opaqueId: string;
 }
 
 async function handleOkResponse(
@@ -380,7 +380,7 @@ async function handleOkResponse(
     ipAddress,
     txmaAuditEncoded,
     redirect_uri: sessionAttributes.redirectUri,
-    opaque_id: opaqueId,
+    opaqueId,
   });
 
   if (writeEventResult.isError) {

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -148,6 +148,7 @@ export class EventService implements IEventService {
       extensions: {
         documentType: eventConfig.documentType,
         redirect_uri: eventConfig.redirect_uri,
+        opaque_id: eventConfig.opaque_id,
       },
       restricted: this.getRestrictedData(eventConfig.txmaAuditEncoded),
     };

--- a/backend-api/src/functions/services/events/eventService.ts
+++ b/backend-api/src/functions/services/events/eventService.ts
@@ -148,7 +148,7 @@ export class EventService implements IEventService {
       extensions: {
         documentType: eventConfig.documentType,
         redirect_uri: eventConfig.redirect_uri,
-        opaque_id: eventConfig.opaque_id,
+        opaque_id: eventConfig.opaqueId,
       },
       restricted: this.getRestrictedData(eventConfig.txmaAuditEncoded),
     };

--- a/backend-api/src/functions/services/events/tests/eventService.test.ts
+++ b/backend-api/src/functions/services/events/tests/eventService.test.ts
@@ -275,6 +275,7 @@ describe("Event Service", () => {
           ipAddress: "mockIpAddress",
           txmaAuditEncoded: "mockTxmaAuditEncoded",
           redirect_uri: "https://mockredirecturi.com/",
+          opaque_id: "mockOpaqueId",
         });
       });
 
@@ -294,6 +295,7 @@ describe("Event Service", () => {
             extensions: {
               documentType: "NFC_PASSPORT",
               redirect_uri: "https://mockredirecturi.com/",
+              opaque_id: "mockOpaqueId",
             },
             restricted: {
               device_information: {
@@ -330,6 +332,7 @@ describe("Event Service", () => {
             ipAddress: "mockIpAddress",
             txmaAuditEncoded: undefined,
             redirect_uri: undefined,
+            opaque_id: undefined,
           });
         });
 
@@ -378,6 +381,7 @@ describe("Event Service", () => {
             ipAddress: "mockIpAddress",
             txmaAuditEncoded: "mockTxmaAuditEncoded",
             redirect_uri: undefined,
+            opaque_id: undefined,
           });
         });
 

--- a/backend-api/src/functions/services/events/tests/eventService.test.ts
+++ b/backend-api/src/functions/services/events/tests/eventService.test.ts
@@ -275,7 +275,7 @@ describe("Event Service", () => {
           ipAddress: "mockIpAddress",
           txmaAuditEncoded: "mockTxmaAuditEncoded",
           redirect_uri: "https://mockredirecturi.com/",
-          opaque_id: "mockOpaqueId",
+          opaqueId: "mockOpaqueId",
         });
       });
 
@@ -332,7 +332,7 @@ describe("Event Service", () => {
             ipAddress: "mockIpAddress",
             txmaAuditEncoded: undefined,
             redirect_uri: undefined,
-            opaque_id: undefined,
+            opaqueId: "mockOpaqueId",
           });
         });
 
@@ -351,6 +351,7 @@ describe("Event Service", () => {
               component_id: "mockComponentId",
               extensions: {
                 documentType: "NFC_PASSPORT",
+                opaque_id: "mockOpaqueId",
               },
             }),
             QueueUrl: "mockSqsQueue",
@@ -381,7 +382,7 @@ describe("Event Service", () => {
             ipAddress: "mockIpAddress",
             txmaAuditEncoded: "mockTxmaAuditEncoded",
             redirect_uri: undefined,
-            opaque_id: undefined,
+            opaqueId: "mockOpaqueId",
           });
         });
 
@@ -400,6 +401,7 @@ describe("Event Service", () => {
               component_id: "mockComponentId",
               extensions: {
                 documentType: "NFC_PASSPORT",
+                opaque_id: "mockOpaqueId",
               },
               restricted: {
                 device_information: {

--- a/backend-api/src/functions/services/events/types.ts
+++ b/backend-api/src/functions/services/events/types.ts
@@ -101,7 +101,7 @@ export interface CredentialTokenIssuedEventConfig extends BaseEventConfig {
 export interface BiometricTokenIssuedEventConfig extends BaseUserEventConfig {
   documentType: DocumentType;
   redirect_uri: string | undefined;
-  opaque_id: string | undefined;
+  opaqueId: string;
 }
 
 export interface GenericTxmaEvent extends BaseUserTxmaEvent {
@@ -118,7 +118,7 @@ export interface BiometricTokenIssuedEvent extends BaseUserTxmaEvent {
   extensions: {
     documentType: DocumentType;
     redirect_uri: string | undefined;
-    opaque_id: string | undefined;
+    opaque_id: string;
   };
 }
 

--- a/backend-api/src/functions/services/events/types.ts
+++ b/backend-api/src/functions/services/events/types.ts
@@ -101,6 +101,7 @@ export interface CredentialTokenIssuedEventConfig extends BaseEventConfig {
 export interface BiometricTokenIssuedEventConfig extends BaseUserEventConfig {
   documentType: DocumentType;
   redirect_uri: string | undefined;
+  opaque_id: string | undefined;
 }
 
 export interface GenericTxmaEvent extends BaseUserTxmaEvent {
@@ -117,6 +118,7 @@ export interface BiometricTokenIssuedEvent extends BaseUserTxmaEvent {
   extensions: {
     documentType: DocumentType;
     redirect_uri: string | undefined;
+    opaque_id: string | undefined;
   };
 }
 


### PR DESCRIPTION
## Jira Ticket

DCMAW-14562

## Description of changes

This change is required to improve consistency in TxMA event streams for user journeys
involving biometric token issuance.  Currently TCIF ops can use the field `opaque_id` in
event `DCMAW_ASYNC_BIOMETRIC_TOKEN_ISSUED` when analysing v1 user journeys,
but not v2 as it isn't emitted.

A bit of plumbing is needed in this change to ensure the opaque ID allocated at the start of
the biometric credential is passed through to the point the Event service is called.

## Review guidance
<details>
<summary>Review checklist</summary>

### Functional Review
- **Functionality**: Does it meet the acceptance criteria on the ticket and work as expected?
- **Requirements**: Does the code meet functional and non-functional requirements including compliance with programme standards and security gates?

### Security & Compliance
- **Personally Identifiable Information**: Is it possible for PII to be logged?
- **Security Considerations**: Are there any security implications that need to be addressed?

### Quality Assurance
- **Testing**: Is the code well-tested with sufficient coverage to provide confidence in correctness?
- **Edge Cases**: Have edge cases been considered and handled appropriately?

### Code Quality
- **Readability**: Is the code easy to understand for all team members, with clear naming and appropriate documentation?
- **Maintainability**: Is the code easy to change, reuse, and extend?
- **Code Style**: Does it follow our coding conventions and best practices?
- **Code Quality**: Is the code maintainable and following best practices? See [Values, Principles & Practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4955865126/ID+Check+Web+-+Values+Principles+and+Practices)

### Observability & Operations
- **Observability**: Are there appropriate logs/metrics that would help debug and monitor the service?
- **Performance**: Are there any performance considerations or potential bottlenecks?
- **Runbooks for Alarms**: If an alarm has been created or updated, has a corresponding runbook been created or updated?
  - [Critical alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarm+Runbook+Critical+Alerts)
  - [Warning alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings)

### Documentation
- **Documentation**: Is the code well documented? Is there any existing documentation that needs updating?
- **Comments**: Are complex sections of code adequately commented if the intent is not clear?

### Review PR:
- **Title**: Contains ticket number and clear summary of change
- **Description**: Has clear description of change
</details>

## Evidence

Unit tests are clean:

<img width="661" height="226" alt="image" src="https://github.com/user-attachments/assets/d54db257-f8b9-457d-9f8b-ff06e2b3a5ba" />

## Documentation

We need to be sure to update the Event catalogue for this change.
That is covered in a separate follow-up ticket, DCMAW-14564.
