### PR TITLE
biocred logger error() is deprecated, so make it a no-op

### DIFF
--- a/backend-api/src/functions/asyncIssueBiometricCredential/getCredentialFromBiometricSessionLogger.test.ts
+++ b/backend-api/src/functions/asyncIssueBiometricCredential/getCredentialFromBiometricSessionLogger.test.ts
@@ -18,16 +18,13 @@ describe("getCredentialFromBiometricSessionLogger", () => {
     consoleInfoSpy = vi.spyOn(console, "info");
   });
 
-  it("Logs at error", () => {
+  it("Give that error is deprecated, it does not log", () => {
     logger.appendPersistentKeys({ mockKey: "mockValue" });
     getCredentialFromBiometricSessionLogger.error(
       "DRIVING_LICENCE_INVALID_ISSUER",
       {},
     );
-    expect(consoleErrorSpy).toHaveBeenCalledWithLogFields({
-      message: "DRIVING_LICENCE_INVALID_ISSUER",
-      mockKey: "mockValue",
-    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
     expect(consoleInfoSpy).not.toHaveBeenCalled();
   });
 

--- a/backend-api/src/functions/asyncIssueBiometricCredential/getCredentialFromBiometricSessionLogger.ts
+++ b/backend-api/src/functions/asyncIssueBiometricCredential/getCredentialFromBiometricSessionLogger.ts
@@ -8,7 +8,7 @@ export const getCredentialFromBiometricSessionLogger: Logger = {
   info: (message: LogMessageName, data: Record<string, unknown>): void => {
     logger.info(message, data);
   },
-  error: (message: LogMessageName, data: Record<string, unknown>): void => {
-    logger.error(message, data);
+  error: (_1: LogMessageName, _2: Record<string, unknown>): void => {
+    // This method is deprecated and will be removed.
   },
 };


### PR DESCRIPTION
## Jira Ticket

DCMAW-18100

## Description of changes

The biometric-credential library's `Logger.error()` method is due to be removed,
as it has an unintended consequence of causing double-logging, which inflates
error counts.

This PR makes the `asyncIssueBiometricCredential` lambda's implementation
of `Logger.error()` an empty, no-op method.

A follow-on PR will bump to the new version of biometric-credential (expected to
be v5.0.0) and will drop the method entirely.

## Review guidance
<details>
<summary>Review checklist</summary>

### Functional Review
- **Functionality**: Does it meet the acceptance criteria on the ticket and work as expected?
- **Requirements**: Does the code meet functional and non-functional requirements including compliance with programme standards and security gates?

### Security & Compliance
- **Personally Identifiable Information**: Is it possible for PII to be logged?
- **Security Considerations**: Are there any security implications that need to be addressed?

### Quality Assurance
- **Testing**: Is the code well-tested with sufficient coverage to provide confidence in correctness?
- **Edge Cases**: Have edge cases been considered and handled appropriately?

### Code Quality
- **Readability**: Is the code easy to understand for all team members, with clear naming and appropriate documentation?
- **Maintainability**: Is the code easy to change, reuse, and extend?
- **Code Style**: Does it follow our coding conventions and best practices?
- **Code Quality**: Is the code maintainable and following best practices? See [Values, Principles & Practices](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4955865126/ID+Check+Web+-+Values+Principles+and+Practices)

### Observability & Operations
- **Observability**: Are there appropriate logs/metrics that would help debug and monitor the service?
- **Performance**: Are there any performance considerations or potential bottlenecks?
- **Runbooks for Alarms**: If an alarm has been created or updated, has a corresponding runbook been created or updated?
  - [Critical alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4799594677/Alarm+Runbook+Critical+Alerts)
  - [Warning alarms runbook](https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4800446694/Alarms+Runbook+Warnings)

### Documentation
- **Documentation**: Is the code well documented? Is there any existing documentation that needs updating?
- **Comments**: Are complex sections of code adequately commented if the intent is not clear?

### Review PR:
- **Title**: Contains ticket number and clear summary of change
- **Description**: Has clear description of change
</details>

## Evidence

**Unit tests**
<img width="907" height="340" alt="image" src="https://github.com/user-attachments/assets/5751da00-c0a6-46ad-8882-b92c71fa49c2" />

## Documentation

N/A