### PR TITLE
[DCMAW-14734] Tune Vendor Processing Queue trigger

### DIFF
--- a/backend-api/infra/resources/async/issueBiometricCredential/function.yaml
+++ b/backend-api/infra/resources/async/issueBiometricCredential/function.yaml
@@ -15,6 +15,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${AWS::StackName}-issue-biometric-credential
       Handler: asyncIssueBiometricCredentialHandler.lambdaHandler
+      Timeout: 1
       DeploymentPreference:
         Enabled: true
         Alarms: !If

--- a/backend-api/infra/resources/async/vendorProcessingQueue/queue.yaml
+++ b/backend-api/infra/resources/async/vendorProcessingQueue/queue.yaml
@@ -5,8 +5,8 @@ Resources:
     Properties:
       QueueName: !Sub ${AWS::StackName}-vendor-processing
       MessageRetentionPeriod: 1209600
-      VisibilityTimeout: 10
-      DelaySeconds: 5
+      VisibilityTimeout: 2
+      DelaySeconds: 7
       ReceiveMessageWaitTimeSeconds: 5
       KmsMasterKeyId: !Ref VendorProcessingKeyAlias
       RedrivePolicy:

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -3797,6 +3797,7 @@ Resources:
           - !Ref Environment
           - IssueBiometricCredentialReservedConcurrentExecutions
       Role: !GetAtt AsyncIssueBiometricCredentialLambdaRole.Arn
+      Timeout: 1
       VpcConfig:
         SecurityGroupIds:
           - !ImportValue devplatform-vpc-AWSServicesEndpointSecurityGroupId
@@ -6606,7 +6607,7 @@ Resources:
   VendorProcessingSqs:
     Type: AWS::SQS::Queue
     Properties:
-      DelaySeconds: 5
+      DelaySeconds: 7
       KmsMasterKeyId: !Ref VendorProcessingKeyAlias
       MessageRetentionPeriod: 1209600
       QueueName: !Sub ${AWS::StackName}-vendor-processing
@@ -6614,7 +6615,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt VendorProcessingDlq.Arn
         maxReceiveCount: 360
-      VisibilityTimeout: 10
+      VisibilityTimeout: 2
 
   VendorProcessingSqsAgeOfOldestMessageAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -1312,6 +1312,13 @@ describe("Backend application infrastructure", () => {
         },
       });
     });
+
+    test("IssueBiometricCredential lambda has a timeout of 1 second", () => {
+      template.hasResourceProperties("AWS::Serverless::Function", {
+        Handler: "asyncIssueBiometricCredentialHandler.lambdaHandler",
+        Timeout: 1,
+      });
+    });
   });
 
   describe("KMS", () => {


### PR DESCRIPTION
## Jira Ticket
<!-- Add your Jira ticket link here. -->
DCMAW-14734

## Description of changes
* Set the initial delay for the Vendor Processing Queue to 7 seconds, to allow more time for the vendor biometric session to be ready
* Sets the visibility timeout for the Vendor Processing Queue to 2 seconds, to allow for faster retries when the vendor biometric session is not ready
* Sets the timeout of the Issue Biometric Credential Lambda to 1 second, to give sufficient headroom below the queue visibility timeout


## Review guidance
<details>
<summary>Review checklist</summary>

### Functional Review
- **Functionality**: Does it meet the acceptance criteria on the ticket and work as expected?
- **Requirements**: Does the code meet functional and non-functional requirements including compliance with programme standards and security gates?

### Security & Compliance
- **Personally Identifiable Information**: Is it possible for PII to be logged?
- **Security Considerations**: Are there any security implications that need to be addressed?

### Quality Assurance
- **Testing**: Is the code well-tested with sufficient coverage to provide confidence in correctness?
- **Edge Cases**: Have edge cases been considered and handled appropriately?

### Code Quality
- **Readability**: Is the code easy to understand for all team members, with clear naming and appropriate documentation?
- **Maintainability**: Is the code easy to change, reuse, and extend?
- **Code Style**: Does it follow our coding conventions and best practices?
- **Code Quality**: Is the code maintainable and following best practices? See [Values, Principles & Practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4955865126/ID+Check+Web+-+Values+Principles+and+Practices)

### Observability & Operations
- **Observability**: Are there appropriate logs/metrics that would help debug and monitor the service?
- **Performance**: Are there any performance considerations or potential bottlenecks?
- **Runbooks for Alarms**: If an alarm has been created or updated, has a corresponding runbook been created or updated?
  - [Critical alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarm+Runbook+Critical+Alerts)
  - [Warning alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings)

### Documentation
- **Documentation**: Is the code well documented? Is there any existing documentation that needs updating?
- **Comments**: Are complex sections of code adequately commented if the intent is not clear?

### Review PR:
- **Title**: Contains ticket number and clear summary of change
- **Description**: Has clear description of change
</details>

## Evidence

Lambda triggers roughly every 2 seconds, in response to a persistent (in this case, manufactured) error being thrown.

<img width="895" height="376" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/1e7d8000-636e-4c74-a7b4-ff0fd30d8cbb" />

<!--
- Provide evidence that changes work as expected
- For UI changes, include screenshots or recordings
- For API changes, include example requests/responses
- For infrastructure changes, include relevant logs or screenshots

Note: Leave this blank if no testing additional to the pull request workflows has been executed

When you should run the test container:
- If you've touched Docker configuration
- If you've added new environment variables
- For UI changes
-->

## Documentation
<!--
- Call out if key repository documentation has been updated
- Link to external documentation that has been updated

Note: Leave this blank if no documentation changes have been made
-->