### PR TITLE
[DCMAW-14761] Define biometric session not ready alarms per document type

### DIFF
--- a/backend-api/infra/resources/common/alarms.yaml
+++ b/backend-api/infra/resources/common/alarms.yaml
@@ -123,6 +123,174 @@ Resources:
           ReturnData: true
           Expression: IF(FILL(journeysStarted, 0) >= 40, journeyCompletionRate, 100)
 
+  PassportBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    DependsOn:
+      - "AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter"
+      - "CredentialsIssuedMetricFilter"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      InsufficientDataActions: []
+      AlarmDescription: !Sub
+        - "Fewer than 90% of passport VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [ StaticVariables, urls, WarningAlarmsRunbook ]
+      AlarmName: !Sub "${AWS::StackName}-passport-biometric-sessions-not-ready"
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 90
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: passportVCsIssuedOnFirstAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: NFC_PASSPORT
+                - Name: ReceiveCount
+                  Value: "1"
+            Period: 3600
+            Stat: SampleCount
+        - Id: passportVCsIssuedOnAnyAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: CredentialsIssued
+              Dimensions:
+                - Name: DocumentType
+                  Value: NFC_PASSPORT
+            Period: 3600
+            Stat: Sum
+        - Id: percentageOfPassportVCsIssuedOnFirstAttempt
+          ReturnData: false
+          Expression: (FILL(passportVCsIssuedOnFirstAttempt, 0)/FILL(passportVCsIssuedOnAnyAttempt, 0)) * 100
+        - Id: threshold
+          ReturnData: true
+          Expression: IF(FILL(passportVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfPassportVCsIssuedOnFirstAttempt, 100)
+
+  DrivingLicenceBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    DependsOn:
+      - "AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter"
+      - "CredentialsIssuedMetricFilter"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      InsufficientDataActions: [ ]
+      AlarmDescription: !Sub
+        - "Fewer than 90% of driving licence VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [ StaticVariables, urls, WarningAlarmsRunbook ]
+      AlarmName: !Sub "${AWS::StackName}-driving-licence-biometric-sessions-not-ready"
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 90
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: drivingLicenceVCsIssuedOnFirstAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: UK_DRIVING_LICENCE
+                - Name: ReceiveCount
+                  Value: "1"
+            Period: 3600
+            Stat: SampleCount
+        - Id: drivingLicenceVCsIssuedOnAnyAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: CredentialsIssued
+              Dimensions:
+                - Name: DocumentType
+                  Value: UK_DRIVING_LICENCE
+            Period: 3600
+            Stat: Sum
+        - Id: percentageOfDrivingLicenceVCsIssuedOnFirstAttempt
+          ReturnData: false
+          Expression: (FILL(drivingLicenceVCsIssuedOnFirstAttempt, 0)/FILL(drivingLicenceVCsIssuedOnAnyAttempt, 0)) * 100
+        - Id: threshold
+          ReturnData: true
+          Expression: IF(FILL(drivingLicenceVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfDrivingLicenceVCsIssuedOnFirstAttempt, 100)
+
+  BrpBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    DependsOn:
+      - "AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter"
+      - "CredentialsIssuedMetricFilter"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      OKActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning"
+      InsufficientDataActions: [ ]
+      AlarmDescription: !Sub
+        - "Fewer than 75% of BRP VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}"
+        - RunbookUrl: !FindInMap [ StaticVariables, urls, WarningAlarmsRunbook ]
+      AlarmName: !Sub "${AWS::StackName}-brp-biometric-sessions-not-ready"
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 75
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: brpVCsIssuedOnFirstAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: UK_NFC_BRP
+                - Name: ReceiveCount
+                  Value: "1"
+            Period: 3600
+            Stat: SampleCount
+        - Id: brpVCsIssuedOnAnyAttempt
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/LogMessages"
+              MetricName: CredentialsIssued
+              Dimensions:
+                - Name: DocumentType
+                  Value: UK_NFC_BRP
+            Period: 3600
+            Stat: Sum
+        - Id: percentageOfBrpVCsIssuedOnFirstAttempt
+          ReturnData: false
+          Expression: (FILL(brpVCsIssuedOnFirstAttempt, 0)/FILL(brpVCsIssuedOnAnyAttempt, 0)) * 100
+        - Id: threshold
+          ReturnData: true
+          Expression: IF(FILL(brpVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfBrpVCsIssuedOnFirstAttempt, 100)
+
   AsyncLambdaClaimedAccountConcurrencyAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -5225,6 +5225,65 @@ Resources:
       TreatMissingData: notBreaching
     Condition: DeployAlarms
 
+  BrpBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn:
+      - AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter
+      - CredentialsIssuedMetricFilter
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Fewer than 75% of BRP VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-brp-biometric-sessions-not-ready
+      ComparisonOperator: LessThanThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      InsufficientDataActions: []
+      Metrics:
+        - Id: brpVCsIssuedOnFirstAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: UK_NFC_BRP
+                - Name: ReceiveCount
+                  Value: "1"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: brpVCsIssuedOnAnyAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: DocumentType
+                  Value: UK_NFC_BRP
+              MetricName: CredentialsIssued
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: Sum
+          ReturnData: false
+        - Expression: (FILL(brpVCsIssuedOnFirstAttempt, 0)/FILL(brpVCsIssuedOnAnyAttempt, 0)) * 100
+          Id: percentageOfBrpVCsIssuedOnFirstAttempt
+          ReturnData: false
+        - Expression: IF(FILL(brpVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfBrpVCsIssuedOnFirstAttempt, 100)
+          Id: threshold
+          ReturnData: true
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Threshold: 75
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
+
   CodeDeployServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -5257,6 +5316,65 @@ Resources:
           MetricName: CredentialsIssued
           MetricNamespace: !Sub ${AWS::StackName}/LogMessages
           MetricValue: "1"
+
+  DrivingLicenceBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn:
+      - AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter
+      - CredentialsIssuedMetricFilter
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Fewer than 90% of driving licence VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-driving-licence-biometric-sessions-not-ready
+      ComparisonOperator: LessThanThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      InsufficientDataActions: []
+      Metrics:
+        - Id: drivingLicenceVCsIssuedOnFirstAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: UK_DRIVING_LICENCE
+                - Name: ReceiveCount
+                  Value: "1"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: drivingLicenceVCsIssuedOnAnyAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: DocumentType
+                  Value: UK_DRIVING_LICENCE
+              MetricName: CredentialsIssued
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: Sum
+          ReturnData: false
+        - Expression: (FILL(drivingLicenceVCsIssuedOnFirstAttempt, 0)/FILL(drivingLicenceVCsIssuedOnAnyAttempt, 0)) * 100
+          Id: percentageOfDrivingLicenceVCsIssuedOnFirstAttempt
+          ReturnData: false
+        - Expression: IF(FILL(drivingLicenceVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfDrivingLicenceVCsIssuedOnFirstAttempt, 100)
+          Id: threshold
+          ReturnData: true
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Threshold: 90
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
 
   IPVCoreDlqAgeOfOldestMessageLowThresholdAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -5842,6 +5960,65 @@ Resources:
   NullResource:
     Type: AWS::CloudFormation::WaitConditionHandle
     Condition: NeverDeploy
+
+  PassportBiometricSessionsNotReadyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    DependsOn:
+      - AsyncIssueBiometricCredentialApproximateReceiveCountMetricFilter
+      - CredentialsIssuedMetricFilter
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      AlarmDescription: !Sub
+        - 'Fewer than 90% of passport VCs are being issued after the first call to retrieve a biometric session from the vendor. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap
+            - StaticVariables
+            - urls
+            - WarningAlarmsRunbook
+      AlarmName: !Sub ${AWS::StackName}-passport-biometric-sessions-not-ready
+      ComparisonOperator: LessThanThreshold
+      DatapointsToAlarm: 2
+      EvaluationPeriods: 5
+      InsufficientDataActions: []
+      Metrics:
+        - Id: passportVCsIssuedOnFirstAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: MessageCode
+                  Value: MOBILE_ASYNC_ISSUE_BIOMETRIC_CREDENTIAL_VC_ISSUED
+                - Name: DocumentType
+                  Value: NFC_PASSPORT
+                - Name: ReceiveCount
+                  Value: "1"
+              MetricName: AsyncIssueBiometricCredentialApproximateReceiveCount
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: SampleCount
+          ReturnData: false
+        - Id: passportVCsIssuedOnAnyAttempt
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: DocumentType
+                  Value: NFC_PASSPORT
+              MetricName: CredentialsIssued
+              Namespace: !Sub ${AWS::StackName}/LogMessages
+            Period: 3600
+            Stat: Sum
+          ReturnData: false
+        - Expression: (FILL(passportVCsIssuedOnFirstAttempt, 0)/FILL(passportVCsIssuedOnAnyAttempt, 0)) * 100
+          Id: percentageOfPassportVCsIssuedOnFirstAttempt
+          ReturnData: false
+        - Expression: IF(FILL(passportVCsIssuedOnAnyAttempt, 0) >= 5, percentageOfPassportVCsIssuedOnFirstAttempt, 100)
+          Id: threshold
+          ReturnData: true
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:platform-alarms-sns-warning
+      Threshold: 90
+      TreatMissingData: notBreaching
+    Condition: DeployAlarms
 
   PrivateApi:
     Type: AWS::Serverless::Api

--- a/backend-api/tests/infra-tests/application.test.ts
+++ b/backend-api/tests/infra-tests/application.test.ts
@@ -410,6 +410,9 @@ describe("Backend application infrastructure", () => {
         ["abort-session-concurrency-reaching-limit"],
         ["txma-event-concurrency-reaching-limit"],
         ["zero-journeys-started"],
+        ["passport-biometric-sessions-not-ready"],
+        ["driving-licence-biometric-sessions-not-ready"],
+        ["brp-biometric-sessions-not-ready"],
       ])(
         "The %s alarm is configured to send an event to the warnings SNS topic on Alarm and OK actions",
         (alarmName: string) => {


### PR DESCRIPTION
## Jira Ticket
<!-- Add your Jira ticket link here. -->
DCMAW-14761

## Description of changes
* Defines three new alarms (one per document type) capturing a drop in the percentage of VCs issued after the first call to ReadID. These alarms fire when, in two of the past five hours, there have been at least 5 VCs issued for that document type, and the percentage of these that were issued on the first attempt is below the threshold (90% for passports and driving licences, 75% for BRPs). **Please see the ticket for the rationale for this configuration.**
* Updates infra tests
<!--
- Describe what changed and why
- Call out specific areas that need focus in the review
- Call out new patterns and articulate why they're being proposed
- For larger PRs, provide guidance on how best to start the review/understand the change
-->

## Review guidance
<details>
<summary>Review checklist</summary>

### Functional Review
- **Functionality**: Does it meet the acceptance criteria on the ticket and work as expected?
- **Requirements**: Does the code meet functional and non-functional requirements including compliance with programme standards and security gates?

### Security & Compliance
- **Personally Identifiable Information**: Is it possible for PII to be logged?
- **Security Considerations**: Are there any security implications that need to be addressed?

### Quality Assurance
- **Testing**: Is the code well-tested with sufficient coverage to provide confidence in correctness?
- **Edge Cases**: Have edge cases been considered and handled appropriately?

### Code Quality
- **Readability**: Is the code easy to understand for all team members, with clear naming and appropriate documentation?
- **Maintainability**: Is the code easy to change, reuse, and extend?
- **Code Style**: Does it follow our coding conventions and best practices?
- **Code Quality**: Is the code maintainable and following best practices? See [Values, Principles & Practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4955865126/ID+Check+Web+-+Values+Principles+and+Practices)

### Observability & Operations
- **Observability**: Are there appropriate logs/metrics that would help debug and monitor the service?
- **Performance**: Are there any performance considerations or potential bottlenecks?
- **Runbooks for Alarms**: If an alarm has been created or updated, has a corresponding runbook been created or updated?
  - [Critical alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarm+Runbook+Critical+Alerts)
  - [Warning alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings)

### Documentation
Runbook updated https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarm+Runbook+Warnings
- **Documentation**: Is the code well documented? Is there any existing documentation that needs updating?
- **Comments**: Are complex sections of code adequately commented if the intent is not clear?

### Review PR:
- **Title**: Contains ticket number and clear summary of change
- **Description**: Has clear description of change
</details>

## Evidence
Attached to the ticket.
<!--
- Provide evidence that changes work as expected
- For UI changes, include screenshots or recordings
- For API changes, include example requests/responses
- For infrastructure changes, include relevant logs or screenshots

Note: Leave this blank if no testing additional to the pull request workflows has been executed

When you should run the test container:
- If you've touched Docker configuration
- If you've added new environment variables
- For UI changes
-->

## Documentation
<!--
- Call out if key repository documentation has been updated
- Link to external documentation that has been updated

Note: Leave this blank if no documentation changes have been made
-->