### PR TITLE
DCMAW-15481: Add dormant permission for private api to invoke lambda alias

### DIFF
--- a/backend-api/infra/resources/privateApi/credential/function.yaml
+++ b/backend-api/infra/resources/privateApi/credential/function.yaml
@@ -15,6 +15,13 @@ Resources:
     Properties:
       FunctionName: !Sub ${AWS::StackName}-credential      
       Handler: asyncCredentialHandler.lambdaHandler
+      Events:
+        PostCredential:
+          Type: Api
+          Properties:
+            Path: /async/credential
+            Method: post
+            RestApiId: !Ref PrivateApi
       Role: !GetAtt AsyncCredentialLambdaRole.Arn
       ReservedConcurrentExecutions: !If
         - isDev

--- a/backend-api/infra/resources/privateApi/token/function.yaml
+++ b/backend-api/infra/resources/privateApi/token/function.yaml
@@ -15,6 +15,13 @@ Resources:
     Properties:
       FunctionName: !Sub ${AWS::StackName}-token      
       Handler: asyncTokenHandler.lambdaHandler
+      Events:
+        PostToken:
+          Type: Api
+          Properties:
+            Path: /async/token
+            Method: post
+            RestApiId: !Ref PrivateApi
       Role: !GetAtt AsyncTokenLambdaRole.Arn
       ReservedConcurrentExecutions: !If
         - isDev

--- a/backend-api/template.yaml
+++ b/backend-api/template.yaml
@@ -2578,6 +2578,13 @@ Resources:
             - EnvironmentVariables
             - !Ref Environment
             - SessionDurationInSeconds
+      Events:
+        PostCredential:
+          Properties:
+            Method: post
+            Path: /async/credential
+            RestApiId: !Ref PrivateApi
+          Type: Api
       FunctionName: !Sub ${AWS::StackName}-credential
       Handler: asyncCredentialHandler.lambdaHandler
       ReservedConcurrentExecutions: !If
@@ -4584,6 +4591,13 @@ Resources:
             - EnvironmentVariables
             - !Ref Environment
             - ClientRegistrySecretPath
+      Events:
+        PostToken:
+          Properties:
+            Method: post
+            Path: /async/token
+            RestApiId: !Ref PrivateApi
+          Type: Api
       FunctionName: !Sub ${AWS::StackName}-token
       Handler: asyncTokenHandler.lambdaHandler
       ReservedConcurrentExecutions: !If


### PR DESCRIPTION
## Jira Ticket
<!-- Add your Jira ticket link here. -->
DCMAW-15481

The Private API currently integrates directly to the lambda qualifier (arn:aws:lambda:eu-west-2:<accountId>:function:sandy-async-backend-token) and **not** to the live alias.

This is **part 1.** of a three step approach to remediate this:
1. Add a lambda permission enabling the Private API to invoke the lambda `live` alias
2. Update the Private API to integrate with the `live` alias
3. Remove the old lambda permission that allows the lambda qualifier above to be invoked by the Private API

This change also has the side benefit of ensuring the lambda can only be invoked by `POST /async/token` and `POST /async/credential` endpoints.
## Description of changes
<!--
- Describe what changed and why
- Call out specific areas that need focus in the review
- Call out new patterns and articulate why they're being proposed
- For larger PRs, provide guidance on how best to start the review/understand the change
-->

## Review guidance
<details>
<summary>Review checklist</summary>

### Functional Review
- **Functionality**: Does it meet the acceptance criteria on the ticket and work as expected?
- **Requirements**: Does the code meet functional and non-functional requirements including compliance with programme standards and security gates?

### Security & Compliance
- **Personally Identifiable Information**: Is it possible for PII to be logged?
- **Security Considerations**: Are there any security implications that need to be addressed?

### Quality Assurance
- **Testing**: Is the code well-tested with sufficient coverage to provide confidence in correctness?
- **Edge Cases**: Have edge cases been considered and handled appropriately?

### Code Quality
- **Readability**: Is the code easy to understand for all team members, with clear naming and appropriate documentation?
- **Maintainability**: Is the code easy to change, reuse, and extend?
- **Code Style**: Does it follow our coding conventions and best practices?
- **Code Quality**: Is the code maintainable and following best practices? See [Values, Principles & Practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4955865126/ID+Check+Web+-+Values+Principles+and+Practices)

### Observability & Operations
- **Observability**: Are there appropriate logs/metrics that would help debug and monitor the service?
- **Performance**: Are there any performance considerations or potential bottlenecks?
- **Runbooks for Alarms**: If an alarm has been created or updated, has a corresponding runbook been created or updated?
  - [Critical alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarm+Runbook+Critical+Alerts)
  - [Warning alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings)

### Documentation
- **Documentation**: Is the code well documented? Is there any existing documentation that needs updating?
- **Comments**: Are complex sections of code adequately commented if the intent is not clear?

### Review PR:
- **Title**: Contains ticket number and clear summary of change
- **Description**: Has clear description of change
</details>

## Evidence
1. API tests pass
2. API tests with Private API integrating with the lambda `live` alias pass (i.e. testing the dormant change in this PR with step 2.) Lambda permissions are visible on both lambdas when looking at the `live` alias in the console.
<!--
- Provide evidence that changes work as expected
- For UI changes, include screenshots or recordings
- For API changes, include example requests/responses
- For infrastructure changes, include relevant logs or screenshots

Note: Leave this blank if no testing additional to the pull request workflows has been executed

When you should run the test container:
- If you've touched Docker configuration
- If you've added new environment variables
- For UI changes
-->

## Documentation
<!--
- Call out if key repository documentation has been updated
- Link to external documentation that has been updated

Note: Leave this blank if no documentation changes have been made
-->